### PR TITLE
Fix/cookie host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,5 @@ cmd:
 	cd server && go build -ldflags "-w -X main.Version=$(VERSION)" -o '../build/server'
 clean:
 	rm -rf build
+test:
+	cd server && go test ./...

--- a/server/handlers/oauthCallback.go
+++ b/server/handlers/oauthCallback.go
@@ -40,7 +40,7 @@ func processGoogleUserInfo(code string) (db.User, error) {
 	// Parse and verify ID Token payload.
 	idToken, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return user, fmt.Errorf("unable to verify id_token:", err.Error())
+		return user, fmt.Errorf("unable to verify id_token: %s", err.Error())
 	}
 
 	// Extract custom claims

--- a/server/utils/cookie.go
+++ b/server/utils/cookie.go
@@ -10,10 +10,15 @@ import (
 func SetCookie(gc *gin.Context, token string) {
 	secure := true
 	httpOnly := true
-	host := GetDomainName(constants.AUTHORIZER_URL)
+	host := GetHostName(constants.AUTHORIZER_URL)
+	domain := GetDomainName(constants.AUTHORIZER_URL)
+	if domain != "localhost" {
+		domain = "." + domain
+	}
 
 	gc.SetSameSite(http.SameSiteNoneMode)
 	gc.SetCookie(constants.COOKIE_NAME, token, 3600, "/", host, secure, httpOnly)
+	gc.SetCookie(constants.COOKIE_NAME+"-client", token, 3600, "/", domain, secure, httpOnly)
 }
 
 func GetCookie(gc *gin.Context) (string, error) {
@@ -30,7 +35,12 @@ func DeleteCookie(gc *gin.Context) {
 	httpOnly := true
 
 	host := GetDomainName(constants.AUTHORIZER_URL)
+	domain := GetDomainName(constants.AUTHORIZER_URL)
+	if domain != "localhost" {
+		domain = "." + domain
+	}
 
 	gc.SetSameSite(http.SameSiteNoneMode)
 	gc.SetCookie(constants.COOKIE_NAME, "", -1, "/", host, secure, httpOnly)
+	gc.SetCookie(constants.COOKIE_NAME+"-client", "", -1, "/", domain, secure, httpOnly)
 }

--- a/server/utils/cookie.go
+++ b/server/utils/cookie.go
@@ -10,7 +10,7 @@ import (
 func SetCookie(gc *gin.Context, token string) {
 	secure := true
 	httpOnly := true
-	host := GetHostName(constants.AUTHORIZER_URL)
+	host := GetDomainName(constants.AUTHORIZER_URL)
 
 	gc.SetSameSite(http.SameSiteNoneMode)
 	gc.SetCookie(constants.COOKIE_NAME, token, 3600, "/", host, secure, httpOnly)
@@ -29,7 +29,7 @@ func DeleteCookie(gc *gin.Context) {
 	secure := true
 	httpOnly := true
 
-	host := GetHostName(constants.AUTHORIZER_URL)
+	host := GetDomainName(constants.AUTHORIZER_URL)
 
 	gc.SetSameSite(http.SameSiteNoneMode)
 	gc.SetCookie(constants.COOKIE_NAME, "", -1, "/", host, secure, httpOnly)

--- a/server/utils/urls.go
+++ b/server/utils/urls.go
@@ -17,7 +17,7 @@ func GetHostName(auth_url string) string {
 	return host
 }
 
-// function to get domain name
+// GetDomainName function to get domain name
 func GetDomainName(auth_url string) string {
 	u, err := url.Parse(auth_url)
 	if err != nil {

--- a/server/utils/urls_test.go
+++ b/server/utils/urls_test.go
@@ -9,7 +9,7 @@ func TestGetHostName(t *testing.T) {
 	want := "test.herokuapp.com"
 
 	if got != want {
-		t.Errorf("GetHostName Test failed got %q, wanted %q", got, want)
+		t.Errorf("GetHostName Test failed got %s, wanted %s", got, want)
 	}
 }
 

--- a/server/utils/urls_test.go
+++ b/server/utils/urls_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import "testing"
+
+func TestGetHostName(t *testing.T) {
+	authorizer_url := "http://test.herokuapp.com"
+
+	got := GetHostName(authorizer_url)
+	want := "test.herokuapp.com"
+
+	if got != want {
+		t.Errorf("GetHostName Test failed got %q, wanted %q", got, want)
+	}
+}
+
+func TestGetDomainName(t *testing.T) {
+	authorizer_url := "http://test.herokuapp.com"
+
+	got := GetDomainName(authorizer_url)
+	want := "herokuapp.com"
+
+	if got != want {
+		t.Errorf("GetHostName Test failed got %q, wanted %q", got, want)
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

- Set the root domain specific cookie if allowed. This will allow using authorizer cookies seamlessly if frontend is using the same domain name.

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
