### PR TITLE
fix: use char(36) with golang uuid instead of sql uuid type

### DIFF
--- a/server/db/roles.go
+++ b/server/db/roles.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Role struct {
-	ID   uuid.UUID `gorm:"type:uuid;"`
+	ID   uuid.UUID `gorm:"primaryKey;type:char(36)"`
 	Role string    `gorm:"unique"`
 }
 

--- a/server/db/session.go
+++ b/server/db/session.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Session struct {
-	ID        uuid.UUID `gorm:"type:uuid;"`
-	UserID    uuid.UUID `gorm:"type:uuid;"`
+	ID        uuid.UUID `gorm:"primaryKey;type:char(36)"`
+	UserID    uuid.UUID `gorm:"type:char(36)"`
 	User      User
 	UserAgent string
 	IP        string

--- a/server/db/user.go
+++ b/server/db/user.go
@@ -10,16 +10,16 @@ import (
 )
 
 type User struct {
-	ID              uuid.UUID `gorm:"type:uuid;"`
+	ID              uuid.UUID `gorm:"primaryKey;type:char(36)"`
 	FirstName       string
 	LastName        string
 	Email           string `gorm:"unique"`
-	Password        string
+	Password        string `gorm:"type:text"`
 	SignupMethod    string
 	EmailVerifiedAt int64
-	CreatedAt       int64 `gorm:"autoCreateTime"`
-	UpdatedAt       int64 `gorm:"autoUpdateTime"`
-	Image           string
+	CreatedAt       int64  `gorm:"autoCreateTime"`
+	UpdatedAt       int64  `gorm:"autoUpdateTime"`
+	Image           string `gorm:"type:text"`
 	Roles           string
 }
 

--- a/server/db/verificationRequests.go
+++ b/server/db/verificationRequests.go
@@ -9,8 +9,8 @@ import (
 )
 
 type VerificationRequest struct {
-	ID         uuid.UUID `gorm:"type:uuid;"`
-	Token      string    `gorm:"index"`
+	ID         uuid.UUID `gorm:"primaryKey;type:char(36)"`
+	Token      string    `gorm:"type:text"`
 	Identifier string
 	ExpiresAt  int64
 	CreatedAt  int64  `gorm:"autoCreateTime"`


### PR DESCRIPTION
#### What does this PR do?
Use golang uuid instead of sql to support all db types.

Also fixes few data types for mysql db

#### Which issue(s) does this PR fix?
resolves #77

Tested using following docker configs

```
version: '3.3'
services:
  db:
    image: amd64/mysql:8.0.27
    restart: always
    environment:
      MYSQL_DATABASE: 'db'
      # So you don't have to use root, but you can if you like
      MYSQL_USER: 'user'
      # You can use whatever password you like
      MYSQL_PASSWORD: 'password'
      # Password for root access
      MYSQL_ROOT_PASSWORD: 'password'
    ports:
      # <Port exposed> : < MySQL Port running inside container>
      - '3306:3306'
    expose:
      # Opens port 3306 on the container
      - '3306'
      # Where our data will be persisted
    volumes:
      - my-db:/var/lib/mysql
volumes:
  my-db:

```

#### If this PR affects any API reference documentation, please share the updated endpoint references
