### PR TITLE
Improve smtp variable names

### DIFF
--- a/server/constants/constants.go
+++ b/server/constants/constants.go
@@ -11,8 +11,9 @@ var (
 	DATABASE_NAME                = ""
 	SMTP_HOST                    = ""
 	SMTP_PORT                    = ""
+	SMTP_USERNAME                = ""
+	SMTP_PASSWORD                = ""
 	SENDER_EMAIL                 = ""
-	SENDER_PASSWORD              = ""
 	JWT_TYPE                     = ""
 	JWT_SECRET                   = ""
 	ALLOWED_ORIGINS              = []string{}

--- a/server/email/email.go
+++ b/server/email/email.go
@@ -27,11 +27,11 @@ type Sender struct {
 }
 
 func NewSender() Sender {
-	return Sender{User: constants.SENDER_EMAIL, Password: constants.SENDER_PASSWORD}
+	return Sender{User: constants.SMTP_USERNAME, Password: constants.SMTP_PASSWORD}
 }
 
 func (sender Sender) SendMail(Dest []string, Subject, bodyMessage string) error {
-	msg := "From: " + sender.User + "\n" +
+	msg := "From: " + constants.SENDER_EMAIL + "\n" +
 		"To: " + strings.Join(Dest, ",") + "\n" +
 		"Subject: " + Subject + "\n" + bodyMessage
 

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -94,12 +94,16 @@ func InitEnv() {
 		constants.SMTP_PORT = os.Getenv("SMTP_PORT")
 	}
 
-	if constants.SENDER_EMAIL == "" {
-		constants.SENDER_EMAIL = os.Getenv("SENDER_EMAIL")
+	if constants.SMTP_USERNAME == "" {
+		constants.SMTP_USERNAME = os.Getenv("SMTP_USERNAME")
 	}
 
-	if constants.SENDER_PASSWORD == "" {
-		constants.SENDER_PASSWORD = os.Getenv("SENDER_PASSWORD")
+	if constants.SMTP_PASSWORD == "" {
+		constants.SMTP_PASSWORD = os.Getenv("SMTP_PASSWORD")
+	}
+
+	if constants.SENDER_EMAIL == "" {
+		constants.SENDER_EMAIL = os.Getenv("SENDER_EMAIL")
 	}
 
 	if constants.JWT_SECRET == "" {
@@ -174,7 +178,7 @@ func InitEnv() {
 	constants.DISABLE_MAGIC_LINK_LOGIN = os.Getenv("DISABLE_MAGIC_LINK_LOGIN") == "true"
 	constants.DISABLE_LOGIN_PAGE = os.Getenv("DISABLE_LOGIN_PAGE") == "true"
 
-	if constants.SMTP_HOST == "" || constants.SENDER_EMAIL == "" || constants.SENDER_PASSWORD == "" {
+	if constants.SMTP_HOST == "" || constants.SMTP_USERNAME == "" || constants.SMTP_PASSWORD == "" || constants.SENDER_EMAIL == "" {
 		constants.DISABLE_EMAIL_VERIFICATION = true
 		constants.DISABLE_MAGIC_LINK_LOGIN = true
 	}


### PR DESCRIPTION

#### What does this PR do?

Improves SMTP env variable names + support `SENDER_EMAIL`. This will help integrate vendors like send grid.

_Rename:_

- `SENDER_EMAIL` -> `SMTP_USERNAME`
- `SENDER_PASSWORD` -> `SMTP_PASSWORD`
- `SENDER_EMAIL` -> Used as `From` in email



#### Which issue(s) does this PR fix?

Resolves #94

#### If this PR affects any API reference documentation, please share the updated endpoint references
