### PR TITLE
enhancement: add access_token_expiry_time env variable

### DIFF
--- a/dashboard/src/constants.ts
+++ b/dashboard/src/constants.ts
@@ -2,6 +2,7 @@ export const LOGO_URL =
 	'https://user-images.githubusercontent.com/6964334/147834043-fc384cab-e7ca-40f8-9663-38fc25fd5f3a.png';
 
 export const TextInputType = {
+	ACCESS_TOKEN_EXPIRY_TIME: 'ACCESS_TOKEN_EXPIRY_TIME',
 	CLIENT_ID: 'CLIENT_ID',
 	GOOGLE_CLIENT_ID: 'GOOGLE_CLIENT_ID',
 	GITHUB_CLIENT_ID: 'GITHUB_CLIENT_ID',

--- a/dashboard/src/graphql/queries/index.ts
+++ b/dashboard/src/graphql/queries/index.ts
@@ -52,6 +52,7 @@ export const EnvVariablesQuery = `
       DATABASE_NAME,
       DATABASE_TYPE,
       DATABASE_URL,
+      ACCESS_TOKEN_EXPIRY_TIME,
     }
   }
 `;

--- a/dashboard/src/pages/Environment.tsx
+++ b/dashboard/src/pages/Environment.tsx
@@ -72,6 +72,7 @@ interface envVarTypes {
 	DATABASE_NAME: string;
 	DATABASE_TYPE: string;
 	DATABASE_URL: string;
+	ACCESS_TOKEN_EXPIRY_TIME: string;
 }
 
 export default function Environment() {
@@ -118,6 +119,7 @@ export default function Environment() {
 		DATABASE_NAME: '',
 		DATABASE_TYPE: '',
 		DATABASE_URL: '',
+		ACCESS_TOKEN_EXPIRY_TIME: '',
 	});
 
 	const [fieldVisibility, setFieldVisibility] = React.useState<
@@ -626,19 +628,35 @@ export default function Environment() {
 			</Stack>
 			<Divider marginTop="2%" marginBottom="2%" />
 			<Text fontSize="md" paddingTop="2%" fontWeight="bold">
-				Custom Access Token Scripts
+				Access Token
 			</Text>
 			<Stack spacing={6} padding="2% 0%">
 				<Flex>
-					<Center w="100%">
+					<Flex w="30%" justifyContent="start" alignItems="center">
+						<Text fontSize="sm">Access Token Expiry Time:</Text>
+					</Flex>
+					<Flex w="70%">
 						<InputField
+							variables={envVariables}
+							setVariables={setEnvVariables}
+							inputType={TextInputType.ACCESS_TOKEN_EXPIRY_TIME}
+							placeholder="0h15m0s"
+						/>
+					</Flex>
+				</Flex>
+				<Flex>
+					<Flex w="30%" justifyContent="start" alignItems="center">
+						<Text fontSize="sm">Custom Access Token Scripts:</Text>
+					</Flex>
+					<Flex w="70%">
+					<InputField
 							variables={envVariables}
 							setVariables={setEnvVariables}
 							inputType={TextAreaInputType.CUSTOM_ACCESS_TOKEN_SCRIPT}
 							placeholder="Add script here"
 							minH="25vh"
 						/>
-					</Center>
+					</Flex>
 				</Flex>
 			</Stack>
 			<Divider marginTop="2%" marginBottom="2%" />

--- a/server/constants/env.go
+++ b/server/constants/env.go
@@ -21,6 +21,8 @@ const (
 	// EnvKeyPort key for env variable PORT
 	EnvKeyPort = "PORT"
 
+	// EnvKeyAccessTokenExpiryTime key for env variable ACCESS_TOKEN_EXPIRY_TIME
+	EnvKeyAccessTokenExpiryTime = "ACCESS_TOKEN_EXPIRY_TIME"
 	// EnvKeyAdminSecret key for env variable ADMIN_SECRET
 	EnvKeyAdminSecret = "ADMIN_SECRET"
 	// EnvKeyDatabaseType key for env variable DATABASE_TYPE

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -120,6 +120,10 @@ func InitAllEnv() error {
 		}
 	}
 
+	if envData.StringEnv[constants.EnvKeyAccessTokenExpiryTime] == "" {
+		envData.StringEnv[constants.EnvKeyAccessTokenExpiryTime] = os.Getenv(constants.EnvKeyAccessTokenExpiryTime)
+	}
+
 	if envData.StringEnv[constants.EnvKeyAdminSecret] == "" {
 		envData.StringEnv[constants.EnvKeyAdminSecret] = os.Getenv(constants.EnvKeyAdminSecret)
 	}

--- a/server/graph/generated/generated.go
+++ b/server/graph/generated/generated.go
@@ -53,6 +53,7 @@ type ComplexityRoot struct {
 	}
 
 	Env struct {
+		AccessTokenExpiryTime      func(childComplexity int) int
 		AdminSecret                func(childComplexity int) int
 		AllowedOrigins             func(childComplexity int) int
 		AppURL                     func(childComplexity int) int
@@ -275,6 +276,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AuthResponse.User(childComplexity), true
+
+	case "Env.ACCESS_TOKEN_EXPIRY_TIME":
+		if e.complexity.Env.AccessTokenExpiryTime == nil {
+			break
+		}
+
+		return e.complexity.Env.AccessTokenExpiryTime(childComplexity), true
 
 	case "Env.ADMIN_SECRET":
 		if e.complexity.Env.AdminSecret == nil {
@@ -1247,6 +1255,7 @@ type Response {
 }
 
 type Env {
+	ACCESS_TOKEN_EXPIRY_TIME: String
 	ADMIN_SECRET: String
 	DATABASE_NAME: String!
 	DATABASE_URL: String!
@@ -1287,6 +1296,7 @@ type Env {
 }
 
 input UpdateEnvInput {
+	ACCESS_TOKEN_EXPIRY_TIME: String
 	ADMIN_SECRET: String
 	CUSTOM_ACCESS_TOKEN_SCRIPT: String
 	OLD_ADMIN_SECRET: String
@@ -1973,6 +1983,38 @@ func (ec *executionContext) _AuthResponse_user(ctx context.Context, field graphq
 	res := resTmp.(*model.User)
 	fc.Result = res
 	return ec.marshalOUser2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋserverᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Env_ACCESS_TOKEN_EXPIRY_TIME(ctx context.Context, field graphql.CollectedField, obj *model.Env) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Env",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AccessTokenExpiryTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Env_ADMIN_SECRET(ctx context.Context, field graphql.CollectedField, obj *model.Env) (ret graphql.Marshaler) {
@@ -7322,6 +7364,14 @@ func (ec *executionContext) unmarshalInputUpdateEnvInput(ctx context.Context, ob
 
 	for k, v := range asMap {
 		switch k {
+		case "ACCESS_TOKEN_EXPIRY_TIME":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ACCESS_TOKEN_EXPIRY_TIME"))
+			it.AccessTokenExpiryTime, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "ADMIN_SECRET":
 			var err error
 
@@ -7893,6 +7943,8 @@ func (ec *executionContext) _Env(ctx context.Context, sel ast.SelectionSet, obj 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Env")
+		case "ACCESS_TOKEN_EXPIRY_TIME":
+			out.Values[i] = ec._Env_ACCESS_TOKEN_EXPIRY_TIME(ctx, field, obj)
 		case "ADMIN_SECRET":
 			out.Values[i] = ec._Env_ADMIN_SECRET(ctx, field, obj)
 		case "DATABASE_NAME":

--- a/server/graph/model/models_gen.go
+++ b/server/graph/model/models_gen.go
@@ -24,6 +24,7 @@ type DeleteUserInput struct {
 }
 
 type Env struct {
+	AccessTokenExpiryTime      *string  `json:"ACCESS_TOKEN_EXPIRY_TIME"`
 	AdminSecret                *string  `json:"ADMIN_SECRET"`
 	DatabaseName               string   `json:"DATABASE_NAME"`
 	DatabaseURL                string   `json:"DATABASE_URL"`
@@ -157,6 +158,7 @@ type SignUpInput struct {
 }
 
 type UpdateEnvInput struct {
+	AccessTokenExpiryTime      *string  `json:"ACCESS_TOKEN_EXPIRY_TIME"`
 	AdminSecret                *string  `json:"ADMIN_SECRET"`
 	CustomAccessTokenScript    *string  `json:"CUSTOM_ACCESS_TOKEN_SCRIPT"`
 	OldAdminSecret             *string  `json:"OLD_ADMIN_SECRET"`

--- a/server/graph/schema.graphqls
+++ b/server/graph/schema.graphqls
@@ -85,6 +85,7 @@ type Response {
 }
 
 type Env {
+	ACCESS_TOKEN_EXPIRY_TIME: String
 	ADMIN_SECRET: String
 	DATABASE_NAME: String!
 	DATABASE_URL: String!
@@ -125,6 +126,7 @@ type Env {
 }
 
 input UpdateEnvInput {
+	ACCESS_TOKEN_EXPIRY_TIME: String
 	ADMIN_SECRET: String
 	CUSTOM_ACCESS_TOKEN_SCRIPT: String
 	OLD_ADMIN_SECRET: String

--- a/server/handlers/authorize.go
+++ b/server/handlers/authorize.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/cookie"
@@ -276,7 +277,11 @@ func AuthorizeHandler() gin.HandlerFunc {
 			sessionstore.SetState(authToken.FingerPrintHash, authToken.FingerPrint+"@"+user.ID)
 			sessionstore.SetState(authToken.AccessToken.Token, authToken.FingerPrint+"@"+user.ID)
 			cookie.SetSession(gc, authToken.FingerPrintHash)
-			expiresIn := int64(1800)
+
+			expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+			if expiresIn <= 0 {
+				expiresIn = 1
+			}
 
 			// used of query mode
 			params := "access_token=" + authToken.AccessToken.Token + "&token_type=bearer&expires_in=" + strconv.FormatInt(expiresIn, 10) + "&state=" + state + "&id_token=" + authToken.IDToken.Token

--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -150,7 +150,12 @@ func OAuthCallbackHandler() gin.HandlerFunc {
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 		}
-		expiresIn := int64(1800)
+
+		expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+		if expiresIn <= 0 {
+			expiresIn = 1
+		}
+
 		params := "access_token=" + authToken.AccessToken.Token + "&token_type=bearer&expires_in=" + strconv.FormatInt(expiresIn, 10) + "&state=" + stateValue + "&id_token=" + authToken.IDToken.Token
 
 		cookie.SetSession(c, authToken.FingerPrintHash)

--- a/server/handlers/token.go
+++ b/server/handlers/token.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/cookie"
@@ -174,7 +175,11 @@ func TokenHandler() gin.HandlerFunc {
 		sessionstore.SetState(authToken.AccessToken.Token, authToken.FingerPrint+"@"+user.ID)
 		cookie.SetSession(gc, authToken.FingerPrintHash)
 
-		expiresIn := int64(1800)
+		expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+		if expiresIn <= 0 {
+			expiresIn = 1
+		}
+
 		res := map[string]interface{}{
 			"access_token": authToken.AccessToken.Token,
 			"id_token":     authToken.IDToken.Token,

--- a/server/handlers/verify_email.go
+++ b/server/handlers/verify_email.go
@@ -82,7 +82,12 @@ func VerifyEmailHandler() gin.HandlerFunc {
 			c.JSON(500, errorRes)
 			return
 		}
-		expiresIn := int64(1800)
+
+		expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+		if expiresIn <= 0 {
+			expiresIn = 1
+		}
+
 		params := "access_token=" + authToken.AccessToken.Token + "&token_type=bearer&expires_in=" + strconv.FormatInt(expiresIn, 10) + "&state=" + state + "&id_token=" + authToken.IDToken.Token
 
 		cookie.SetSession(c, authToken.FingerPrintHash)

--- a/server/resolvers/env.go
+++ b/server/resolvers/env.go
@@ -27,6 +27,7 @@ func EnvResolver(ctx context.Context) (*model.Env, error) {
 
 	// get clone of store
 	store := envstore.EnvStoreObj.GetEnvStoreClone()
+	accessTokenExpiryTime := store.StringEnv[constants.EnvKeyAccessTokenExpiryTime]
 	adminSecret := store.StringEnv[constants.EnvKeyAdminSecret]
 	clientID := store.StringEnv[constants.EnvKeyClientID]
 	clientSecret := store.StringEnv[constants.EnvKeyClientSecret]
@@ -66,6 +67,7 @@ func EnvResolver(ctx context.Context) (*model.Env, error) {
 	organizationLogo := store.StringEnv[constants.EnvKeyOrganizationLogo]
 
 	res = &model.Env{
+		AccessTokenExpiryTime:      &accessTokenExpiryTime,
 		AdminSecret:                &adminSecret,
 		DatabaseName:               databaseName,
 		DatabaseURL:                databaseURL,

--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/cookie"
@@ -69,7 +70,11 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 		return res, err
 	}
 
-	expiresIn := int64(1800)
+	expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
 	res = &model.AuthResponse{
 		Message:     `Logged in successfully`,
 		AccessToken: &authToken.AccessToken.Token,

--- a/server/resolvers/session.go
+++ b/server/resolvers/session.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/authorizerdev/authorizer/server/cookie"
 	"github.com/authorizerdev/authorizer/server/db"
@@ -69,7 +70,11 @@ func SessionResolver(ctx context.Context, params *model.SessionQueryInput) (*mod
 	sessionstore.SetState(authToken.AccessToken.Token, authToken.FingerPrint+"@"+user.ID)
 	cookie.SetSession(gc, authToken.FingerPrintHash)
 
-	expiresIn := int64(1800)
+	expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
 	res = &model.AuthResponse{
 		Message:     `Session token refreshed`,
 		AccessToken: &authToken.AccessToken.Token,

--- a/server/resolvers/signup.go
+++ b/server/resolvers/signup.go
@@ -164,7 +164,10 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		cookie.SetSession(gc, authToken.FingerPrintHash)
 		go utils.SaveSessionInDB(gc, user.ID)
 
-		expiresIn := int64(1800)
+		expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+		if expiresIn <= 0 {
+			expiresIn = 1
+		}
 
 		res = &model.AuthResponse{
 			Message:     `Signed up successfully.`,

--- a/server/resolvers/verify_email.go
+++ b/server/resolvers/verify_email.go
@@ -64,7 +64,11 @@ func VerifyEmailResolver(ctx context.Context, params model.VerifyEmailInput) (*m
 	cookie.SetSession(gc, authToken.FingerPrintHash)
 	go utils.SaveSessionInDB(gc, user.ID)
 
-	expiresIn := int64(1800)
+	expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
 	res = &model.AuthResponse{
 		Message:     `Email verified successfully.`,
 		AccessToken: &authToken.AccessToken.Token,

--- a/server/token/auth_token.go
+++ b/server/token/auth_token.go
@@ -130,7 +130,11 @@ func CreateRefreshToken(user models.User, roles, scopes []string, hostname, nonc
 // CreateAccessToken util to create JWT token, based on
 // user information, roles config and CUSTOM_ACCESS_TOKEN_SCRIPT
 func CreateAccessToken(user models.User, roles, scopes []string, hostName, nonce string) (string, int64, error) {
-	expiryBound := time.Minute * 30
+	expiryBound, err := utils.ParseDurationInSeconds(envstore.EnvStoreObj.GetStringStoreEnvVariable(constants.EnvKeyAccessTokenExpiryTime))
+	if err != nil {
+		expiryBound = time.Minute * 15
+	}
+
 	expiresAt := time.Now().Add(expiryBound).Unix()
 
 	customClaims := jwt.MapClaims{
@@ -277,7 +281,11 @@ func ValidateBrowserSession(gc *gin.Context, encryptedSession string) (*SessionD
 // CreateIDToken util to create JWT token, based on
 // user information, roles config and CUSTOM_ACCESS_TOKEN_SCRIPT
 func CreateIDToken(user models.User, roles []string, hostname, nonce string) (string, int64, error) {
-	expiryBound := time.Minute * 30
+	expiryBound, err := utils.ParseDurationInSeconds(envstore.EnvStoreObj.GetStringStoreEnvVariable(constants.EnvKeyAccessTokenExpiryTime))
+	if err != nil {
+		expiryBound = time.Minute * 15
+	}
+
 	expiresAt := time.Now().Add(expiryBound).Unix()
 
 	resUser := user.AsAPIUser()

--- a/server/utils/parser.go
+++ b/server/utils/parser.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"errors"
+	"time"
+)
+
+// ParseDurationInSeconds parses input s, removes ms/us/ns and returns result duration
+func ParseDurationInSeconds(s string) (time.Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+
+	d = d.Truncate(time.Second)
+	if d <= 0 {
+		return 0, errors.New(`duration must be greater than 0s`)
+	}
+
+	return d, nil
+}


### PR DESCRIPTION
#### What does this PR do?
ACCESS_TOKEN_EXPIRY_TIME env variable can be added in `1h15m15s` format.   
This setting is used for **access_token's** and **id_token's** lifetime.  
Default value = `15m` (in case of absent value or incorrect value).  
May be updated from dashboard interface in `Access token` section.  

#### Which issue(s) does this PR fix?
[Issue](https://github.com/authorizerdev/authorizer/issues/109)

#### If this PR affects any API reference documentation, please share the updated endpoint references
Update docs PR - [url](https://github.com/authorizerdev/docs/pull/4)
