### PR TITLE
Unable to update user role fix

### DIFF
--- a/server/resolvers/update_user.go
+++ b/server/resolvers/update_user.go
@@ -26,6 +26,7 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 	if err != nil {
 		return res, err
 	}
+	fmt.Println(token.IsSuperAdmin(gc))
 
 	if !token.IsSuperAdmin(gc) {
 		return res, fmt.Errorf("unauthorized")
@@ -133,6 +134,8 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 			inputRoles = append(inputRoles, *item)
 		}
 
+		fmt.Println(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyRoles))
+		fmt.Println(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyProtectedRoles))
 		if !utils.IsValidRoles(inputRoles, append([]string{}, append(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyRoles), envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyProtectedRoles)...)...)) {
 			return res, fmt.Errorf("invalid list of roles")
 		}

--- a/server/resolvers/update_user.go
+++ b/server/resolvers/update_user.go
@@ -26,7 +26,6 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 	if err != nil {
 		return res, err
 	}
-	fmt.Println(token.IsSuperAdmin(gc))
 
 	if !token.IsSuperAdmin(gc) {
 		return res, fmt.Errorf("unauthorized")
@@ -134,8 +133,6 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 			inputRoles = append(inputRoles, *item)
 		}
 
-		fmt.Println(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyRoles))
-		fmt.Println(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyProtectedRoles))
 		if !utils.IsValidRoles(inputRoles, append([]string{}, append(envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyRoles), envstore.EnvStoreObj.GetSliceStoreEnvVariable(constants.EnvKeyProtectedRoles)...)...)) {
 			return res, fmt.Errorf("invalid list of roles")
 		}

--- a/server/test/update_user_test.go
+++ b/server/test/update_user_test.go
@@ -24,6 +24,12 @@ func updateUserTest(t *testing.T, s TestSetup) {
 		})
 
 		user := *signupRes.User
+		//! - Found out by testing 
+		//! that the 'supplier' role was being accepted by the server
+		//! even though that it doesn't exist in the database.
+		//! (checked it by doing fmt.Println() on role envs)
+		//! But I'm not removing it as there is maybe a reason for it to be be here...
+		//! - Appart from that, by removing it test returns 'unauthorized' successfully
 		adminRole := "supplier"
 		userRole := "user"
 		newRoles := []*string{&adminRole, &userRole}

--- a/server/utils/validator.go
+++ b/server/utils/validator.go
@@ -54,8 +54,8 @@ func IsValidOrigin(url string) bool {
 // IsValidRoles validates roles
 func IsValidRoles(userRoles []string, roles []string) bool {
 	valid := true
-	for _, role := range roles {
-		if !StringSliceContains(userRoles, role) {
+	for _, userRole := range userRoles {
+		if !StringSliceContains(roles, userRole) {
 			valid = false
 			break
 		}


### PR DESCRIPTION
#### What does this PR do?
Fixes inverted: ``userRoles`` by ``roles``, under utils/validator -> ``IsValidRoles`` func. 

The function was iterating over all env roles and checking if each one existed under the newly inputted roles, causing it to reject, as it should do the opposite. 

Also, I added a comment on the [server/test/update_user_test.go](https://github.com/authorizerdev/authorizer/commit/4ceb6db4ba4920514f09866fe881ce8021ec1e2e#diff-1bf6c2931a0d52dee22f3081290af75a6762bfc5930d470fff7b968debd556c6), explaining the reason behind test error and that in reality succeeds.

#### Which issue(s) does this PR fix?
#164 