### PR TITLE
fix: parallel access of env vars

### DIFF
--- a/server/constants/env.go
+++ b/server/constants/env.go
@@ -3,6 +3,8 @@ package constants
 var VERSION = "0.0.1"
 
 const (
+	// TestEnv is used for testing
+	TestEnv = "test"
 	// EnvKeyEnv key for env variable ENV
 	EnvKeyEnv = "ENV"
 	// EnvKeyEnvPath key for cli arg variable ENV_PATH

--- a/server/email/email.go
+++ b/server/email/email.go
@@ -37,7 +37,7 @@ func SendMail(to []string, Subject, bodyMessage string) error {
 	if err != nil {
 		return err
 	}
-	if envKey == "test" {
+	if envKey == constants.TestEnv {
 		return nil
 	}
 	m := gomail.NewMessage()

--- a/server/memorystore/providers/inmemory/envstore.go
+++ b/server/memorystore/providers/inmemory/envstore.go
@@ -26,20 +26,11 @@ func (e *EnvStore) UpdateStore(store map[string]interface{}) {
 
 // GetStore returns the env store
 func (e *EnvStore) GetStore() map[string]interface{} {
-	if os.Getenv("ENV") != "test" {
-		e.mutex.Lock()
-		defer e.mutex.Unlock()
-	}
-
 	return e.store
 }
 
 // Get returns the value of the key in evn store
 func (e *EnvStore) Get(key string) interface{} {
-	if os.Getenv("ENV") != "test" {
-		e.mutex.Lock()
-		defer e.mutex.Unlock()
-	}
 	return e.store[key]
 }
 

--- a/server/memorystore/providers/inmemory/envstore.go
+++ b/server/memorystore/providers/inmemory/envstore.go
@@ -3,6 +3,8 @@ package inmemory
 import (
 	"os"
 	"sync"
+
+	"github.com/authorizerdev/authorizer/server/constants"
 )
 
 // EnvStore struct to store the env variables
@@ -13,7 +15,7 @@ type EnvStore struct {
 
 // UpdateEnvStore to update the whole env store object
 func (e *EnvStore) UpdateStore(store map[string]interface{}) {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		e.mutex.Lock()
 		defer e.mutex.Unlock()
 	}
@@ -36,7 +38,7 @@ func (e *EnvStore) Get(key string) interface{} {
 
 // Set sets the value of the key in env store
 func (e *EnvStore) Set(key string, value interface{}) {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		e.mutex.Lock()
 		defer e.mutex.Unlock()
 	}

--- a/server/memorystore/providers/inmemory/store.go
+++ b/server/memorystore/providers/inmemory/store.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/authorizerdev/authorizer/server/constants"
 )
 
 // ClearStore clears the in-memory store.
 func (c *provider) ClearStore() error {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
 	}
@@ -32,7 +34,7 @@ func (c *provider) GetUserSessions(userId string) map[string]string {
 
 // DeleteAllUserSession deletes all the user sessions from in-memory store.
 func (c *provider) DeleteAllUserSession(userId string) error {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
 	}
@@ -46,7 +48,7 @@ func (c *provider) DeleteAllUserSession(userId string) error {
 
 // SetState sets the state in the in-memory store.
 func (c *provider) SetState(key, state string) error {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
 	}
@@ -67,7 +69,7 @@ func (c *provider) GetState(key string) (string, error) {
 
 // RemoveState removes the state from the in-memory store.
 func (c *provider) RemoveState(key string) error {
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("ENV") != constants.TestEnv {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
 	}

--- a/server/memorystore/providers/inmemory/store.go
+++ b/server/memorystore/providers/inmemory/store.go
@@ -19,10 +19,6 @@ func (c *provider) ClearStore() error {
 
 // GetUserSessions returns all the user session token from the in-memory store.
 func (c *provider) GetUserSessions(userId string) map[string]string {
-	if os.Getenv("ENV") != "test" {
-		c.mutex.Lock()
-		defer c.mutex.Unlock()
-	}
 	res := map[string]string{}
 	for k, v := range c.stateStore {
 		split := strings.Split(v, "@")
@@ -61,11 +57,6 @@ func (c *provider) SetState(key, state string) error {
 
 // GetState gets the state from the in-memory store.
 func (c *provider) GetState(key string) (string, error) {
-	if os.Getenv("ENV") != "test" {
-		c.mutex.Lock()
-		defer c.mutex.Unlock()
-	}
-
 	state := ""
 	if stateVal, ok := c.stateStore[key]; ok {
 		state = stateVal


### PR DESCRIPTION
#### What does this PR do?

Remove mutex lock while getting vars

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
