### PR TITLE
feat: Add a option to disable httpOnly cookies

### DIFF
--- a/server/constants/env.go
+++ b/server/constants/env.go
@@ -49,6 +49,10 @@ const (
 	EnvKeySenderEmail = "SENDER_EMAIL"
 	// EnvKeyIsEmailServiceEnabled key for env variable IS_EMAIL_SERVICE_ENABLED
 	EnvKeyIsEmailServiceEnabled = "IS_EMAIL_SERVICE_ENABLED"
+	// EnvKeyAppCookieSecure key for env variable APP_COOKIE_SECURE
+	EnvKeyAppCookieSecure = "APP_COOKIE_SECURE"
+	// EnvKeyAdminCookieSecure key for env variable ADMIN_COOKIE_SECURE
+	EnvKeyAdminCookieSecure = "ADMIN_COOKIE_SECURE"
 	// EnvKeyJwtType key for env variable JWT_TYPE
 	EnvKeyJwtType = "JWT_TYPE"
 	// EnvKeyJwtSecret key for env variable JWT_SECRET

--- a/server/cookie/admin_cookie.go
+++ b/server/cookie/admin_cookie.go
@@ -3,15 +3,24 @@ package cookie
 import (
 	"net/url"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/authorizerdev/authorizer/server/constants"
+	"github.com/authorizerdev/authorizer/server/memorystore"
 	"github.com/authorizerdev/authorizer/server/parsers"
 	"github.com/gin-gonic/gin"
 )
 
 // SetAdminCookie sets the admin cookie in the response
 func SetAdminCookie(gc *gin.Context, token string) {
-	secure := true
-	httpOnly := true
+	adminCookieSecure, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyAdminCookieSecure)
+	if err != nil {
+		log.Debug("Error while getting admin cookie secure from env variable: %v", err)
+		adminCookieSecure = true
+	}
+
+	secure := adminCookieSecure
+	httpOnly := adminCookieSecure
 	hostname := parsers.GetHost(gc)
 	host, _ := parsers.GetHostParts(hostname)
 	gc.SetCookie(constants.AdminCookieName, token, 3600, "/", host, secure, httpOnly)
@@ -35,8 +44,14 @@ func GetAdminCookie(gc *gin.Context) (string, error) {
 
 // DeleteAdminCookie sets the response cookie to empty
 func DeleteAdminCookie(gc *gin.Context) {
-	secure := true
-	httpOnly := true
+	adminCookieSecure, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyAdminCookieSecure)
+	if err != nil {
+		log.Debug("Error while getting admin cookie secure from env variable: %v", err)
+		adminCookieSecure = true
+	}
+
+	secure := adminCookieSecure
+	httpOnly := adminCookieSecure
 	hostname := parsers.GetHost(gc)
 	host, _ := parsers.GetHostParts(hostname)
 	gc.SetCookie(constants.AdminCookieName, "", -1, "/", host, secure, httpOnly)

--- a/server/cookie/cookie.go
+++ b/server/cookie/cookie.go
@@ -4,15 +4,24 @@ import (
 	"net/http"
 	"net/url"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/authorizerdev/authorizer/server/constants"
+	"github.com/authorizerdev/authorizer/server/memorystore"
 	"github.com/authorizerdev/authorizer/server/parsers"
 	"github.com/gin-gonic/gin"
 )
 
 // SetSession sets the session cookie in the response
 func SetSession(gc *gin.Context, sessionID string) {
-	secure := true
-	httpOnly := true
+	appCookieSecure, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyAppCookieSecure)
+	if err != nil {
+		log.Debug("Error while getting app cookie secure from env variable: %v", err)
+		appCookieSecure = true
+	}
+
+	secure := appCookieSecure
+	httpOnly := appCookieSecure
 	hostname := parsers.GetHost(gc)
 	host, _ := parsers.GetHostParts(hostname)
 	domain := parsers.GetDomainName(hostname)
@@ -30,8 +39,14 @@ func SetSession(gc *gin.Context, sessionID string) {
 
 // DeleteSession sets session cookies to expire
 func DeleteSession(gc *gin.Context) {
-	secure := true
-	httpOnly := true
+	appCookieSecure, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyAppCookieSecure)
+	if err != nil {
+		log.Debug("Error while getting app cookie secure from env variable: %v", err)
+		appCookieSecure = true
+	}
+
+	secure := appCookieSecure
+	httpOnly := appCookieSecure
 	hostname := parsers.GetHost(gc)
 	host, _ := parsers.GetHostParts(hostname)
 	domain := parsers.GetDomainName(hostname)

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -420,7 +420,11 @@ func InitAllEnv() error {
 	}
 
 	if _, ok := envData[constants.EnvKeyAppCookieSecure]; !ok {
-		envData[constants.EnvKeyAppCookieSecure] = osAppCookieSecure == "true"
+		if osAppCookieSecure == "" {
+			envData[constants.EnvKeyAppCookieSecure] = "true"
+		} else {
+			envData[constants.EnvKeyAppCookieSecure] = osAppCookieSecure == "true"
+		}
 	}
 	if osAppCookieSecure != "" {
 		boolValue, err := strconv.ParseBool(osAppCookieSecure)
@@ -433,7 +437,11 @@ func InitAllEnv() error {
 	}
 
 	if _, ok := envData[constants.EnvKeyAdminCookieSecure]; !ok {
-		envData[constants.EnvKeyAdminCookieSecure] = osAdminCookieSecure == "true"
+		if osAdminCookieSecure == "" {
+			envData[constants.EnvKeyAdminCookieSecure] = "true"
+		} else {
+			envData[constants.EnvKeyAdminCookieSecure] = osAdminCookieSecure == "true"
+		}
 	}
 	if osAdminCookieSecure != "" {
 		boolValue, err := strconv.ParseBool(osAdminCookieSecure)

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -79,6 +79,8 @@ func InitAllEnv() error {
 	osOrganizationLogo := os.Getenv(constants.EnvKeyOrganizationLogo)
 
 	// os bool vars
+	osAppCookieSecure := os.Getenv(constants.EnvKeyAppCookieSecure)
+	osAdminCookieSecure := os.Getenv(constants.EnvKeyAdminCookieSecure)
 	osDisableBasicAuthentication := os.Getenv(constants.EnvKeyDisableBasicAuthentication)
 	osDisableEmailVerification := os.Getenv(constants.EnvKeyDisableEmailVerification)
 	osDisableMagicLinkLogin := os.Getenv(constants.EnvKeyDisableMagicLinkLogin)
@@ -415,6 +417,32 @@ func InitAllEnv() error {
 	}
 	if osOrganizationLogo != "" && envData[constants.EnvKeyOrganizationLogo] != osOrganizationLogo {
 		envData[constants.EnvKeyOrganizationLogo] = osOrganizationLogo
+	}
+
+	if _, ok := envData[constants.EnvKeyAppCookieSecure]; !ok {
+		envData[constants.EnvKeyAppCookieSecure] = osAppCookieSecure == "true"
+	}
+	if osAppCookieSecure != "" {
+		boolValue, err := strconv.ParseBool(osAppCookieSecure)
+		if err != nil {
+			return err
+		}
+		if boolValue != envData[constants.EnvKeyAppCookieSecure].(bool) {
+			envData[constants.EnvKeyAppCookieSecure] = boolValue
+		}
+	}
+
+	if _, ok := envData[constants.EnvKeyAdminCookieSecure]; !ok {
+		envData[constants.EnvKeyAdminCookieSecure] = osAdminCookieSecure == "true"
+	}
+	if osAdminCookieSecure != "" {
+		boolValue, err := strconv.ParseBool(osAdminCookieSecure)
+		if err != nil {
+			return err
+		}
+		if boolValue != envData[constants.EnvKeyAdminCookieSecure].(bool) {
+			envData[constants.EnvKeyAdminCookieSecure] = boolValue
+		}
 	}
 
 	if _, ok := envData[constants.EnvKeyDisableBasicAuthentication]; !ok {

--- a/server/env/env.go
+++ b/server/env/env.go
@@ -421,7 +421,7 @@ func InitAllEnv() error {
 
 	if _, ok := envData[constants.EnvKeyAppCookieSecure]; !ok {
 		if osAppCookieSecure == "" {
-			envData[constants.EnvKeyAppCookieSecure] = "true"
+			envData[constants.EnvKeyAppCookieSecure] = true
 		} else {
 			envData[constants.EnvKeyAppCookieSecure] = osAppCookieSecure == "true"
 		}
@@ -438,7 +438,7 @@ func InitAllEnv() error {
 
 	if _, ok := envData[constants.EnvKeyAdminCookieSecure]; !ok {
 		if osAdminCookieSecure == "" {
-			envData[constants.EnvKeyAdminCookieSecure] = "true"
+			envData[constants.EnvKeyAdminCookieSecure] = true
 		} else {
 			envData[constants.EnvKeyAdminCookieSecure] = osAdminCookieSecure == "true"
 		}


### PR DESCRIPTION
#### What does this PR do?

Adds 2 envs to disable httpOnly cookies

#### Which issue(s) does this PR fix?

fixes https://github.com/authorizerdev/authorizer/issues/227

#### If this PR affects any API reference documentation, please share the updated endpoint references

Probably the envs section?
