### PR TITLE
fix: scope for github auth

### DIFF
--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -287,9 +287,9 @@ func processGithubUserInfo(code string) (models.User, error) {
 		log.Debug("Failed to create github user info request: ", err)
 		return user, fmt.Errorf("error creating github user info request: %s", err.Error())
 	}
-	req.Header = http.Header{
-		"Authorization": []string{fmt.Sprintf("token %s", oauth2Token.AccessToken)},
-	}
+	req.Header.Set(
+		"Authorization", fmt.Sprintf("token %s", oauth2Token.AccessToken),
+	)
 
 	response, err := client.Do(req)
 	if err != nil {
@@ -331,14 +331,14 @@ func processGithubUserInfo(code string) (models.User, error) {
 		}
 
 		// fetch using /users/email endpoint
-		req, err := http.NewRequest("GET", constants.GithubUserEmails, nil)
+		req, err := http.NewRequest(http.MethodGet, constants.GithubUserEmails, nil)
 		if err != nil {
 			log.Debug("Failed to create github emails request: ", err)
 			return user, fmt.Errorf("error creating github user info request: %s", err.Error())
 		}
-		req.Header = http.Header{
-			"Authorization": []string{fmt.Sprintf("token %s", oauth2Token.AccessToken)},
-		}
+		req.Header.Set(
+			"Authorization", fmt.Sprintf("token %s", oauth2Token.AccessToken),
+		)
 
 		response, err := client.Do(req)
 		if err != nil {

--- a/server/oauth/oauth.go
+++ b/server/oauth/oauth.go
@@ -75,6 +75,7 @@ func InitOAuth() error {
 			ClientSecret: githubClientSecret,
 			RedirectURL:  "/oauth_callback/github",
 			Endpoint:     githubOAuth2.Endpoint,
+			Scopes:       []string{"read:user", "user:email"},
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do?

- Fix the default scope for github login
- Adds following scopes `read:user`, `user:email`

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
