### PR TITLE
fix(server): use sameSite as lax by default for app cookie

### DIFF
--- a/server/cookie/cookie.go
+++ b/server/cookie/cookie.go
@@ -30,6 +30,8 @@ func SetSession(gc *gin.Context, sessionID string) {
 	}
 
 	// Use sameSite = lax by default
+	// Since app cookie can come from cross site it becomes important to set this in lax mode.
+	// Example person using custom UI on their app domain and making request to authorizer domain.
 	// For more information check:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 	// https://github.com/gin-gonic/gin/blob/master/context.go#L86

--- a/server/cookie/cookie.go
+++ b/server/cookie/cookie.go
@@ -29,10 +29,16 @@ func SetSession(gc *gin.Context, sessionID string) {
 		domain = "." + domain
 	}
 
+	// Use sameSite = lax by default
+	// For more information check:
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+	// https://github.com/gin-gonic/gin/blob/master/context.go#L86
+	// TODO add ability to sameSite = none / strict from dashboard
+	gc.SetSameSite(http.SameSiteLaxMode)
+
 	// TODO allow configuring from dashboard
 	year := 60 * 60 * 24 * 365
 
-	gc.SetSameSite(http.SameSiteNoneMode)
 	gc.SetCookie(constants.AppCookieName+"_session", sessionID, year, "/", host, secure, httpOnly)
 	gc.SetCookie(constants.AppCookieName+"_session_domain", sessionID, year, "/", domain, secure, httpOnly)
 }

--- a/server/parsers/url.go
+++ b/server/parsers/url.go
@@ -11,8 +11,8 @@ import (
 )
 
 // GetHost returns hostname from request context
-// if X-Authorizer-URL header is set it is given highest priority
-// if EnvKeyAuthorizerURL is set it is given second highest priority.
+// if EnvKeyAuthorizerURL is set it is given highest priority.
+// if X-Authorizer-URL header is set it is given second highest priority
 // if above 2 are not set the requesting host name is used
 func GetHost(c *gin.Context) string {
 	authorizerURL, err := memorystore.Provider.GetStringStoreEnvVariable(constants.EnvKeyAuthorizerURL)


### PR DESCRIPTION
#### What does this PR do?

Use sameSite = lax by default
Since app cookie can come from cross site it becomes important to set this in lax mode.
Example person using custom UI on their app domain and making request to authorizer domain.
For more information check:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
https://github.com/gin-gonic/gin/blob/master/context.go#L86

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
