### PR TITLE
chore: update golang to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as go-builder
+FROM golang:1.19.1-alpine as go-builder
 WORKDIR /authorizer
 COPY server server
 COPY Makefile .


### PR DESCRIPTION
#### What does this PR do?

Updates golang version in docker image to 1.19.1

#### Which issue(s) does this PR fix?

Resolves #245 

#### If this PR affects any API reference documentation, please share the updated endpoint references
