### PR TITLE
Added login user to get all allowed roles as param

### DIFF
--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -86,12 +86,16 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 
 	currentRoles := strings.Split(user.Roles, ",")
 	if len(params.Roles) > 0 {
-		if !validators.IsValidRoles(params.Roles, currentRoles) {
-			log.Debug("Invalid roles: ", params.Roles)
-			return res, fmt.Errorf(`invalid roles`)
-		}
+		if params.Roles[0] = "all_allowed_roles" {
+			roles = currentRoles
+		} else {
+			if !validators.IsValidRoles(params.Roles, currentRoles) {
+				log.Debug("Invalid roles: ", params.Roles)
+				return res, fmt.Errorf(`invalid roles`)
+			}
 
-		roles = params.Roles
+			roles = params.Roles
+		}
 	}
 
 	scope := []string{"openid", "email", "profile"}


### PR DESCRIPTION
#### What does this PR do?
This makes it so that if a login request is made with roles params = "all_allowed_roles" then it will just return a JWT with all the users allowed roles

#### Which issue(s) does this PR fix?
Currently you have to login once to know the allowed roles of a user, then send another request with the allowed roles added to the roles param in the request. This would make it possible to make one request and get a JWT that automatically holds all the users allowed roles in the roles claim.

DISCLAIMER: Again I am not a GO programmer, so I have no clue how to locally test 😕 
