### PR TITLE
fix: codeVerifier shouldn't be empty for basic auth

### DIFF
--- a/server/handlers/token.go
+++ b/server/handlers/token.go
@@ -66,7 +66,7 @@ func TokenHandler() gin.HandlerFunc {
 
 		// check if clientID & clientSecret are present as part of
 		// authorization header with basic auth
-		if clientID == "" && clientSecret == "" && codeVerifier == "" {
+		if clientID == "" && clientSecret == "" && codeVerifier != "" {
 			clientID, clientSecret, _ = gc.Request.BasicAuth()
 		}
 


### PR DESCRIPTION
#### What does this PR do?
When you need to get the clientID and clientSecret from the basic auth, codeVerifier SHOULD be set (so != "").

#### Which issue(s) does this PR fix?
It fixes the OpenID flow for software that use POST forms (per example, Peertube, thanks @skid9000).
