### PR TITLE
Modify the Facebook login authentication callback to enable user email access through the response body.

### DIFF
--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -450,7 +450,7 @@ func processFacebookUserInfo(code string) (models.User, error) {
 	userRawData := make(map[string]interface{})
 	json.Unmarshal(body, &userRawData)
 
-	email := fmt.Sprintf("%v", userRawData["sub"])
+	email := fmt.Sprintf("%v", userRawData["email"])
 
 	picObject := userRawData["picture"].(map[string]interface{})["data"]
 	picDataObject := picObject.(map[string]interface{})


### PR DESCRIPTION


#### What does this PR do?

The main change in this PR is the modification of the method to access the user's email returned from the Facebook response body during login.This fix resolves an issue with the previous method that caused an auth_callback error, and enables the Facebook login functionality to work as expected, allowing users to successfully log in and register their data.
Issue created in #354 is fixed under this PR.

#### Which issue(s) does this PR fix?
#354



#### If this PR affects any API reference documentation, please share the updated endpoint references
It doesn't affect any endpoint.