### PR TITLE
Fix wrong response_type parsed when missing response_mode

### DIFF
--- a/server/handlers/authorize.go
+++ b/server/handlers/authorize.go
@@ -84,9 +84,9 @@ func AuthorizeHandler() gin.HandlerFunc {
 
 		if responseMode == "" {
 			if val, err := memorystore.Provider.GetStringStoreEnvVariable(constants.EnvKeyDefaultAuthorizeResponseMode); err == nil {
-				responseType = val
+				responseMode = val
 			} else {
-				responseType = constants.ResponseModeQuery
+				responseMode = constants.ResponseModeQuery
 			}
 		}
 


### PR DESCRIPTION
#### What does this PR do?

The original code incorrectly read configured default `respone_mode` value into a variable holding `response_type` value. This causes OAuth2 requests without `response_mode` passed via URL query parameter to fail, because `response_type` value will then be filled with illegal value.

#### Which issue(s) does this PR fix?

There's no issue at this point. I was testing integration with [Memos](https://usememos.com) and found this coding typo. Their SSO implementation does not pass `response_mode`, thus resulting in error.

#### If this PR affects any API reference documentation, please share the updated endpoint references

There's no API change.
