### PR TITLE
refactor(server/utils): remove redundant nil check

### DIFF
--- a/server/utils/webhook.go
+++ b/server/utils/webhook.go
@@ -83,10 +83,8 @@ func RegisterEvent(ctx context.Context, eventName string, authRecipe string, use
 		}
 		req.Header.Set("Content-Type", "application/json")
 
-		if webhook.Headers != nil {
-			for key, val := range webhook.Headers {
-				req.Header.Set(key, val.(string))
-			}
+		for key, val := range webhook.Headers {
+			req.Header.Set(key, val.(string))
 		}
 
 		client := &http.Client{Timeout: time.Second * 30}


### PR DESCRIPTION
#### What does this PR do?

From the Go specification:

> "3. If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/xzuA7WNrkF4

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
