### PR TITLE
fix: use session / access_token for profile related queries or mutation

### DIFF
--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -1222,10 +1222,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-esbuild-linux-64@0.14.9:
+esbuild-darwin-arm64@0.14.9:
   version "0.14.9"
-  resolved "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.9.tgz"
-  integrity sha512-WoEI+R6/PLZAxS7XagfQMFgRtLUi5cjqqU9VCfo3tnWmAXh/wt8QtUfCVVCcXVwZLS/RNvI19CtfjlrJU61nOg==
+  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.9.tgz"
+  integrity sha512-3ue+1T4FR5TaAu4/V1eFMG8Uwn0pgAwQZb/WwL1X78d5Cy8wOVQ67KNH1lsjU+y/9AcwMKZ9x0GGNxBB4a1Rbw==
 
 esbuild@^0.14.9:
   version "0.14.9"

--- a/server/handlers/userinfo.go
+++ b/server/handlers/userinfo.go
@@ -21,7 +21,6 @@ func UserInfoHandler() gin.HandlerFunc {
 			})
 			return
 		}
-
 		claims, err := token.ValidateAccessToken(gc, accessToken)
 		if err != nil {
 			log.Debug("Error validating access token: ", err)
@@ -30,7 +29,6 @@ func UserInfoHandler() gin.HandlerFunc {
 			})
 			return
 		}
-
 		userID := claims["sub"].(string)
 		user, err := db.Provider.GetUserByID(gc, userID)
 		if err != nil {

--- a/server/resolvers/deactivate_account.go
+++ b/server/resolvers/deactivate_account.go
@@ -21,17 +21,11 @@ func DeactivateAccountResolver(ctx context.Context) (*model.Response, error) {
 		log.Debug("Failed to get GinContext: ", err)
 		return res, err
 	}
-	accessToken, err := token.GetAccessToken(gc)
+	userID, err := token.GetUserIDFromSessionOrAccessToken(gc)
 	if err != nil {
-		log.Debug("Failed to get access token: ", err)
+		log.Debug("Failed GetUserIDFromSessionOrAccessToken: ", err)
 		return res, err
 	}
-	claims, err := token.ValidateAccessToken(gc, accessToken)
-	if err != nil {
-		log.Debug("Failed to validate access token: ", err)
-		return res, err
-	}
-	userID := claims["sub"].(string)
 	log := log.WithFields(log.Fields{
 		"user_id": userID,
 	})

--- a/server/resolvers/profile.go
+++ b/server/resolvers/profile.go
@@ -20,21 +20,11 @@ func ProfileResolver(ctx context.Context) (*model.User, error) {
 		log.Debug("Failed to get GinContext: ", err)
 		return res, err
 	}
-
-	accessToken, err := token.GetAccessToken(gc)
+	userID, err := token.GetUserIDFromSessionOrAccessToken(gc)
 	if err != nil {
-		log.Debug("Failed to get access token: ", err)
+		log.Debug("Failed GetUserIDFromSessionOrAccessToken: ", err)
 		return res, err
 	}
-
-	claims, err := token.ValidateAccessToken(gc, accessToken)
-	if err != nil {
-		log.Debug("Failed to validate access token: ", err)
-		return res, err
-	}
-
-	userID := claims["sub"].(string)
-
 	log := log.WithFields(log.Fields{
 		"user_id": userID,
 	})

--- a/server/resolvers/update_profile.go
+++ b/server/resolvers/update_profile.go
@@ -35,15 +35,9 @@ func UpdateProfileResolver(ctx context.Context, params model.UpdateProfileInput)
 		log.Debug("Failed to get GinContext: ", err)
 		return res, err
 	}
-
-	accessToken, err := token.GetAccessToken(gc)
+	userID, err := token.GetUserIDFromSessionOrAccessToken(gc)
 	if err != nil {
-		log.Debug("Failed to get access token: ", err)
-		return res, err
-	}
-	claims, err := token.ValidateAccessToken(gc, accessToken)
-	if err != nil {
-		log.Debug("Failed to validate access token: ", err)
+		log.Debug("Failed GetUserIDFromSessionOrAccessToken: ", err)
 		return res, err
 	}
 
@@ -52,8 +46,6 @@ func UpdateProfileResolver(ctx context.Context, params model.UpdateProfileInput)
 		log.Debug("All params are empty")
 		return res, fmt.Errorf("please enter at least one param to update")
 	}
-
-	userID := claims["sub"].(string)
 	log := log.WithFields(log.Fields{
 		"user_id": userID,
 	})


### PR DESCRIPTION
#### What does this PR do?

Earlier it was only allowing access to profile / update_profile / deactiavte_account using access_token in bearer header, but now it also allows accessing those queries/mutations using session token

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references
