### PR TITLE
feat: unify email & mobile singup + login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-all-db:
 	docker run -d --name dynamodb-local-test  -p 8000:8000 amazon/dynamodb-local:latest
 	docker run -d --name couchbase-local-test  -p 8091-8097:8091-8097 -p 11210:11210 -p 11207:11207 -p 18091-18095:18091-18095 -p 18096:18096 -p 18097:18097 couchbase:latest
 	sh scripts/couchbase-test.sh
-	cd server && go clean --testcache && TEST_DBS="sqlite,mongodb,arangodb,scylladb,dynamodb" go test -p 1 -v ./test
+	cd server && go clean --testcache && TEST_DBS="sqlite,mongodb,arangodb,scylladb,dynamodb,couchbase" go test -p 1 -v ./test
 	docker rm -vf authorizer_scylla_db
 	docker rm -vf authorizer_mongodb_db
 	docker rm -vf authorizer_arangodb

--- a/server/db/models/user.go
+++ b/server/db/models/user.go
@@ -15,7 +15,7 @@ type User struct {
 	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // for arangodb
 	ID  string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
 
-	Email                    string  `gorm:"unique" json:"email" bson:"email" cql:"email" dynamo:"email" index:"email,hash"`
+	Email                    *string `gorm:"unique" json:"email" bson:"email" cql:"email" dynamo:"email" index:"email,hash"`
 	EmailVerifiedAt          *int64  `json:"email_verified_at" bson:"email_verified_at" cql:"email_verified_at" dynamo:"email_verified_at"`
 	Password                 *string `json:"password" bson:"password" cql:"password" dynamo:"password"`
 	SignupMethods            string  `json:"signup_methods" bson:"signup_methods" cql:"signup_methods" dynamo:"signup_methods"`
@@ -54,7 +54,7 @@ func (user *User) AsAPIUser() *model.User {
 		FamilyName:               user.FamilyName,
 		MiddleName:               user.MiddleName,
 		Nickname:                 user.Nickname,
-		PreferredUsername:        refs.NewStringRef(user.Email),
+		PreferredUsername:        user.Email,
 		Gender:                   user.Gender,
 		Birthdate:                user.Birthdate,
 		PhoneNumber:              user.PhoneNumber,

--- a/server/db/providers/couchbase/user.go
+++ b/server/db/providers/couchbase/user.go
@@ -69,7 +69,7 @@ func (p *provider) DeleteUser(ctx context.Context, user *models.User) error {
 func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) (*model.Users, error) {
 	users := []*model.User{}
 	paginationClone := pagination
-	userQuery := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, created_at, updated_at FROM %s.%s ORDER BY id OFFSET $1 LIMIT $2", p.scopeName, models.Collections.User)
+	userQuery := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s ORDER BY id OFFSET $1 LIMIT $2", p.scopeName, models.Collections.User)
 	queryResult, err := p.db.Query(userQuery, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -103,7 +103,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) 
 // GetUserByEmail to get user information from database using email address
 func (p *provider) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	var user *models.User
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, created_at, updated_at FROM %s.%s WHERE email = $1 LIMIT 1", p.scopeName, models.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE email = $1 LIMIT 1", p.scopeName, models.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -122,7 +122,7 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*models.Us
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*models.User, error) {
 	var user *models.User
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, created_at, updated_at FROM %s.%s WHERE _id = $1 LIMIT 1", p.scopeName, models.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE _id = $1 LIMIT 1", p.scopeName, models.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -175,7 +175,7 @@ func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{},
 // GetUserByPhoneNumber to get user information from database using phone number
 func (p *provider) GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (*models.User, error) {
 	var user *models.User
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, created_at, updated_at FROM %s.%s WHERE phone_number = $1 LIMIT 1", p.scopeName, models.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE phone_number = $1 LIMIT 1", p.scopeName, models.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,

--- a/server/db/providers/dynamodb/user.go
+++ b/server/db/providers/dynamodb/user.go
@@ -136,7 +136,7 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*models.User, er
 	var user *models.User
 	err := collection.Get("id", id).OneWithContext(ctx, &user)
 	if err != nil {
-		if user.Email == "" {
+		if refs.StringValue(user.Email) == "" {
 			return user, errors.New("no documets found")
 		} else {
 			return user, nil

--- a/server/db/providers/mongodb/provider.go
+++ b/server/db/providers/mongodb/provider.go
@@ -47,8 +47,6 @@ func NewProvider() (*provider, error) {
 			Keys:    bson.M{"email": 1},
 			Options: options.Index().SetUnique(true).SetSparse(true),
 		},
-	}, options.CreateIndexes())
-	userCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys: bson.M{"phone_number": 1},
 			Options: options.Index().SetUnique(true).SetSparse(true).SetPartialFilterExpression(map[string]interface{}{
@@ -56,7 +54,6 @@ func NewProvider() (*provider, error) {
 			}),
 		},
 	}, options.CreateIndexes())
-
 	mongodb.CreateCollection(ctx, models.Collections.VerificationRequest, options.CreateCollection())
 	verificationRequestCollection := mongodb.Collection(models.Collections.VerificationRequest, options.Collection())
 	verificationRequestCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{

--- a/server/graph/generated/generated.go
+++ b/server/graph/generated/generated.go
@@ -2560,7 +2560,7 @@ input AdminSignupInput {
   admin_secret: String!
 }
 
-# Deprecated with v1.2.0
+# Deprecated from v1.2.0
 input MobileSignUpInput {
   email: String
   given_name: String
@@ -2619,7 +2619,7 @@ input LoginInput {
   state: String
 }
 
-# Deprecated with v1.2.0
+# Deprecated from v1.2.0
 input MobileLoginInput {
   phone_number: String!
   password: String!
@@ -2831,10 +2831,10 @@ input GetUserRequest {
 
 type Mutation {
   signup(params: SignUpInput!): AuthResponse!
-  # Deprecated with v1.2.0
+  # Deprecated from v1.2.0
   mobile_signup(params: MobileSignUpInput): AuthResponse!
   login(params: LoginInput!): AuthResponse!
-  # Deprecated with v1.2.0
+  # Deprecated from v1.2.0
   mobile_login(params: MobileLoginInput!): AuthResponse!
   magic_link_login(params: MagicLinkLoginInput!): Response!
   logout: Response!

--- a/server/graph/generated/generated.go
+++ b/server/graph/generated/generated.go
@@ -2286,7 +2286,8 @@ type Meta {
 
 type User {
   id: ID!
-  email: String!
+  # email or phone_number is always present
+  email: String
   email_verified: Boolean!
   signup_methods: String!
   given_name: String
@@ -11696,14 +11697,11 @@ func (ec *executionContext) _User_email(ctx context.Context, field graphql.Colle
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_User_email(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19847,9 +19845,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "email":
 			out.Values[i] = ec._User_email(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "email_verified":
 			out.Values[i] = ec._User_email_verified(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/server/graph/generated/generated.go
+++ b/server/graph/generated/generated.go
@@ -2560,6 +2560,7 @@ input AdminSignupInput {
   admin_secret: String!
 }
 
+# Deprecated with v1.2.0
 input MobileSignUpInput {
   email: String
   given_name: String
@@ -2584,7 +2585,7 @@ input MobileSignUpInput {
 }
 
 input SignUpInput {
-  email: String!
+  email: String
   given_name: String
   family_name: String
   middle_name: String
@@ -2607,7 +2608,8 @@ input SignUpInput {
 }
 
 input LoginInput {
-  email: String!
+  email: String
+  phone_number: String
   password: String!
   roles: [String!]
   scope: [String!]
@@ -2617,6 +2619,7 @@ input LoginInput {
   state: String
 }
 
+# Deprecated with v1.2.0
 input MobileLoginInput {
   phone_number: String!
   password: String!
@@ -2828,8 +2831,10 @@ input GetUserRequest {
 
 type Mutation {
   signup(params: SignUpInput!): AuthResponse!
+  # Deprecated with v1.2.0
   mobile_signup(params: MobileSignUpInput): AuthResponse!
   login(params: LoginInput!): AuthResponse!
+  # Deprecated with v1.2.0
   mobile_login(params: MobileLoginInput!): AuthResponse!
   magic_link_login(params: MagicLinkLoginInput!): Response!
   logout: Response!
@@ -16364,7 +16369,7 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email", "password", "roles", "scope", "state"}
+	fieldsInOrder := [...]string{"email", "phone_number", "password", "roles", "scope", "state"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -16375,11 +16380,20 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj in
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Email = data
+		case "phone_number":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("phone_number"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PhoneNumber = data
 		case "password":
 			var err error
 
@@ -17018,7 +17032,7 @@ func (ec *executionContext) unmarshalInputSignUpInput(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/server/graph/model/models_gen.go
+++ b/server/graph/model/models_gen.go
@@ -429,7 +429,7 @@ type UpdateWebhookRequest struct {
 
 type User struct {
 	ID                       string                 `json:"id"`
-	Email                    string                 `json:"email"`
+	Email                    *string                `json:"email,omitempty"`
 	EmailVerified            bool                   `json:"email_verified"`
 	SignupMethods            string                 `json:"signup_methods"`
 	GivenName                *string                `json:"given_name,omitempty"`

--- a/server/graph/model/models_gen.go
+++ b/server/graph/model/models_gen.go
@@ -166,11 +166,12 @@ type ListWebhookLogRequest struct {
 }
 
 type LoginInput struct {
-	Email    string   `json:"email"`
-	Password string   `json:"password"`
-	Roles    []string `json:"roles,omitempty"`
-	Scope    []string `json:"scope,omitempty"`
-	State    *string  `json:"state,omitempty"`
+	Email       *string  `json:"email,omitempty"`
+	PhoneNumber *string  `json:"phone_number,omitempty"`
+	Password    string   `json:"password"`
+	Roles       []string `json:"roles,omitempty"`
+	Scope       []string `json:"scope,omitempty"`
+	State       *string  `json:"state,omitempty"`
 }
 
 type MagicLinkLoginInput struct {
@@ -284,7 +285,7 @@ type SessionQueryInput struct {
 }
 
 type SignUpInput struct {
-	Email                    string                 `json:"email"`
+	Email                    *string                `json:"email,omitempty"`
 	GivenName                *string                `json:"given_name,omitempty"`
 	FamilyName               *string                `json:"family_name,omitempty"`
 	MiddleName               *string                `json:"middle_name,omitempty"`

--- a/server/graph/schema.graphqls
+++ b/server/graph/schema.graphqls
@@ -306,7 +306,7 @@ input AdminSignupInput {
   admin_secret: String!
 }
 
-# Deprecated with v1.2.0
+# Deprecated from v1.2.0
 input MobileSignUpInput {
   email: String
   given_name: String
@@ -365,7 +365,7 @@ input LoginInput {
   state: String
 }
 
-# Deprecated with v1.2.0
+# Deprecated from v1.2.0
 input MobileLoginInput {
   phone_number: String!
   password: String!
@@ -577,10 +577,10 @@ input GetUserRequest {
 
 type Mutation {
   signup(params: SignUpInput!): AuthResponse!
-  # Deprecated with v1.2.0
+  # Deprecated from v1.2.0
   mobile_signup(params: MobileSignUpInput): AuthResponse!
   login(params: LoginInput!): AuthResponse!
-  # Deprecated with v1.2.0
+  # Deprecated from v1.2.0
   mobile_login(params: MobileLoginInput!): AuthResponse!
   magic_link_login(params: MagicLinkLoginInput!): Response!
   logout: Response!

--- a/server/graph/schema.graphqls
+++ b/server/graph/schema.graphqls
@@ -32,7 +32,8 @@ type Meta {
 
 type User {
   id: ID!
-  email: String!
+  # email or phone_number is always present
+  email: String
   email_verified: Boolean!
   signup_methods: String!
   given_name: String

--- a/server/graph/schema.graphqls
+++ b/server/graph/schema.graphqls
@@ -306,6 +306,7 @@ input AdminSignupInput {
   admin_secret: String!
 }
 
+# Deprecated with v1.2.0
 input MobileSignUpInput {
   email: String
   given_name: String
@@ -330,7 +331,7 @@ input MobileSignUpInput {
 }
 
 input SignUpInput {
-  email: String!
+  email: String
   given_name: String
   family_name: String
   middle_name: String
@@ -353,7 +354,8 @@ input SignUpInput {
 }
 
 input LoginInput {
-  email: String!
+  email: String
+  phone_number: String
   password: String!
   roles: [String!]
   scope: [String!]
@@ -363,6 +365,7 @@ input LoginInput {
   state: String
 }
 
+# Deprecated with v1.2.0
 input MobileLoginInput {
   phone_number: String!
   password: String!
@@ -574,8 +577,10 @@ input GetUserRequest {
 
 type Mutation {
   signup(params: SignUpInput!): AuthResponse!
+  # Deprecated with v1.2.0
   mobile_signup(params: MobileSignUpInput): AuthResponse!
   login(params: LoginInput!): AuthResponse!
+  # Deprecated with v1.2.0
   mobile_login(params: MobileLoginInput!): AuthResponse!
   magic_link_login(params: MagicLinkLoginInput!): Response!
   logout: Response!

--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -23,6 +23,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/db/models"
 	"github.com/authorizerdev/authorizer/server/memorystore"
 	"github.com/authorizerdev/authorizer/server/oauth"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/authorizerdev/authorizer/server/utils"
 )
@@ -85,7 +86,7 @@ func OAuthCallbackHandler() gin.HandlerFunc {
 			return
 		}
 
-		existingUser, err := db.Provider.GetUserByEmail(ctx, user.Email)
+		existingUser, err := db.Provider.GetUserByEmail(ctx, refs.StringValue(user.Email))
 		log := log.WithField("user", user.Email)
 		isSignUp := false
 
@@ -415,7 +416,7 @@ func processGithubUserInfo(ctx context.Context, code string) (*models.User, erro
 		GivenName:  &firstName,
 		FamilyName: &lastName,
 		Picture:    &picture,
-		Email:      email,
+		Email:      &email,
 	}
 
 	return user, nil
@@ -466,7 +467,7 @@ func processFacebookUserInfo(ctx context.Context, code string) (*models.User, er
 		GivenName:  &firstName,
 		FamilyName: &lastName,
 		Picture:    &picture,
-		Email:      email,
+		Email:      &email,
 	}
 
 	return user, nil
@@ -548,7 +549,7 @@ func processLinkedInUserInfo(ctx context.Context, code string) (*models.User, er
 		GivenName:  &firstName,
 		FamilyName: &lastName,
 		Picture:    &profilePicture,
-		Email:      emailAddress,
+		Email:      &emailAddress,
 	}
 
 	return user, nil
@@ -588,7 +589,8 @@ func processAppleUserInfo(ctx context.Context, code string) (*models.User, error
 		log.Debug("Failed to extract email from claims.")
 		return user, fmt.Errorf("unable to extract email, please check the scopes enabled for your app. It needs `email`, `name` scopes")
 	} else {
-		user.Email = val.(string)
+		email := val.(string)
+		user.Email = &email
 	}
 
 	if val, ok := claims["name"]; ok {

--- a/server/resolvers/invite_members.go
+++ b/server/resolvers/invite_members.go
@@ -106,7 +106,7 @@ func InviteMembersResolver(ctx context.Context, params model.InviteMemberInput) 
 		}
 
 		user := &models.User{
-			Email: email,
+			Email: refs.NewStringRef(email),
 			Roles: strings.Join(defaultRoles, ","),
 		}
 		hostname := parsers.GetHost(gc)
@@ -171,7 +171,7 @@ func InviteMembersResolver(ctx context.Context, params model.InviteMemberInput) 
 		}
 
 		// exec it as go routine so that we can reduce the api latency
-		go emailservice.SendEmail([]string{user.Email}, constants.VerificationTypeInviteMember, map[string]interface{}{
+		go emailservice.SendEmail([]string{refs.StringValue(user.Email)}, constants.VerificationTypeInviteMember, map[string]interface{}{
 			"user":             user.ToMap(),
 			"organization":     utils.GetOrganization(),
 			"verification_url": utils.GetInviteVerificationURL(verifyEmailURL, verificationToken, redirectURL),

--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -145,7 +145,7 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 		otp := utils.GenerateOTP()
 		expires := time.Now().Add(1 * time.Minute).Unix()
 		otpData, err := db.Provider.UpsertOTP(ctx, &models.OTP{
-			Email:     user.Email,
+			Email:     refs.StringValue(user.Email),
 			Otp:       otp,
 			ExpiresAt: expires,
 		})

--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -14,16 +14,18 @@ import (
 	"github.com/authorizerdev/authorizer/server/cookie"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/db/models"
-	"github.com/authorizerdev/authorizer/server/email"
+	mailService "github.com/authorizerdev/authorizer/server/email"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
 	"github.com/authorizerdev/authorizer/server/refs"
+	"github.com/authorizerdev/authorizer/server/smsproviders"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/authorizerdev/authorizer/server/utils"
 	"github.com/authorizerdev/authorizer/server/validators"
 )
 
 // LoginResolver is a resolver for login mutation
+// User can login with email or phone number, but not both
 func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthResponse, error) {
 	var res *model.AuthResponse
 
@@ -39,43 +41,72 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 		isBasicAuthDisabled = true
 	}
 
+	isMobileBasicAuthDisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableMobileBasicAuthentication)
+	if err != nil {
+		log.Debug("Error getting mobile basic auth disabled: ", err)
+		isMobileBasicAuthDisabled = true
+	}
+
+	email := refs.StringValue(params.Email)
+	phoneNumber := refs.StringValue(params.PhoneNumber)
+	if email == "" && phoneNumber == "" {
+		log.Debug("Email or phone number is required")
+		return res, fmt.Errorf(`email or phone number is required`)
+	}
+	log := log.WithFields(log.Fields{
+		"email":        refs.StringValue(params.Email),
+		"phone_number": refs.StringValue(params.PhoneNumber),
+	})
+	isEmailLogin := email != ""
+	isMobileLogin := phoneNumber != ""
 	if isBasicAuthDisabled {
 		log.Debug("Basic authentication is disabled.")
 		return res, fmt.Errorf(`basic authentication is disabled for this instance`)
 	}
-
-	log := log.WithFields(log.Fields{
-		"email": params.Email,
-	})
-	params.Email = strings.ToLower(params.Email)
-	user, err := db.Provider.GetUserByEmail(ctx, params.Email)
+	if isMobileBasicAuthDisabled && isMobileLogin {
+		log.Debug("Mobile basic authentication is disabled.")
+		return res, fmt.Errorf(`mobile basic authentication is disabled for this instance`)
+	}
+	var user *models.User
+	if isEmailLogin {
+		user, err = db.Provider.GetUserByEmail(ctx, email)
+	} else {
+		user, err = db.Provider.GetUserByPhoneNumber(ctx, phoneNumber)
+	}
 	if err != nil {
-		log.Debug("Failed to get user by email: ", err)
+		log.Debug("Failed to get user: ", err)
 		return res, fmt.Errorf(`bad user credentials`)
 	}
-
 	if user.RevokedTimestamp != nil {
 		log.Debug("User access is revoked")
 		return res, fmt.Errorf(`user access has been revoked`)
 	}
+	if isEmailLogin {
+		if !strings.Contains(user.SignupMethods, constants.AuthRecipeMethodBasicAuth) {
+			log.Debug("User signup method is not basic auth")
+			return res, fmt.Errorf(`user has not signed up email & password`)
+		}
 
-	if !strings.Contains(user.SignupMethods, constants.AuthRecipeMethodBasicAuth) {
-		log.Debug("User signup method is not basic auth")
-		return res, fmt.Errorf(`user has not signed up email & password`)
+		if user.EmailVerifiedAt == nil {
+			log.Debug("User email is not verified")
+			return res, fmt.Errorf(`email not verified`)
+		}
+	} else {
+		if !strings.Contains(user.SignupMethods, constants.AuthRecipeMethodMobileBasicAuth) {
+			log.Debug("User signup method is not mobile basic auth")
+			return res, fmt.Errorf(`user has not signed up with phone number & password`)
+		}
+
+		if user.PhoneNumberVerifiedAt == nil {
+			log.Debug("User phone number is not verified")
+			return res, fmt.Errorf(`phone number is not verified`)
+		}
 	}
-
-	if user.EmailVerifiedAt == nil {
-		log.Debug("User email is not verified")
-		return res, fmt.Errorf(`email not verified`)
-	}
-
 	err = bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte(params.Password))
-
 	if err != nil {
 		log.Debug("Failed to compare password: ", err)
 		return res, fmt.Errorf(`bad user credentials`)
 	}
-
 	defaultRolesString, err := memorystore.Provider.GetStringStoreEnvVariable(constants.EnvKeyDefaultRoles)
 	roles := []string{}
 	if err != nil {
@@ -84,25 +115,25 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 	} else {
 		roles = strings.Split(defaultRolesString, ",")
 	}
-
 	currentRoles := strings.Split(user.Roles, ",")
 	if len(params.Roles) > 0 {
 		if !validators.IsValidRoles(params.Roles, currentRoles) {
 			log.Debug("Invalid roles: ", params.Roles)
 			return res, fmt.Errorf(`invalid roles`)
 		}
-
 		roles = params.Roles
 	}
-
 	scope := []string{"openid", "email", "profile"}
 	if params.Scope != nil && len(scope) > 0 {
 		scope = params.Scope
 	}
-
 	isEmailServiceEnabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyIsEmailServiceEnabled)
 	if err != nil || !isEmailServiceEnabled {
 		log.Debug("Email service not enabled: ", err)
+	}
+	isSMSServiceEnabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyIsSMSServiceEnabled)
+	if err != nil || !isSMSServiceEnabled {
+		log.Debug("SMS service not enabled: ", err)
 	}
 
 	isMFADisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableMultiFactorAuthentication)
@@ -110,8 +141,7 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 		log.Debug("MFA service not enabled: ", err)
 	}
 
-	// If email service is not enabled continue the process in any way
-	if refs.BoolValue(user.IsMultiFactorAuthEnabled) && isEmailServiceEnabled && !isMFADisabled {
+	if refs.BoolValue(user.IsMultiFactorAuthEnabled) && !isMFADisabled {
 		otp := utils.GenerateOTP()
 		expires := time.Now().Add(1 * time.Minute).Unix()
 		otpData, err := db.Provider.UpsertOTP(ctx, &models.OTP{
@@ -131,22 +161,33 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 			return nil, err
 		}
 		cookie.SetMfaSession(gc, mfaSession)
-
-		go func() {
-			// exec it as go routine so that we can reduce the api latency
-			go email.SendEmail([]string{params.Email}, constants.VerificationTypeOTP, map[string]interface{}{
-				"user":         user.ToMap(),
-				"organization": utils.GetOrganization(),
-				"otp":          otpData.Otp,
-			})
-			if err != nil {
-				log.Debug("Failed to send otp email: ", err)
-			}
-		}()
-
+		if isEmailServiceEnabled && isEmailLogin {
+			go func() {
+				// exec it as go routine so that we can reduce the api latency
+				if err := mailService.SendEmail([]string{email}, constants.VerificationTypeOTP, map[string]interface{}{
+					"user":         user.ToMap(),
+					"organization": utils.GetOrganization(),
+					"otp":          otpData.Otp,
+				}); err != nil {
+					log.Debug("Failed to send otp email: ", err)
+				}
+				utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+			}()
+		} else if isSMSServiceEnabled && isMobileLogin {
+			smsBody := strings.Builder{}
+			smsBody.WriteString("Your verification code is: ")
+			smsBody.WriteString(otpData.Otp)
+			go func() {
+				utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodMobileBasicAuth, user)
+				if err := smsproviders.SendSMS(phoneNumber, smsBody.String()); err != nil {
+					log.Debug("Failed to send sms: ", err)
+				}
+			}()
+		}
 		return &model.AuthResponse{
-			Message:                  "Please check the OTP in your inbox",
-			ShouldShowEmailOtpScreen: refs.NewBoolRef(true),
+			Message:                   "Please check the OTP in",
+			ShouldShowEmailOtpScreen:  refs.NewBoolRef(isEmailLogin),
+			ShouldShowMobileOtpScreen: refs.NewBoolRef(isMobileLogin),
 		}, nil
 	}
 
@@ -210,7 +251,13 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 	}
 
 	go func() {
-		utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+		// Register event
+		if isEmailLogin {
+			utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+		} else {
+			utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodMobileBasicAuth, user)
+		}
+		// Record session
 		db.Provider.AddSession(ctx, &models.Session{
 			UserID:    user.ID,
 			UserAgent: utils.GetUserAgent(gc.Request),

--- a/server/resolvers/magic_link_login.go
+++ b/server/resolvers/magic_link_login.go
@@ -56,7 +56,7 @@ func MagicLinkLoginResolver(ctx context.Context, params model.MagicLinkLoginInpu
 	inputRoles := []string{}
 
 	user := &models.User{
-		Email: params.Email,
+		Email: refs.NewStringRef(params.Email),
 	}
 
 	// find user with email

--- a/server/resolvers/mobile_signup.go
+++ b/server/resolvers/mobile_signup.go
@@ -131,7 +131,7 @@ func MobileSignupResolver(ctx context.Context, params *model.MobileSignUpInput) 
 	}
 
 	user := &models.User{
-		Email:       emailInput,
+		Email:       &emailInput,
 		PhoneNumber: &mobile,
 	}
 

--- a/server/resolvers/resend_otp.go
+++ b/server/resolvers/resend_otp.go
@@ -100,7 +100,7 @@ func ResendOTPResolver(ctx context.Context, params model.ResendOTPRequest) (*mod
 
 	otp := utils.GenerateOTP()
 	if _, err := db.Provider.UpsertOTP(ctx, &models.OTP{
-		Email:     user.Email,
+		Email:     refs.StringValue(user.Email),
 		Otp:       otp,
 		ExpiresAt: time.Now().Add(1 * time.Minute).Unix(),
 	}); err != nil {

--- a/server/resolvers/signup.go
+++ b/server/resolvers/signup.go
@@ -16,11 +16,12 @@ import (
 	"github.com/authorizerdev/authorizer/server/crypto"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/db/models"
-	"github.com/authorizerdev/authorizer/server/email"
+	emailService "github.com/authorizerdev/authorizer/server/email"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
 	"github.com/authorizerdev/authorizer/server/parsers"
 	"github.com/authorizerdev/authorizer/server/refs"
+	"github.com/authorizerdev/authorizer/server/smsproviders"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/authorizerdev/authorizer/server/utils"
 	"github.com/authorizerdev/authorizer/server/validators"
@@ -51,46 +52,77 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		log.Debug("Error getting basic auth disabled: ", err)
 		isBasicAuthDisabled = true
 	}
-
-	if isBasicAuthDisabled {
-		log.Debug("Basic authentication is disabled")
-		return res, fmt.Errorf(`basic authentication is disabled for this instance`)
+	isMobileBasicAuthDisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableMobileBasicAuthentication)
+	if err != nil {
+		log.Debug("Error getting mobile basic auth disabled: ", err)
+		isMobileBasicAuthDisabled = true
 	}
-
 	if params.ConfirmPassword != params.Password {
 		log.Debug("Passwords do not match")
 		return res, fmt.Errorf(`password and confirm password does not match`)
 	}
-
 	if err := validators.IsValidPassword(params.Password); err != nil {
 		log.Debug("Invalid password")
 		return res, err
 	}
-
-	params.Email = strings.ToLower(params.Email)
-
-	if !validators.IsValidEmail(params.Email) {
+	email := strings.TrimSpace(refs.StringValue(params.Email))
+	phoneNumber := strings.TrimSpace(refs.StringValue(params.PhoneNumber))
+	if email == "" && phoneNumber == "" {
+		log.Debug("Email or phone number is required")
+		return res, fmt.Errorf(`email or phone number is required`)
+	}
+	isEmailSignup := email != ""
+	isMobileSignup := phoneNumber != ""
+	if isBasicAuthDisabled {
+		log.Debug("Basic authentication is disabled")
+		return res, fmt.Errorf(`basic authentication is disabled for this instance`)
+	}
+	if isMobileBasicAuthDisabled && isMobileSignup {
+		log.Debug("Mobile basic authentication is disabled")
+		return res, fmt.Errorf(`mobile basic authentication is disabled for this instance`)
+	}
+	if isEmailSignup && !validators.IsValidEmail(email) {
 		log.Debug("Invalid email: ", params.Email)
 		return res, fmt.Errorf(`invalid email address`)
 	}
-
-	log := log.WithFields(log.Fields{
-		"email": params.Email,
-	})
-	// find user with email
-	existingUser, err := db.Provider.GetUserByEmail(ctx, params.Email)
-	if err != nil {
-		log.Debug("Failed to get user by email: ", err)
+	if isMobileSignup && (phoneNumber == "" || len(phoneNumber) < 10) {
+		log.Debug("Invalid phone number: ", phoneNumber)
+		return res, fmt.Errorf(`invalid phone number`)
 	}
-
-	if existingUser != nil {
-		if existingUser.EmailVerifiedAt != nil {
-			// email is verified
-			log.Debug("Email is already verified and signed up.")
-			return res, fmt.Errorf(`%s has already signed up`, params.Email)
-		} else if existingUser.ID != "" && existingUser.EmailVerifiedAt == nil {
-			log.Debug("Email is already signed up. Verification pending...")
-			return res, fmt.Errorf("%s has already signed up. please complete the email verification process or reset the password", params.Email)
+	log := log.WithFields(log.Fields{
+		"email":        email,
+		"phone_number": phoneNumber,
+	})
+	// find user with email / phone number
+	if isEmailSignup {
+		existingUser, err := db.Provider.GetUserByEmail(ctx, email)
+		if err != nil {
+			log.Debug("Failed to get user by email: ", err)
+		}
+		if existingUser != nil {
+			if existingUser.EmailVerifiedAt != nil {
+				// email is verified
+				log.Debug("Email is already verified and signed up.")
+				return res, fmt.Errorf(`%s has already signed up`, email)
+			} else if existingUser.ID != "" && existingUser.EmailVerifiedAt == nil {
+				log.Debug("Email is already signed up. Verification pending...")
+				return res, fmt.Errorf("%s has already signed up. please complete the email verification process or reset the password", email)
+			}
+		}
+	} else {
+		existingUser, err := db.Provider.GetUserByPhoneNumber(ctx, phoneNumber)
+		if err != nil {
+			log.Debug("Failed to get user by phone number: ", err)
+		}
+		if existingUser != nil {
+			if existingUser.PhoneNumberVerifiedAt != nil {
+				// email is verified
+				log.Debug("Phone number is already verified and signed up.")
+				return res, fmt.Errorf(`%s has already signed up`, phoneNumber)
+			} else if existingUser.ID != "" && existingUser.PhoneNumberVerifiedAt == nil {
+				log.Debug("Phone number is already signed up. Verification pending...")
+				return res, fmt.Errorf("%s has already signed up. please complete the phone number verification process or reset the password", phoneNumber)
+			}
 		}
 	}
 
@@ -120,13 +152,14 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 			inputRoles = strings.Split(inputRolesString, ",")
 		}
 	}
-	user := &models.User{
-		Email: params.Email,
-	}
+	user := &models.User{}
 	user.Roles = strings.Join(inputRoles, ",")
 	password, _ := crypto.EncryptPassword(params.Password)
 	user.Password = &password
-
+	if email != "" {
+		user.SignupMethods = constants.AuthRecipeMethodBasicAuth
+		user.Email = email
+	}
 	if params.GivenName != nil {
 		user.GivenName = params.GivenName
 	}
@@ -151,8 +184,9 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		user.Birthdate = params.Birthdate
 	}
 
-	if params.PhoneNumber != nil {
-		user.PhoneNumber = params.PhoneNumber
+	if phoneNumber != "" {
+		user.SignupMethods = constants.AuthRecipeMethodMobileBasicAuth
+		user.PhoneNumber = refs.NewStringRef(phoneNumber)
 	}
 
 	if params.Picture != nil {
@@ -183,8 +217,6 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		appDataString = string(appDataBytes)
 		user.AppData = &appDataString
 	}
-
-	user.SignupMethods = constants.AuthRecipeMethodBasicAuth
 	isEmailVerificationDisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableEmailVerification)
 	if err != nil {
 		log.Debug("Error getting email verification disabled: ", err)
@@ -194,6 +226,15 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		now := time.Now().Unix()
 		user.EmailVerifiedAt = &now
 	}
+	disablePhoneVerification, _ := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisablePhoneVerification)
+	if disablePhoneVerification {
+		now := time.Now().Unix()
+		user.PhoneNumberVerifiedAt = &now
+	}
+	isSMSServiceEnabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyIsSMSServiceEnabled)
+	if err != nil || !isSMSServiceEnabled {
+		log.Debug("SMS service not enabled: ", err)
+	}
 	user, err = db.Provider.AddUser(ctx, user)
 	if err != nil {
 		log.Debug("Failed to add user: ", err)
@@ -201,9 +242,8 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 	}
 	roles := strings.Split(user.Roles, ",")
 	userToReturn := user.AsAPIUser()
-
 	hostname := parsers.GetHost(gc)
-	if !isEmailVerificationDisabled {
+	if !isEmailVerificationDisabled && isEmailSignup {
 		// insert verification request
 		_, nonceHash, err := utils.GenerateNonce()
 		if err != nil {
@@ -215,7 +255,7 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 		if params.RedirectURI != nil {
 			redirectURL = *params.RedirectURI
 		}
-		verificationToken, err := token.CreateVerificationToken(params.Email, verificationType, hostname, nonceHash, redirectURL)
+		verificationToken, err := token.CreateVerificationToken(email, verificationType, hostname, nonceHash, redirectURL)
 		if err != nil {
 			log.Debug("Failed to create verification token: ", err)
 			return res, err
@@ -224,7 +264,7 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 			Token:       verificationToken,
 			Identifier:  verificationType,
 			ExpiresAt:   time.Now().Add(time.Minute * 30).Unix(),
-			Email:       params.Email,
+			Email:       email,
 			Nonce:       nonceHash,
 			RedirectURI: redirectURL,
 		})
@@ -232,11 +272,10 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 			log.Debug("Failed to add verification request: ", err)
 			return res, err
 		}
-
 		// exec it as go routine so that we can reduce the api latency
 		go func() {
 			// exec it as go routine so that we can reduce the api latency
-			email.SendEmail([]string{params.Email}, constants.VerificationTypeBasicAuthSignup, map[string]interface{}{
+			emailService.SendEmail([]string{email}, constants.VerificationTypeBasicAuthSignup, map[string]interface{}{
 				"user":             user.ToMap(),
 				"organization":     utils.GetOrganization(),
 				"verification_url": utils.GetEmailVerificationURL(verificationToken, hostname, redirectURL),
@@ -244,86 +283,120 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 			utils.RegisterEvent(ctx, constants.UserCreatedWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
 		}()
 
-		res = &model.AuthResponse{
+		return &model.AuthResponse{
 			Message: `Verification email has been sent. Please check your inbox`,
 			User:    userToReturn,
-		}
-	} else {
-		scope := []string{"openid", "email", "profile"}
-		if params.Scope != nil && len(scope) > 0 {
-			scope = params.Scope
-		}
+		}, nil
+	} else if !disablePhoneVerification && isSMSServiceEnabled && isMobileSignup {
+		duration, _ := time.ParseDuration("10m")
+		smsCode := utils.GenerateOTP()
 
-		code := ""
-		codeChallenge := ""
-		nonce := ""
-		if params.State != nil {
-			// Get state from store
-			authorizeState, _ := memorystore.Provider.GetState(refs.StringValue(params.State))
-			if authorizeState != "" {
-				authorizeStateSplit := strings.Split(authorizeState, "@@")
-				if len(authorizeStateSplit) > 1 {
-					code = authorizeStateSplit[0]
-					codeChallenge = authorizeStateSplit[1]
-				} else {
-					nonce = authorizeState
-				}
-				go memorystore.Provider.RemoveState(refs.StringValue(params.State))
-			}
-		}
+		smsBody := strings.Builder{}
+		smsBody.WriteString("Your verification code is: ")
+		smsBody.WriteString(smsCode)
 
-		if nonce == "" {
-			nonce = uuid.New().String()
-		}
-
-		authToken, err := token.CreateAuthToken(gc, user, roles, scope, constants.AuthRecipeMethodBasicAuth, nonce, code)
+		// TODO: For those who enabled the webhook to call their sms vendor separately - sending the otp to their api
 		if err != nil {
-			log.Debug("Failed to create auth token: ", err)
+			log.Debug("error while upserting user: ", err.Error())
+			return nil, err
+		}
+		_, err = db.Provider.UpsertOTP(ctx, &models.OTP{
+			PhoneNumber: phoneNumber,
+			Otp:         smsCode,
+			ExpiresAt:   time.Now().Add(duration).Unix(),
+		})
+		if err != nil {
+			log.Debug("error while upserting OTP: ", err.Error())
+			return nil, err
+		}
+		go func() {
+			smsproviders.SendSMS(phoneNumber, smsBody.String())
+			utils.RegisterEvent(ctx, constants.UserCreatedWebhookEvent, constants.AuthRecipeMethodMobileBasicAuth, user)
+		}()
+		return &model.AuthResponse{
+			Message:                   "Please check the OTP in your inbox",
+			ShouldShowMobileOtpScreen: refs.NewBoolRef(true),
+		}, nil
+	}
+	scope := []string{"openid", "email", "profile"}
+	if params.Scope != nil && len(scope) > 0 {
+		scope = params.Scope
+	}
+
+	code := ""
+	codeChallenge := ""
+	nonce := ""
+	if params.State != nil {
+		// Get state from store
+		authorizeState, _ := memorystore.Provider.GetState(refs.StringValue(params.State))
+		if authorizeState != "" {
+			authorizeStateSplit := strings.Split(authorizeState, "@@")
+			if len(authorizeStateSplit) > 1 {
+				code = authorizeStateSplit[0]
+				codeChallenge = authorizeStateSplit[1]
+			} else {
+				nonce = authorizeState
+			}
+			go memorystore.Provider.RemoveState(refs.StringValue(params.State))
+		}
+	}
+
+	if nonce == "" {
+		nonce = uuid.New().String()
+	}
+
+	authToken, err := token.CreateAuthToken(gc, user, roles, scope, constants.AuthRecipeMethodBasicAuth, nonce, code)
+	if err != nil {
+		log.Debug("Failed to create auth token: ", err)
+		return res, err
+	}
+
+	// Code challenge could be optional if PKCE flow is not used
+	if code != "" {
+		if err := memorystore.Provider.SetState(code, codeChallenge+"@@"+authToken.FingerPrintHash); err != nil {
+			log.Debug("SetState failed: ", err)
 			return res, err
 		}
-
-		// Code challenge could be optional if PKCE flow is not used
-		if code != "" {
-			if err := memorystore.Provider.SetState(code, codeChallenge+"@@"+authToken.FingerPrintHash); err != nil {
-				log.Debug("SetState failed: ", err)
-				return res, err
-			}
-		}
-
-		expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
-		if expiresIn <= 0 {
-			expiresIn = 1
-		}
-
-		res = &model.AuthResponse{
-			Message:     `Signed up successfully.`,
-			AccessToken: &authToken.AccessToken.Token,
-			ExpiresIn:   &expiresIn,
-			User:        userToReturn,
-		}
-
-		sessionKey := constants.AuthRecipeMethodBasicAuth + ":" + user.ID
-		cookie.SetSession(gc, authToken.FingerPrintHash)
-		memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeSessionToken+"_"+authToken.FingerPrint, authToken.FingerPrintHash, authToken.SessionTokenExpiresAt)
-		memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeAccessToken+"_"+authToken.FingerPrint, authToken.AccessToken.Token, authToken.AccessToken.ExpiresAt)
-
-		if authToken.RefreshToken != nil {
-			res.RefreshToken = &authToken.RefreshToken.Token
-			memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeRefreshToken+"_"+authToken.FingerPrint, authToken.RefreshToken.Token, authToken.RefreshToken.ExpiresAt)
-		}
-
-		go func() {
-			utils.RegisterEvent(ctx, constants.UserCreatedWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
-			utils.RegisterEvent(ctx, constants.UserSignUpWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
-			// User is also logged in with signup
-			utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
-			db.Provider.AddSession(ctx, &models.Session{
-				UserID:    user.ID,
-				UserAgent: utils.GetUserAgent(gc.Request),
-				IP:        utils.GetIP(gc.Request),
-			})
-		}()
 	}
+
+	expiresIn := authToken.AccessToken.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
+	res = &model.AuthResponse{
+		Message:     `Signed up successfully.`,
+		AccessToken: &authToken.AccessToken.Token,
+		ExpiresIn:   &expiresIn,
+		User:        userToReturn,
+	}
+
+	sessionKey := constants.AuthRecipeMethodBasicAuth + ":" + user.ID
+	cookie.SetSession(gc, authToken.FingerPrintHash)
+	memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeSessionToken+"_"+authToken.FingerPrint, authToken.FingerPrintHash, authToken.SessionTokenExpiresAt)
+	memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeAccessToken+"_"+authToken.FingerPrint, authToken.AccessToken.Token, authToken.AccessToken.ExpiresAt)
+
+	if authToken.RefreshToken != nil {
+		res.RefreshToken = &authToken.RefreshToken.Token
+		memorystore.Provider.SetUserSession(sessionKey, constants.TokenTypeRefreshToken+"_"+authToken.FingerPrint, authToken.RefreshToken.Token, authToken.RefreshToken.ExpiresAt)
+	}
+
+	go func() {
+		utils.RegisterEvent(ctx, constants.UserCreatedWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+		if isEmailSignup {
+			utils.RegisterEvent(ctx, constants.UserSignUpWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+			utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodBasicAuth, user)
+		} else {
+			utils.RegisterEvent(ctx, constants.UserSignUpWebhookEvent, constants.AuthRecipeMethodMobileBasicAuth, user)
+			utils.RegisterEvent(ctx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodMobileBasicAuth, user)
+		}
+
+		db.Provider.AddSession(ctx, &models.Session{
+			UserID:    user.ID,
+			UserAgent: utils.GetUserAgent(gc.Request),
+			IP:        utils.GetIP(gc.Request),
+		})
+	}()
 
 	return res, nil
 }

--- a/server/resolvers/signup.go
+++ b/server/resolvers/signup.go
@@ -158,7 +158,7 @@ func SignupResolver(ctx context.Context, params model.SignUpInput) (*model.AuthR
 	user.Password = &password
 	if email != "" {
 		user.SignupMethods = constants.AuthRecipeMethodBasicAuth
-		user.Email = email
+		user.Email = &email
 	}
 	if params.GivenName != nil {
 		user.GivenName = params.GivenName

--- a/server/resolvers/test_endpoint.go
+++ b/server/resolvers/test_endpoint.go
@@ -39,7 +39,7 @@ func TestEndpointResolver(ctx context.Context, params model.TestEndpointRequest)
 
 	user := model.User{
 		ID:            uuid.NewString(),
-		Email:         "test_endpoint@foo.com",
+		Email:         refs.NewStringRef("test_endpoint@authorizer.dev"),
 		EmailVerified: true,
 		SignupMethods: constants.AuthRecipeMethodMagicLinkLogin,
 		GivenName:     refs.NewStringRef("Foo"),

--- a/server/resolvers/update_profile.go
+++ b/server/resolvers/update_profile.go
@@ -196,7 +196,7 @@ func UpdateProfileResolver(ctx context.Context, params model.UpdateProfileInput)
 
 	hasEmailChanged := false
 
-	if params.Email != nil && user.Email != refs.StringValue(params.Email) {
+	if params.Email != nil && refs.StringValue(user.Email) != refs.StringValue(params.Email) {
 		// check if valid email
 		if !validators.IsValidEmail(*params.Email) {
 			log.Debug("Failed to validate email: ", refs.StringValue(params.Email))
@@ -220,7 +220,7 @@ func UpdateProfileResolver(ctx context.Context, params model.UpdateProfileInput)
 		go memorystore.Provider.DeleteAllUserSessions(user.ID)
 		go cookie.DeleteSession(gc)
 
-		user.Email = newEmail
+		user.Email = &newEmail
 		isEmailVerificationDisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableEmailVerification)
 		if err != nil {
 			log.Debug("Failed to get disable email verification env variable: ", err)
@@ -257,7 +257,7 @@ func UpdateProfileResolver(ctx context.Context, params model.UpdateProfileInput)
 			}
 
 			// exec it as go routine so that we can reduce the api latency
-			go email.SendEmail([]string{user.Email}, verificationType, map[string]interface{}{
+			go email.SendEmail([]string{refs.StringValue(user.Email)}, verificationType, map[string]interface{}{
 				"user":             user.ToMap(),
 				"organization":     utils.GetOrganization(),
 				"verification_url": utils.GetEmailVerificationURL(verificationToken, hostname, redirectURL),

--- a/server/resolvers/update_user.go
+++ b/server/resolvers/update_user.go
@@ -127,7 +127,7 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 		}
 	}
 
-	if params.Email != nil && user.Email != *params.Email {
+	if params.Email != nil && refs.StringValue(user.Email) != refs.StringValue(params.Email) {
 		// check if valid email
 		if !validators.IsValidEmail(*params.Email) {
 			log.Debug("Invalid email: ", *params.Email)
@@ -145,7 +145,7 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 		go memorystore.Provider.DeleteAllUserSessions(user.ID)
 
 		hostname := parsers.GetHost(gc)
-		user.Email = newEmail
+		user.Email = &newEmail
 		user.EmailVerifiedAt = nil
 		// insert verification request
 		_, nonceHash, err := utils.GenerateNonce()
@@ -173,7 +173,7 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 		}
 
 		// exec it as go routine so that we can reduce the api latency
-		go email.SendEmail([]string{user.Email}, constants.VerificationTypeBasicAuthSignup, map[string]interface{}{
+		go email.SendEmail([]string{refs.StringValue(user.Email)}, constants.VerificationTypeBasicAuthSignup, map[string]interface{}{
 			"user":             user.ToMap(),
 			"organization":     utils.GetOrganization(),
 			"verification_url": utils.GetEmailVerificationURL(verificationToken, hostname, redirectURL),

--- a/server/test/deactivate_account_test.go
+++ b/server/test/deactivate_account_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func deactivateAccountTests(t *testing.T, s TestSetup) {
 		email := "deactiavte_account." + s.TestInfo.Email
 
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/delete_user_test.go
+++ b/server/test/delete_user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/crypto"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func deleteUserTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "delete_user." + s.TestInfo.Email
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/forgot_password_test.go
+++ b/server/test/forgot_password_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +17,7 @@ func forgotPasswordTest(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		email := "forgot_password." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/login_test.go
+++ b/server/test/login_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/authorizerdev/authorizer/server/utils"
 	"github.com/stretchr/testify/assert"
@@ -17,14 +18,14 @@ func loginTests(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		email := "login." + s.TestInfo.Email
 		signUpRes, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, signUpRes)
 		res, err := resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 
@@ -43,20 +44,20 @@ func loginTests(t *testing.T, s TestSetup) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		_, err = resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 			Roles:    []string{"test"},
 		})
 		assert.NotNil(t, err, "invalid roles")
 
 		_, err = resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password + "s",
 		})
 		assert.NotNil(t, err, "invalid password")
 
 		loginRes, err := resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 

--- a/server/test/mobile_login_test.go
+++ b/server/test/mobile_login_test.go
@@ -20,33 +20,17 @@ func mobileLoginTests(t *testing.T, s TestSetup) {
 	t.Helper()
 	t.Run(`should login via mobile`, func(t *testing.T) {
 		_, ctx := createContext(s)
-		email := "mobile_login." + s.TestInfo.Email
 		phoneNumber := "2234567890"
-		signUpRes, err := resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			Email:           refs.NewStringRef(email),
-			PhoneNumber:     phoneNumber,
+		signUpRes, err := resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, signUpRes)
-		res, err := resolvers.MobileLoginResolver(ctx, model.MobileLoginInput{
-			PhoneNumber: phoneNumber,
-			Password:    "random_test",
-		})
-		assert.Error(t, err)
-		assert.Nil(t, res)
-
-		// Should fail for email login
-		res, err = resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
-			Password: s.TestInfo.Password,
-		})
-		assert.Error(t, err)
-		assert.Nil(t, res)
 		// should fail because phone is not verified
-		res, err = resolvers.MobileLoginResolver(ctx, model.MobileLoginInput{
-			PhoneNumber: phoneNumber,
+		res, err := resolvers.LoginResolver(ctx, model.LoginInput{
+			PhoneNumber: refs.NewStringRef(phoneNumber),
 			Password:    s.TestInfo.Password,
 		})
 		assert.NotNil(t, err, "should fail because phone is not verified")
@@ -73,6 +57,5 @@ func mobileLoginTests(t *testing.T, s TestSetup) {
 		assert.NotEqual(t, verifySMSRequest.Message, "", "message should not be empty")
 		assert.NotEmpty(t, verifySMSRequest.AccessToken)
 		assert.NotEmpty(t, verifySMSRequest.IDToken)
-		cleanData(email)
 	})
 }

--- a/server/test/mobile_signup_test.go
+++ b/server/test/mobile_signup_test.go
@@ -20,25 +20,23 @@ func mobileSingupTest(t *testing.T, s TestSetup) {
 	t.Helper()
 	t.Run(`should complete the signup with mobile and check duplicates`, func(t *testing.T) {
 		_, ctx := createContext(s)
-		email := "mobile_basic_auth_signup." + s.TestInfo.Email
-		res, err := resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			Email:           refs.NewStringRef(email),
+		phoneNumber := "1234567890"
+		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password + "s",
 		})
 		assert.NotNil(t, err, "invalid password")
 		assert.Nil(t, res)
-
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			Email:           refs.NewStringRef(email),
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
 			Password:        "test",
 			ConfirmPassword: "test",
 		})
-		assert.Error(t, err)
+		assert.Error(t, err, "phone number or email should be provided")
 		assert.Nil(t, res)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableSignUp, true)
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			Email:           refs.NewStringRef(email),
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -46,8 +44,8 @@ func mobileSingupTest(t *testing.T, s TestSetup) {
 		assert.Nil(t, res)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableSignUp, false)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableMobileBasicAuthentication, true)
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			Email:           refs.NewStringRef(email),
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -55,24 +53,24 @@ func mobileSingupTest(t *testing.T, s TestSetup) {
 		assert.Nil(t, res)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableMobileBasicAuthentication, false)
 
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			PhoneNumber:     "   ",
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef("   "),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
 		assert.Error(t, err)
 		assert.Nil(t, res)
 
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			PhoneNumber:     "test",
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef("test"),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
 		assert.Error(t, err)
 		assert.Nil(t, res)
-		phoneNumber := "1234567890"
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			PhoneNumber:     phoneNumber,
+
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -95,20 +93,18 @@ func mobileSingupTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		req.Header.Set("Cookie", cookie)
 		otpRes, err := resolvers.VerifyOtpResolver(ctx, model.VerifyOTPRequest{
-			PhoneNumber: &phoneNumber,
+			PhoneNumber: refs.NewStringRef(phoneNumber),
 			Otp:         otp.Otp,
 		})
 		assert.Nil(t, err)
 		assert.NotEmpty(t, otpRes.Message)
-		res, err = resolvers.MobileSignupResolver(ctx, &model.MobileSignUpInput{
-			PhoneNumber:     "1234567890",
+		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
+			PhoneNumber:     refs.NewStringRef(phoneNumber),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
 		assert.Error(t, err)
 		assert.Nil(t, res)
-
-		cleanData(email)
 		cleanData("1234567890@authorizer.dev")
 	})
 }

--- a/server/test/profile_test.go
+++ b/server/test/profile_test.go
@@ -43,8 +43,7 @@ func profileTests(t *testing.T, s TestSetup) {
 		assert.NotNil(t, profileRes)
 		s.GinContext.Request.Header.Set("Authorization", "")
 		newEmail := profileRes.Email
-		assert.Equal(t, email, newEmail, "emails should be equal")
-
+		assert.Equal(t, email, refs.StringValue(newEmail), "emails should be equal")
 		cleanData(email)
 	})
 }

--- a/server/test/profile_test.go
+++ b/server/test/profile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func profileTests(t *testing.T, s TestSetup) {
 		email := "profile." + s.TestInfo.Email
 
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/resend_otp_test.go
+++ b/server/test/resend_otp_test.go
@@ -23,7 +23,7 @@ func resendOTPTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "resend_otp." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -32,7 +32,7 @@ func resendOTPTest(t *testing.T, s TestSetup) {
 
 		// Login should fail as email is not verified
 		loginRes, err := resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 		assert.Error(t, err)
@@ -63,7 +63,7 @@ func resendOTPTest(t *testing.T, s TestSetup) {
 
 		// Login should not return error but access token should be empty as otp should have been sent
 		loginRes, err = resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 		assert.NoError(t, err)

--- a/server/test/resend_verify_email_test.go
+++ b/server/test/resend_verify_email_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +16,7 @@ func resendVerifyEmailTests(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		email := "resend_verify_email." + s.TestInfo.Email
 		_, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/reset_password_test.go
+++ b/server/test/reset_password_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +17,7 @@ func resetPasswordTest(t *testing.T, s TestSetup) {
 		email := "reset_password." + s.TestInfo.Email
 		_, ctx := createContext(s)
 		_, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/session_test.go
+++ b/server/test/session_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func sessionTests(t *testing.T, s TestSetup) {
 		email := "session." + s.TestInfo.Email
 
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/signup_test.go
+++ b/server/test/signup_test.go
@@ -50,7 +50,7 @@ func signupTests(t *testing.T, s TestSetup) {
 		})
 		assert.Nil(t, err, "signup should be successful")
 		user := *res.User
-		assert.Equal(t, email, user.Email)
+		assert.Equal(t, email, refs.StringValue(user.Email))
 		assert.Equal(t, "test", user.AppData["test"])
 		assert.Nil(t, res.AccessToken, "access token should be nil")
 		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{

--- a/server/test/signup_test.go
+++ b/server/test/signup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,14 +18,14 @@ func signupTests(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		email := "signup." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password + "s",
 		})
 		assert.NotNil(t, err, "invalid password")
 		assert.Nil(t, res)
 		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        "test",
 			ConfirmPassword: "test",
 		})
@@ -32,7 +33,7 @@ func signupTests(t *testing.T, s TestSetup) {
 		assert.Nil(t, res)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableSignUp, true)
 		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -40,7 +41,7 @@ func signupTests(t *testing.T, s TestSetup) {
 		assert.Nil(t, res)
 		memorystore.Provider.UpdateEnvVariable(constants.EnvKeyDisableSignUp, false)
 		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 			AppData: map[string]interface{}{
@@ -53,7 +54,7 @@ func signupTests(t *testing.T, s TestSetup) {
 		assert.Equal(t, "test", user.AppData["test"])
 		assert.Nil(t, res.AccessToken, "access token should be nil")
 		res, err = resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/update_all_users_tests.go
+++ b/server/test/update_all_users_tests.go
@@ -19,7 +19,7 @@ func updateAllUsersTest(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		for i := 0; i < 10; i++ {
 			user := &models.User{
-				Email:         fmt.Sprintf("update_all_user_%d_%s", i, s.TestInfo.Email),
+				Email:         refs.NewStringRef(fmt.Sprintf("update_all_user_%d_%s", i, s.TestInfo.Email)),
 				SignupMethods: constants.AuthRecipeMethodBasicAuth,
 				Roles:         "user",
 			}
@@ -61,7 +61,7 @@ func updateAllUsersTest(t *testing.T, s TestSetup) {
 			} else {
 				assert.True(t, refs.BoolValue(u.IsMultiFactorAuthEnabled))
 			}
-			cleanData(u.Email)
+			cleanData(refs.StringValue(u.Email))
 		}
 	})
 }

--- a/server/test/update_profile_test.go
+++ b/server/test/update_profile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func updateProfileTests(t *testing.T, s TestSetup) {
 		email := "update_profile." + s.TestInfo.Email
 
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/update_user_test.go
+++ b/server/test/update_user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/crypto"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func updateUserTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "update_user." + s.TestInfo.Email
 		signupRes, _ := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/user_test.go
+++ b/server/test/user_test.go
@@ -19,7 +19,7 @@ func userTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "user." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/user_test.go
+++ b/server/test/user_test.go
@@ -59,14 +59,14 @@ func userTest(t *testing.T, s TestSetup) {
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, res.User.ID, userRes.ID)
-		assert.Equal(t, email, userRes.Email)
+		assert.Equal(t, email, refs.StringValue(userRes.Email))
 		// Should get user by email
 		userRes, err = resolvers.UserResolver(ctx, model.GetUserRequest{
 			Email: &email,
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, res.User.ID, userRes.ID)
-		assert.Equal(t, email, userRes.Email)
+		assert.Equal(t, email, refs.StringValue(userRes.Email))
 		cleanData(email)
 	})
 }

--- a/server/test/users_test.go
+++ b/server/test/users_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/crypto"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func usersTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "users." + s.TestInfo.Email
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/validate_jwt_token_test.go
+++ b/server/test/validate_jwt_token_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/db/models"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/authorizerdev/authorizer/server/utils"
@@ -41,7 +42,7 @@ func validateJwtTokenTest(t *testing.T, s TestSetup) {
 	scope := []string{"openid", "email", "profile", "offline_access"}
 	user := &models.User{
 		ID:        uuid.New().String(),
-		Email:     "jwt_test_" + s.TestInfo.Email,
+		Email:     refs.NewStringRef("jwt_test_" + s.TestInfo.Email),
 		Roles:     "user",
 		UpdatedAt: time.Now().Unix(),
 		CreatedAt: time.Now().Unix(),
@@ -96,6 +97,6 @@ func validateJwtTokenTest(t *testing.T, s TestSetup) {
 		})
 		assert.NoError(t, err)
 		assert.True(t, res.IsValid)
-		assert.Equal(t, user.Email, res.Claims["email"])
+		assert.Equal(t, refs.StringValue(user.Email), res.Claims["email"])
 	})
 }

--- a/server/test/validate_session_test.go
+++ b/server/test/validate_session_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/authorizerdev/authorizer/server/token"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func validateSessionTests(t *testing.T, s TestSetup) {
 		email := "validate_session." + s.TestInfo.Email
 
 		resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/verification_requests_test.go
+++ b/server/test/verification_requests_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/crypto"
 	"github.com/authorizerdev/authorizer/server/graph/model"
 	"github.com/authorizerdev/authorizer/server/memorystore"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,7 +20,7 @@ func verificationRequestsTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "verification_requests." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/verify_email_test.go
+++ b/server/test/verify_email_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authorizerdev/authorizer/server/constants"
 	"github.com/authorizerdev/authorizer/server/db"
 	"github.com/authorizerdev/authorizer/server/graph/model"
+	"github.com/authorizerdev/authorizer/server/refs"
 	"github.com/authorizerdev/authorizer/server/resolvers"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +17,7 @@ func verifyEmailTest(t *testing.T, s TestSetup) {
 		_, ctx := createContext(s)
 		email := "verify_email." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})

--- a/server/test/verify_email_test.go
+++ b/server/test/verify_email_test.go
@@ -24,7 +24,7 @@ func verifyEmailTest(t *testing.T, s TestSetup) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		user := *res.User
-		assert.Equal(t, email, user.Email)
+		assert.Equal(t, email, refs.StringValue(user.Email))
 		assert.Nil(t, res.AccessToken, "access token should be nil")
 		verificationRequest, err := db.Provider.GetVerificationRequestByEmail(ctx, email, constants.VerificationTypeBasicAuthSignup)
 		assert.Nil(t, err)

--- a/server/test/verify_otp_test.go
+++ b/server/test/verify_otp_test.go
@@ -23,7 +23,7 @@ func verifyOTPTest(t *testing.T, s TestSetup) {
 		req, ctx := createContext(s)
 		email := "verify_otp." + s.TestInfo.Email
 		res, err := resolvers.SignupResolver(ctx, model.SignUpInput{
-			Email:           email,
+			Email:           refs.NewStringRef(email),
 			Password:        s.TestInfo.Password,
 			ConfirmPassword: s.TestInfo.Password,
 		})
@@ -32,7 +32,7 @@ func verifyOTPTest(t *testing.T, s TestSetup) {
 
 		// Login should fail as email is not verified
 		loginRes, err := resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 		assert.Error(t, err)
@@ -57,7 +57,7 @@ func verifyOTPTest(t *testing.T, s TestSetup) {
 
 		// Login should not return error but access token should be empty as otp should have been sent
 		loginRes, err = resolvers.LoginResolver(ctx, model.LoginInput{
-			Email:    email,
+			Email:    refs.NewStringRef(email),
 			Password: s.TestInfo.Password,
 		})
 		assert.NoError(t, err)


### PR DESCRIPTION
#### What does this PR do?
Make email or mobile optional in login API itself to allow signup / login via mobile

#### Which issue(s) does this PR fix?
Resolves #381 


#### If this PR affects any API reference documentation, please share the updated endpoint references
