### PR TITLE
fix unable to update app_data for user

### DIFF
--- a/server/resolvers/update_user.go
+++ b/server/resolvers/update_user.go
@@ -48,7 +48,7 @@ func UpdateUserResolver(ctx context.Context, params model.UpdateUserInput) (*mod
 		"user_id": params.ID,
 	})
 
-	if params.GivenName == nil && params.FamilyName == nil && params.Picture == nil && params.MiddleName == nil && params.Nickname == nil && params.Email == nil && params.Birthdate == nil && params.Gender == nil && params.PhoneNumber == nil && params.Roles == nil && params.IsMultiFactorAuthEnabled == nil {
+	if params.GivenName == nil && params.FamilyName == nil && params.Picture == nil && params.MiddleName == nil && params.Nickname == nil && params.Email == nil && params.Birthdate == nil && params.Gender == nil && params.PhoneNumber == nil && params.Roles == nil && params.IsMultiFactorAuthEnabled == nil && params.AppData == nil {
 		log.Debug("No params to update")
 		return res, fmt.Errorf("please enter atleast one param to update")
 	}


### PR DESCRIPTION
#### What does this PR do?

Fix bug where i'm unable to update just app-data. 

#### Which issue(s) does this PR fix?

When updating with just app-data i get "please enter atleast one param to update". Even though AppData is present in the request. 

#### If this PR affects any API reference documentation, please share the updated endpoint references
