### PR TITLE
Apple outh fix

### DIFF
--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -101,7 +101,13 @@ func OAuthCallbackHandler() gin.HandlerFunc {
 			ctx.JSON(400, gin.H{"error": err.Error()})
 			return
 		}
-
+		if user == nil{
+			ctx.JSON(
+				500,
+				gin.H{"error": "Something Went Wrong. Please Try Again."},
+			)
+			return
+		}
 		existingUser, err := db.Provider.GetUserByEmail(ctx, refs.StringValue(user.Email))
 		log := log.WithField("user", user.Email)
 		isSignUp := false


### PR DESCRIPTION
#### 1,if user that comes from oauth callback is null it returns something went error to user
#### 2,Apple Oauth call back provides user information outside of id token can be accessed from formvalue using user keyword now fixed to be user info accessed from form value and sent as parameter to processAppleUserInfo function

#### it only affects apple ouath callback endpoint
