### PR TITLE
fix: email login if email not verified

### DIFF
--- a/server/handlers/oauth_callback.go
+++ b/server/handlers/oauth_callback.go
@@ -112,7 +112,8 @@ func OAuthCallbackHandler() gin.HandlerFunc {
 			ctx.JSON(400, gin.H{"error": err.Error()})
 			return
 		}
-		if user == nil{
+		if user == nil {
+			log.Debug("User is nil")
 			ctx.JSON(
 				500,
 				gin.H{"error": "Something Went Wrong. Please Try Again."},

--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -129,6 +129,10 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 				log.Debug("User email is not verified and email service is not enabled")
 				return res, fmt.Errorf(`email not verified`)
 			} else {
+				if vreq, err := db.Provider.GetVerificationRequestByEmail(ctx, email, constants.VerificationTypeBasicAuthSignup); err == nil && vreq != nil {
+					log.Debug("Verification request exists. Please verify email")
+					return res, fmt.Errorf(`email verification pending`)
+				}
 				expiresAt := time.Now().Add(1 * time.Minute).Unix()
 				otpData, err := generateOTP(expiresAt)
 				if err != nil {

--- a/server/resolvers/login.go
+++ b/server/resolvers/login.go
@@ -130,8 +130,17 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 				return res, fmt.Errorf(`email not verified`)
 			} else {
 				if vreq, err := db.Provider.GetVerificationRequestByEmail(ctx, email, constants.VerificationTypeBasicAuthSignup); err == nil && vreq != nil {
-					log.Debug("Verification request exists. Please verify email")
-					return res, fmt.Errorf(`email verification pending`)
+					// if verification request exists and not expired then return
+					// if verification request exists and expired then delete it and proceed
+					if vreq.ExpiresAt <= time.Now().Unix() {
+						if err := db.Provider.DeleteVerificationRequest(ctx, vreq); err != nil {
+							log.Debug("Failed to delete verification request: ", err)
+							// continue with the flow
+						}
+					} else {
+						log.Debug("Verification request exists. Please verify email")
+						return res, fmt.Errorf(`email verification pending`)
+					}
 				}
 				expiresAt := time.Now().Add(1 * time.Minute).Unix()
 				otpData, err := generateOTP(expiresAt)
@@ -156,7 +165,7 @@ func LoginResolver(ctx context.Context, params model.LoginInput) (*model.AuthRes
 				}()
 				return &model.AuthResponse{
 					Message:                  "Please check email inbox for the OTP",
-					ShouldShowEmailOtpScreen: refs.NewBoolRef(isMobileLogin),
+					ShouldShowEmailOtpScreen: refs.NewBoolRef(isEmailLogin),
 				}, nil
 			}
 		}


### PR DESCRIPTION


#### What does this PR do?

If the user signed up & email verification was pending then during login, it use to re-send otp with false boolean.
- Fixed the boolean for showing OTP screen
- Send OTP only if verification link is expired
- Delete verification link if expired

#### Which issue(s) does this PR fix?

#458

#### If this PR affects any API reference documentation, please share the updated endpoint references
