### PR TITLE
fix: use JWTPublicKey for ECDSA token parsing

### DIFF
--- a/internal/token/jwt.go
+++ b/internal/token/jwt.go
@@ -64,7 +64,7 @@ func (p *provider) ParseJWTToken(token string) (jwt.MapClaims, error) {
 		})
 	case jwt.SigningMethodES256, jwt.SigningMethodES384, jwt.SigningMethodES512:
 		_, err = jwt.ParseWithClaims(token, &claims, func(token *jwt.Token) (interface{}, error) {
-			key, err := crypto.ParseEcdsaPublicKeyFromPemStr(p.config.JWTSecret)
+			key, err := crypto.ParseEcdsaPublicKeyFromPemStr(p.config.JWTPublicKey)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
- Fixed ECDSA (ES256/ES384/ES512) token parsing to use `JWTPublicKey` instead of `JWTSecret`
- Signing correctly used `JWTPrivateKey` but parsing was incorrectly using `JWTSecret`

## Test plan
- [ ] Verify ECDSA token signing and parsing works correctly
- [ ] Run existing JWT tests

Fixes #476