### PR TITLE
fix: check verificationRequest.Identifier for login method in VerifyEmail

### DIFF
--- a/internal/graphql/verify_email.go
+++ b/internal/graphql/verify_email.go
@@ -135,7 +135,7 @@ func (g *graphqlProvider) VerifyEmail(ctx context.Context, params *model.VerifyE
 	}
 
 	loginMethod := constants.AuthRecipeMethodBasicAuth
-	if loginMethod == constants.VerificationTypeMagicLinkLogin {
+	if verificationRequest.Identifier == constants.VerificationTypeMagicLinkLogin {
 		loginMethod = constants.AuthRecipeMethodMagicLinkLogin
 	}
 


### PR DESCRIPTION
## Summary
- Fixed dead-code condition where `loginMethod` was compared against `VerificationTypeMagicLinkLogin` immediately after being set to `AuthRecipeMethodBasicAuth`
- Now checks `verificationRequest.Identifier` to correctly identify magic link logins

## Test plan
- [ ] Verify magic link login flow uses correct login method
- [ ] Verify basic auth email verification still works

Fixes #484