### PR TITLE
feat(oidc): token verification + multi-key hardening

### DIFF
--- a/internal/constants/acr.go
+++ b/internal/constants/acr.go
@@ -1,0 +1,14 @@
+package constants
+
+// Authentication Context Class Reference (acr) values per OIDC Core §2.
+// The acr claim communicates the strength of the authentication context
+// to the relying party. Authorizer currently emits a fixed baseline
+// value; richer ACR handling (driven by `acr_values` request parameter
+// and MFA awareness) is a future enhancement.
+const (
+	// ACRBaseline is the no-op baseline acr value. It matches the
+	// "0" level of assurance described by ISO/IEC 29115 and noted
+	// in OIDC Core §2 as the lowest meaningful claim. Emitted so
+	// that clients which require the claim's presence keep working.
+	ACRBaseline = "0"
+)

--- a/internal/constants/amr.go
+++ b/internal/constants/amr.go
@@ -1,0 +1,23 @@
+package constants
+
+// Authentication Methods Reference (amr) values per RFC 8176.
+// These are the values emitted in the OIDC ID Token `amr` claim
+// (OIDC Core §2). Only the subset Authorizer currently supports is
+// listed; extend as new authentication methods land.
+const (
+	// AMRPassword indicates a password-based authentication ("pwd"
+	// per RFC 8176 §2). Used for username/password and mobile/password
+	// login flows.
+	AMRPassword = "pwd"
+	// AMROTP indicates a one-time password authentication ("otp"
+	// per RFC 8176 §2). Used for magic-link and mobile-OTP flows.
+	AMROTP = "otp"
+	// AMRFederated indicates a federated identity assertion ("fed"
+	// per RFC 8176 §2). Used for all upstream OAuth2/OIDC social
+	// providers (Google, GitHub, Apple, etc.).
+	AMRFederated = "fed"
+	// AMRMFA indicates that multi-factor authentication was used
+	// ("mfa" per RFC 8176 §2). Reserved for future use when MFA
+	// signal is plumbed through to the ID token issuer.
+	AMRMFA = "mfa"
+)

--- a/internal/token/audience.go
+++ b/internal/token/audience.go
@@ -1,0 +1,49 @@
+package token
+
+import (
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// AudienceMatches reports whether the JWT `aud` claim contains the
+// expected audience. RFC 7519 §4.1.3 allows `aud` to be either a single
+// case-sensitive string or an array of case-sensitive strings, so naive
+// `==` comparisons miss the array shape entirely. JSON-decoded JWT
+// claims may surface as any of the following Go types depending on the
+// upstream parser, so this helper accepts all of them:
+//
+//   - string
+//   - []string
+//   - []interface{} (default json.Unmarshal target for arrays)
+//   - jwt.ClaimStrings (typed wrapper from golang-jwt/jwt/v4)
+//
+// Returns false for nil, empty arrays, or any other type. Comparison
+// is exact — no scheme normalization or case folding — to match the
+// RFC 7519 case-sensitive requirement.
+func AudienceMatches(aud interface{}, expected string) bool {
+	if aud == nil || expected == "" {
+		return false
+	}
+	switch v := aud.(type) {
+	case string:
+		return v == expected
+	case []string:
+		for _, a := range v {
+			if a == expected {
+				return true
+			}
+		}
+	case jwt.ClaimStrings:
+		for _, a := range v {
+			if a == expected {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == expected {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/token/audience_test.go
+++ b/internal/token/audience_test.go
@@ -1,0 +1,68 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAudienceMatches(t *testing.T) {
+	const expected = "client-123"
+
+	t.Run("string match", func(t *testing.T) {
+		assert.True(t, AudienceMatches("client-123", expected))
+	})
+
+	t.Run("string mismatch", func(t *testing.T) {
+		assert.False(t, AudienceMatches("other", expected))
+	})
+
+	t.Run("[]string contains", func(t *testing.T) {
+		assert.True(t, AudienceMatches([]string{"a", "client-123", "b"}, expected))
+	})
+
+	t.Run("[]string missing", func(t *testing.T) {
+		assert.False(t, AudienceMatches([]string{"a", "b"}, expected))
+	})
+
+	t.Run("[]interface{} contains", func(t *testing.T) {
+		assert.True(t, AudienceMatches([]interface{}{"a", "client-123"}, expected))
+	})
+
+	t.Run("[]interface{} with non-string entries", func(t *testing.T) {
+		assert.False(t, AudienceMatches([]interface{}{1, 2.5, true}, expected))
+	})
+
+	t.Run("[]interface{} mixed match", func(t *testing.T) {
+		assert.True(t, AudienceMatches([]interface{}{1, "client-123"}, expected))
+	})
+
+	t.Run("jwt.ClaimStrings contains", func(t *testing.T) {
+		assert.True(t, AudienceMatches(jwt.ClaimStrings{"a", "client-123"}, expected))
+	})
+
+	t.Run("jwt.ClaimStrings missing", func(t *testing.T) {
+		assert.False(t, AudienceMatches(jwt.ClaimStrings{"a"}, expected))
+	})
+
+	t.Run("nil aud", func(t *testing.T) {
+		assert.False(t, AudienceMatches(nil, expected))
+	})
+
+	t.Run("empty string aud", func(t *testing.T) {
+		assert.False(t, AudienceMatches("", expected))
+	})
+
+	t.Run("empty []string", func(t *testing.T) {
+		assert.False(t, AudienceMatches([]string{}, expected))
+	})
+
+	t.Run("empty expected", func(t *testing.T) {
+		assert.False(t, AudienceMatches("client-123", ""))
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		assert.False(t, AudienceMatches(42, expected))
+	})
+}

--- a/internal/token/auth_token.go
+++ b/internal/token/auth_token.go
@@ -60,14 +60,14 @@ type AuthTokenConfig struct {
 }
 
 // loginMethodToAMR maps an internal LoginMethod value to the OIDC Core §2
-// Authentication Methods Reference array. Returns nil (omit the claim)
-// for unknown or empty methods.
+// Authentication Methods Reference array (RFC 8176 values). Returns nil
+// (omit the claim) for unknown or empty methods.
 func loginMethodToAMR(method string) []string {
 	switch strings.ToLower(method) {
 	case constants.AuthRecipeMethodBasicAuth, constants.AuthRecipeMethodMobileBasicAuth:
-		return []string{"pwd"}
+		return []string{constants.AMRPassword}
 	case constants.AuthRecipeMethodMagicLinkLogin, constants.AuthRecipeMethodMobileOTP:
-		return []string{"otp"}
+		return []string{constants.AMROTP}
 	case constants.AuthRecipeMethodGoogle,
 		constants.AuthRecipeMethodGithub,
 		constants.AuthRecipeMethodFacebook,
@@ -78,7 +78,7 @@ func loginMethodToAMR(method string) []string {
 		constants.AuthRecipeMethodTwitch,
 		constants.AuthRecipeMethodRoblox,
 		constants.AuthRecipeMethodMicrosoft:
-		return []string{"fed"}
+		return []string{constants.AMRFederated}
 	}
 	return nil
 }
@@ -475,7 +475,7 @@ func (p *provider) CreateIDToken(cfg *AuthTokenConfig) (string, int64, error) {
 	// alongside acr_values request support is a future enhancement;
 	// for now returning "0" is safer than omitting the claim for
 	// clients that require its presence.
-	customClaims["acr"] = "0"
+	customClaims["acr"] = constants.ACRBaseline
 	for k, v := range userMap {
 		if k != "roles" {
 			customClaims[k] = v

--- a/internal/token/id_token_hint.go
+++ b/internal/token/id_token_hint.go
@@ -1,0 +1,83 @@
+package token
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/authorizerdev/authorizer/internal/crypto"
+)
+
+// ParseIDTokenHint parses an ID Token presented as the `id_token_hint`
+// authentication or end-session parameter (OIDC Core §3.1.2.1, OIDC
+// RP-Initiated Logout 1.0 §2). Per the spec, the OP SHOULD allow
+// expired ID tokens as hints because the typical hint use-case is
+// "this is who I think the user was when their session lapsed".
+//
+// This helper therefore verifies the signature only and skips
+// time-based claim validation (`exp`, `nbf`, `iat`). Structural
+// validation (alg-mismatch, malformed token) still applies. The same
+// kid-aware key selection as ParseJWTToken is used so primary and
+// secondary keys are honored during a rotation window.
+//
+// The returned MapClaims has `exp` / `iat` left as their parser-native
+// float64 form (no normalization). Callers that need typed values
+// should convert explicitly. The hint MUST NOT be trusted for
+// authorization — only as a soft identifier hint.
+func (p *provider) ParseIDTokenHint(token string) (jwt.MapClaims, error) {
+	if token == "" {
+		return nil, errors.New("empty id_token_hint")
+	}
+	return p.parseJWTWithKidSelection(token, func(algo, secret, publicKey string) (jwt.MapClaims, error) {
+		return p.parseJWTHintWithKey(token, algo, secret, publicKey)
+	})
+}
+
+// parseJWTHintWithKey verifies the signature of an id_token_hint
+// against a single key, skipping time-based claim validation. Mirrors
+// parseJWTWithKey but uses jwt.NewParser(jwt.WithoutClaimsValidation()).
+func (p *provider) parseJWTHintWithKey(token, algo, secret, publicKey string) (jwt.MapClaims, error) {
+	signingMethod := jwt.GetSigningMethod(algo)
+	if signingMethod == nil {
+		return nil, errors.New("unsupported signing method")
+	}
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+
+	var claims jwt.MapClaims
+	var err error
+	switch signingMethod {
+	case jwt.SigningMethodHS256, jwt.SigningMethodHS384, jwt.SigningMethodHS512:
+		_, err = parser.ParseWithClaims(token, &claims, func(t *jwt.Token) (interface{}, error) {
+			if t.Method.Alg() != signingMethod.Alg() {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return []byte(secret), nil
+		})
+	case jwt.SigningMethodRS256, jwt.SigningMethodRS384, jwt.SigningMethodRS512:
+		_, err = parser.ParseWithClaims(token, &claims, func(t *jwt.Token) (interface{}, error) {
+			if t.Method.Alg() != signingMethod.Alg() {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			key, err := crypto.ParseRsaPublicKeyFromPemStr(publicKey)
+			if err != nil {
+				return nil, err
+			}
+			return key, nil
+		})
+	case jwt.SigningMethodES256, jwt.SigningMethodES384, jwt.SigningMethodES512:
+		_, err = parser.ParseWithClaims(token, &claims, func(t *jwt.Token) (interface{}, error) {
+			if t.Method.Alg() != signingMethod.Alg() {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			key, err := crypto.ParseEcdsaPublicKeyFromPemStr(publicKey)
+			if err != nil {
+				return nil, err
+			}
+			return key, nil
+		})
+	default:
+		err = errors.New("unsupported signing method")
+	}
+	return claims, err
+}

--- a/internal/token/id_token_hint_test.go
+++ b/internal/token/id_token_hint_test.go
@@ -1,0 +1,98 @@
+package token
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIDTokenHint_AcceptsExpired(t *testing.T) {
+	p := newTestProvider(t)
+	tok, err := p.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(-1 * time.Hour).Unix(), // expired
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	require.NoError(t, err)
+
+	// Sanity: ParseJWTToken would reject as expired (jwt-go enforces exp).
+	_, parseErr := p.ParseJWTToken(tok)
+	require.Error(t, parseErr)
+
+	// Hint accepts the expired token.
+	claims, err := p.ParseIDTokenHint(tok)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+func TestParseIDTokenHint_RejectsBadSignature(t *testing.T) {
+	signer := newTestProvider(t)
+	signer.config.JWTSecret = "different-secret"
+	tok, err := signer.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	// verifier uses "primary-secret" by default, so signature won't match.
+	_, err = verifier.ParseIDTokenHint(tok)
+	require.Error(t, err)
+}
+
+func TestParseIDTokenHint_RejectsMalformed(t *testing.T) {
+	p := newTestProvider(t)
+	_, err := p.ParseIDTokenHint("not.a.jwt")
+	require.Error(t, err)
+}
+
+func TestParseIDTokenHint_EmptyToken(t *testing.T) {
+	p := newTestProvider(t)
+	_, err := p.ParseIDTokenHint("")
+	require.Error(t, err)
+}
+
+func TestParseIDTokenHint_SecondaryKidSelection(t *testing.T) {
+	// Expired token signed under secondary secret with kid pointing
+	// at the secondary key. ParseIDTokenHint should accept it.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	tok.Header["kid"] = "test-client" + secondaryKidSuffix
+	signed, err := tok.SignedString([]byte("old-secret"))
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	verifier.config.JWTSecret = "new-secret"
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "old-secret"
+
+	claims, err := verifier.ParseIDTokenHint(signed)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+func TestParseIDTokenHint_LegacyKidlessFallback(t *testing.T) {
+	// Legacy expired token (no kid) signed under old secret. The
+	// kid-less try-both fallback inside ParseIDTokenHint should
+	// route to the secondary key.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	signed, err := tok.SignedString([]byte("old-secret"))
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	verifier.config.JWTSecret = "new-secret"
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "old-secret"
+
+	claims, err := verifier.ParseIDTokenHint(signed)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}

--- a/internal/token/jwt.go
+++ b/internal/token/jwt.go
@@ -6,11 +6,38 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
+	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/crypto"
 	"github.com/authorizerdev/authorizer/internal/refs"
 )
 
-// SignJWTToken common util to sing jwt token
+// verificationTokenTypes enumerates the short-lived internal tokens
+// issued by CreateVerificationToken (signup, magic-link, forgot-password,
+// invite, OTP). Per OIDC Core §2 the ID-token `sub` claim MUST be a
+// stable user identifier, but these verification tokens are issued
+// BEFORE the user record exists (signup/magic-link) or address the
+// email channel directly (update-email). For those flows only, we
+// permit `sub == email` as a legitimate fallback. All other token
+// types (access, refresh, ID) require the canonical user ID.
+var verificationTokenTypes = map[string]bool{
+	constants.VerificationTypeBasicAuthSignup: true,
+	constants.VerificationTypeMagicLinkLogin:  true,
+	constants.VerificationTypeUpdateEmail:     true,
+	constants.VerificationTypeForgotPassword:  true,
+	constants.VerificationTypeInviteMember:    true,
+	constants.VerificationTypeOTP:             true,
+}
+
+// secondaryKidSuffix is appended to the primary kid to derive the
+// secondary key's `kid` header value. Mirrors the JWKS handler in
+// internal/http_handlers/jwks.go which publishes the secondary key
+// under "<ClientID>-secondary".
+const secondaryKidSuffix = "-secondary"
+
+// SignJWTToken common util to sign a jwt token. Sets the JOSE
+// `kid` header to the configured ClientID so verifiers (including
+// the Authorizer JWKS endpoint at /.well-known/jwks.json) can pick
+// the right published JWK during a manual key rotation.
 func (p *provider) SignJWTToken(jwtclaims jwt.MapClaims) (string, error) {
 	signingMethod := jwt.GetSigningMethod(p.config.JWTType)
 	if signingMethod == nil {
@@ -21,6 +48,11 @@ func (p *provider) SignJWTToken(jwtclaims jwt.MapClaims) (string, error) {
 		return "", errors.New("unsupported signing method")
 	}
 	t.Claims = jwtclaims
+	// kid identifies the verification key for relying parties.
+	// Authorizer publishes one JWK per active key with kid =
+	// ClientID for the primary and ClientID + "-secondary" for
+	// the optional rotation key.
+	t.Header["kid"] = p.config.ClientID
 
 	switch signingMethod {
 	case jwt.SigningMethodHS256, jwt.SigningMethodHS384, jwt.SigningMethodHS512:
@@ -90,25 +122,94 @@ func (p *provider) parseJWTWithKey(token, algo, secret, publicKey string) (jwt.M
 	return claims, err
 }
 
+// extractKidHeader returns the `kid` JOSE header from a compact JWS
+// without verifying the signature. Used to pre-select the right
+// verification key when both primary and secondary keys are configured.
+// Returns an empty string when the header is absent, malformed, or not
+// a string.
+func extractKidHeader(token string) string {
+	parser := jwt.NewParser()
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil || parsed == nil {
+		return ""
+	}
+	kid, _ := parsed.Header["kid"].(string)
+	return kid
+}
+
+// parseJWTWithKidSelection chooses primary vs secondary verification
+// based on the `kid` header and falls back to trying both keys when
+// the header is missing or unknown (legacy tokens issued before C2 are
+// kid-less). Used by both ParseJWTToken and ParseIDTokenHint.
+//
+// Behaviour:
+//   - kid == ClientID                 → primary only.
+//   - kid == ClientID + "-secondary"  → secondary only (if configured).
+//   - kid missing/unknown             → primary first, then secondary.
+//
+// The fallback only fires for *signature* errors (jwt.ErrTokenSignatureInvalid).
+// Non-signature errors (malformed, alg mismatch, claim error) short-circuit
+// and the primary error is returned wrapped with %w so callers can use
+// errors.Is.
+func (p *provider) parseJWTWithKidSelection(token string, parseFn func(algo, secret, publicKey string) (jwt.MapClaims, error)) (jwt.MapClaims, error) {
+	primaryKid := p.config.ClientID
+	secondaryKid := p.config.ClientID + secondaryKidSuffix
+	hasSecondary := p.config.JWTSecondaryType != ""
+	kid := extractKidHeader(token)
+
+	// kid explicitly identifies a key.
+	if kid != "" {
+		switch kid {
+		case primaryKid:
+			return parseFn(p.config.JWTType, p.config.JWTSecret, p.config.JWTPublicKey)
+		case secondaryKid:
+			if !hasSecondary {
+				return nil, errors.New("token kid references secondary key but no secondary key is configured")
+			}
+			return parseFn(p.config.JWTSecondaryType, p.config.JWTSecondarySecret, p.config.JWTSecondaryPublicKey)
+		}
+		// Unknown kid — fall through to legacy try-both behaviour.
+	}
+
+	claims, err := parseFn(p.config.JWTType, p.config.JWTSecret, p.config.JWTPublicKey)
+	if err == nil {
+		return claims, nil
+	}
+
+	// Only fall back on signature failures so we never paper over
+	// malformed tokens, alg-mismatch errors, or claim errors. The v4
+	// ValidationError type implements Is() against ErrTokenSignatureInvalid.
+	if !hasSecondary || !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+		return claims, fmt.Errorf("primary key verification failed: %w", err)
+	}
+
+	secondaryClaims, secondaryErr := parseFn(p.config.JWTSecondaryType, p.config.JWTSecondarySecret, p.config.JWTSecondaryPublicKey)
+	if secondaryErr != nil {
+		// Surface the primary signature error wrapped — secondary
+		// is best-effort and the caller only needs to know that
+		// verification failed.
+		return claims, fmt.Errorf("primary key verification failed: %w", err)
+	}
+	if p.dependencies != nil && p.dependencies.Log != nil {
+		// Useful rotation signal: a token in the wild was issued
+		// under the previous (now-secondary) key. Token contents
+		// are NOT logged.
+		p.dependencies.Log.Debug().Msg("token verified by secondary key")
+	}
+	return secondaryClaims, nil
+}
+
 // ParseJWTToken common util to parse jwt token. On signature failure
 // with the primary key, retries with the optional secondary key if one
 // is configured — this supports manual key rotation. The signing key
 // for NEW tokens is always the primary; the secondary is only used for
 // verification so outstanding tokens issued with the previous key keep
-// working during a rotation window.
+// working during a rotation window. Honors the `kid` JOSE header to
+// pick the right key directly when present.
 func (p *provider) ParseJWTToken(token string) (jwt.MapClaims, error) {
-	claims, err := p.parseJWTWithKey(token, p.config.JWTType, p.config.JWTSecret, p.config.JWTPublicKey)
-	if err != nil && p.config.JWTSecondaryType != "" {
-		// Retry with the secondary key. Any non-nil error from the
-		// primary path triggers the fallback — signature-invalid,
-		// alg-mismatch, or parse error. If the secondary also fails,
-		// return its error (the caller only cares that verification
-		// failed, not which key failed).
-		if secondaryClaims, secondaryErr := p.parseJWTWithKey(token, p.config.JWTSecondaryType, p.config.JWTSecondarySecret, p.config.JWTSecondaryPublicKey); secondaryErr == nil {
-			claims = secondaryClaims
-			err = nil
-		}
-	}
+	claims, err := p.parseJWTWithKidSelection(token, func(algo, secret, publicKey string) (jwt.MapClaims, error) {
+		return p.parseJWTWithKey(token, algo, secret, publicKey)
+	})
 	if err != nil {
 		return claims, err
 	}
@@ -123,25 +224,25 @@ func (p *provider) ParseJWTToken(token string) (jwt.MapClaims, error) {
 	if !ok {
 		return claims, errors.New("invalid exp claim")
 	}
-
-	iatVal, ok := claims["iat"]
-	if !ok {
-		return claims, errors.New("missing iat claim")
-	}
-	iatFloat, ok := iatVal.(float64)
-	if !ok {
-		return claims, errors.New("invalid iat claim")
-	}
-
 	claims["exp"] = int64(expFloat)
-	claims["iat"] = int64(iatFloat)
+
+	// `iat` is OPTIONAL per RFC 7519 §4.1.6 and OIDC Core for
+	// non-self-issued tokens. Normalize when present, otherwise
+	// leave the claim untouched.
+	if iatVal, ok := claims["iat"]; ok {
+		iatFloat, ok := iatVal.(float64)
+		if !ok {
+			return claims, errors.New("invalid iat claim")
+		}
+		claims["iat"] = int64(iatFloat)
+	}
 
 	return claims, nil
 }
 
 // ValidateJWTClaims common util to validate claims
 func (p *provider) ValidateJWTClaims(claims jwt.MapClaims, authTokenConfig *AuthTokenConfig) (bool, error) {
-	if claims["aud"] != p.config.ClientID {
+	if !AudienceMatches(claims["aud"], p.config.ClientID) {
 		return false, errors.New("invalid audience")
 	}
 
@@ -153,8 +254,17 @@ func (p *provider) ValidateJWTClaims(claims jwt.MapClaims, authTokenConfig *Auth
 		return false, fmt.Errorf("invalid issuer iss[%s] != hostname[%s]", claims["iss"], authTokenConfig.HostName)
 	}
 
-	if claims["sub"] != authTokenConfig.User.ID && claims["sub"] != refs.StringValue(authTokenConfig.User.Email) {
-		return false, errors.New("invalid subject")
+	// OIDC Core §2: `sub` is a stable, never-reassigned identifier.
+	// Accept ONLY the canonical user ID for OIDC-visible tokens
+	// (access, refresh, ID). Verification tokens (signup, magic-link,
+	// forgot-password, invite, OTP) are issued before a stable user
+	// ID is available or address the email channel directly; for
+	// those token_type values we still permit `sub == email`.
+	if claims["sub"] != authTokenConfig.User.ID {
+		tokenType, _ := claims["token_type"].(string)
+		if !verificationTokenTypes[tokenType] || claims["sub"] != refs.StringValue(authTokenConfig.User.Email) {
+			return false, errors.New("invalid subject")
+		}
 	}
 
 	return true, nil
@@ -162,7 +272,7 @@ func (p *provider) ValidateJWTClaims(claims jwt.MapClaims, authTokenConfig *Auth
 
 // ValidateJWTTokenWithoutNonce common util to validate claims without nonce
 func (p *provider) ValidateJWTTokenWithoutNonce(claims jwt.MapClaims, authTokenConfig *AuthTokenConfig) (bool, error) {
-	if claims["aud"] != p.config.ClientID {
+	if !AudienceMatches(claims["aud"], p.config.ClientID) {
 		return false, errors.New("invalid audience")
 	}
 

--- a/internal/token/jwt_test.go
+++ b/internal/token/jwt_test.go
@@ -1,0 +1,272 @@
+package token
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// signHS256NoKid signs an HMAC token WITHOUT a kid header. Used to
+// simulate legacy tokens that were issued before SignJWTToken began
+// stamping `kid`, so the verifier exercises the kid-less try-both
+// fallback path.
+func signHS256NoKid(t *testing.T, secret string, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(secret))
+	require.NoError(t, err)
+	return signed
+}
+
+// newTestProvider builds a minimal *provider for unit tests using HMAC.
+// Caller may override fields on the returned provider's config before
+// signing/verifying.
+func newTestProvider(t *testing.T) *provider {
+	t.Helper()
+	logger := zerolog.New(io.Discard)
+	return &provider{
+		config: &config.Config{
+			ClientID:  "test-client",
+			JWTType:   "HS256",
+			JWTSecret: "primary-secret",
+		},
+		dependencies: &Dependencies{
+			Log: &logger,
+		},
+	}
+}
+
+func TestSignJWTToken_SetsKidHeader(t *testing.T) {
+	p := newTestProvider(t)
+	tok, err := p.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	parsed, _, err := jwt.NewParser().ParseUnverified(tok, jwt.MapClaims{})
+	require.NoError(t, err)
+	assert.Equal(t, "test-client", parsed.Header["kid"])
+}
+
+func TestParseJWTToken_PrimaryKey(t *testing.T) {
+	p := newTestProvider(t)
+	tok, err := p.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	claims, err := p.ParseJWTToken(tok)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+func TestParseJWTToken_OptionalIat(t *testing.T) {
+	p := newTestProvider(t)
+	// Sign without iat — should still parse and validate.
+	tok, err := p.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+	require.NoError(t, err)
+
+	claims, err := p.ParseJWTToken(tok)
+	require.NoError(t, err)
+	_, hasIat := claims["iat"]
+	assert.False(t, hasIat, "iat must remain absent when not signed in")
+}
+
+func TestParseJWTToken_MissingExpRejected(t *testing.T) {
+	p := newTestProvider(t)
+	tok, err := p.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"iat": time.Now().Unix(),
+	})
+	require.NoError(t, err)
+	// jwt-go validates exp during parse only if present; without exp it
+	// passes signature check, then ParseJWTToken's own check fires.
+	_, err = p.ParseJWTToken(tok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exp")
+}
+
+func TestParseJWTToken_LegacyKidlessFallback(t *testing.T) {
+	// Legacy token (no kid header) signed under the old secret.
+	tok := signHS256NoKid(t, "old-secret", jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+
+	verifier := newTestProvider(t)
+	verifier.config.JWTSecret = "new-secret"
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "old-secret"
+
+	claims, err := verifier.ParseJWTToken(tok)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+func TestParseJWTToken_SecondaryKidDirectSelection(t *testing.T) {
+	// Manually craft a token with kid = ClientID + "-secondary" to
+	// exercise the direct secondary-kid selection path. The token is
+	// signed under the secondary secret only — the primary secret
+	// would not verify it, so a successful parse proves the kid header
+	// drove key selection.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	tok.Header["kid"] = "test-client" + secondaryKidSuffix
+	signed, err := tok.SignedString([]byte("old-secret"))
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	verifier.config.ClientID = "test-client"
+	verifier.config.JWTSecret = "new-secret"
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "old-secret"
+
+	claims, err := verifier.ParseJWTToken(signed)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+func TestParseJWTToken_SecondaryKidWithoutConfig(t *testing.T) {
+	// kid claims secondary but verifier has no secondary configured.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+	tok.Header["kid"] = "test-client" + secondaryKidSuffix
+	signed, err := tok.SignedString([]byte("anything"))
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	_, err = verifier.ParseJWTToken(signed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary")
+}
+
+func TestParseJWTToken_NoFallbackOnMalformed(t *testing.T) {
+	verifier := newTestProvider(t)
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "anything"
+
+	_, err := verifier.ParseJWTToken("not-a-jwt")
+	require.Error(t, err)
+	// Must NOT report success — fallback only applies to signature errors.
+	assert.NotContains(t, err.Error(), "user-1")
+}
+
+func TestParseJWTToken_BothKeysFailReturnsWrappedError(t *testing.T) {
+	// Sign a token under a third secret that neither primary nor
+	// secondary can verify.
+	signer := newTestProvider(t)
+	signer.config.JWTSecret = "third-secret"
+	tok, err := signer.SignJWTToken(jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	verifier := newTestProvider(t)
+	verifier.config.JWTSecret = "primary-secret"
+	verifier.config.JWTSecondaryType = "HS256"
+	verifier.config.JWTSecondarySecret = "secondary-secret"
+
+	_, err = verifier.ParseJWTToken(tok)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, jwt.ErrTokenSignatureInvalid), "wrapped error should match jwt.ErrTokenSignatureInvalid via errors.Is")
+}
+
+func TestValidateJWTClaims_AudArray(t *testing.T) {
+	p := newTestProvider(t)
+	claims := jwt.MapClaims{
+		"aud":   []interface{}{"other", "test-client"},
+		"nonce": "n1",
+		"iss":   "https://example.com",
+		"sub":   "user-1",
+	}
+	ok, err := p.ValidateJWTClaims(claims, &AuthTokenConfig{
+		Nonce:    "n1",
+		HostName: "https://example.com",
+		User:     &schemas.User{ID: "user-1"},
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestValidateJWTClaims_AudMismatch(t *testing.T) {
+	p := newTestProvider(t)
+	claims := jwt.MapClaims{
+		"aud":   "other-client",
+		"nonce": "n1",
+		"iss":   "https://example.com",
+		"sub":   "user-1",
+	}
+	_, err := p.ValidateJWTClaims(claims, &AuthTokenConfig{
+		Nonce:    "n1",
+		HostName: "https://example.com",
+		User:     &schemas.User{ID: "user-1"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
+}
+
+func TestValidateJWTClaims_SubMustBeUserIDForOIDCTokens(t *testing.T) {
+	p := newTestProvider(t)
+	email := "alice@example.com"
+	// Access token: email-as-sub must be rejected (OIDC §2 hardening).
+	claims := jwt.MapClaims{
+		"aud":        "test-client",
+		"nonce":      "n1",
+		"iss":        "https://example.com",
+		"sub":        email,
+		"token_type": "access_token",
+	}
+	_, err := p.ValidateJWTClaims(claims, &AuthTokenConfig{
+		Nonce:    "n1",
+		HostName: "https://example.com",
+		User:     &schemas.User{ID: "user-1", Email: refs.NewStringRef(email)},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject")
+}
+
+func TestValidateJWTClaims_VerificationTokenAllowsEmailAsSub(t *testing.T) {
+	p := newTestProvider(t)
+	email := "alice@example.com"
+	// Verification tokens are issued before the user ID exists, so
+	// email-as-sub must still be accepted for those token_types.
+	claims := jwt.MapClaims{
+		"aud":        "test-client",
+		"nonce":      "n1",
+		"iss":        "https://example.com",
+		"sub":        email,
+		"token_type": "magic_link_login",
+	}
+	ok, err := p.ValidateJWTClaims(claims, &AuthTokenConfig{
+		Nonce:    "n1",
+		HostName: "https://example.com",
+		User:     &schemas.User{ID: "", Email: refs.NewStringRef(email)},
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Summary

Token-layer hardening on top of the phase 3 JWKS multi-key work. Addresses the OIDC review findings for token signing, verification, and claim validation.

## Findings fixed

| Severity | ID | File:line | Fix |
|---|---|---|---|
| Critical | C2 | `internal/token/jwt.go` SignJWTToken, parseJWTWithKidSelection | `kid` JOSE header now set to `ClientID` on signing; verifier selects primary/secondary by `kid` and falls back to try-both only for legacy kid-less tokens. |
| High | H1 / Logic #7 | `internal/token/jwt.go` parseJWTWithKidSelection (~L174-200) | Secondary-key fallback gated on `errors.Is(err, jwt.ErrTokenSignatureInvalid)`. Non-signature errors short-circuit. Errors wrapped with `%w` so callers can use `errors.Is` (Logic #13). Successful secondary verify logs `"token verified by secondary key"` at debug — no token contents logged. |
| Medium | M4 | `internal/token/audience.go`, `internal/token/jwt.go` ValidateJWTClaims / ValidateJWTTokenWithoutNonce | New `AudienceMatches` helper supports `string`, `[]string`, `[]interface{}`, and `jwt.ClaimStrings` (plus nil/empty). Replaces `!=` comparison for `aud`. |
| Medium | M5 | `internal/token/jwt.go` ValidateJWTClaims | `sub` now strictly equals `User.ID` for OIDC-visible tokens (access, refresh, ID). Email-as-sub retained only for the internal verification token types (signup, magic-link, forgot-password, invite, OTP) where no user ID exists yet. |
| Logic | #4 | `internal/token/jwt.go` ParseJWTToken (~L229-238) | `iat` is now optional per RFC 7519 §4.1.6 / OIDC Core for non-self-issued tokens; missing `iat` no longer errors. |
| Enhancement | ParseIDTokenHint | `internal/token/id_token_hint.go` (new) | Exposes `(*provider).ParseIDTokenHint` for OIDC Core §3.1.2.1 / RP-Initiated Logout §2 — verifies signature only, skips exp/nbf/iat validation, reuses kid-aware key selection. |
| Enhancement | AMR/ACR constants | `internal/constants/amr.go`, `internal/constants/acr.go` (new); `internal/token/auth_token.go` loginMethodToAMR / CreateIDToken | RFC 8176 `amr` values (`pwd`, `otp`, `fed`, `mfa`) and OIDC Core §2 baseline `acr` value (`"0"`) are now named constants. String literals replaced. |

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/token/...` — all new and existing unit tests pass.
- [x] `make test-sqlite` — all packages pass:
  - `internal/crypto`, `internal/http_handlers`, `internal/integration_tests`, `internal/memory_store`, `internal/memory_store/db`, `internal/metrics`, `internal/parsers`, `internal/storage`, `internal/token`, `internal/utils`, `internal/validators`.
- [x] Unit tests cover: AudienceMatches (4 shapes + nil/empty), kid header stamping, legacy kid-less fallback, direct secondary-kid selection, signature-only fallback (no retry on malformed), wrapped error propagation via `errors.Is`, optional iat, strict sub for OIDC tokens, email-as-sub allowed for verification tokens, ParseIDTokenHint accept-expired / reject-bad-sig / reject-malformed / empty / legacy fallback.

## Notes

- `ParseIDTokenHint` is a method on the concrete `*provider` but is not added to the `Provider` interface — `internal/token/provider.go` is out of scope for this PR. It will be wired into the interface alongside the `id_token_hint` callers in a follow-up.
- The M5 carve-out for verification tokens is necessary because signup / magic-link / forgot-password / invite / OTP tokens are issued before a stable user ID exists. The OIDC-§2 prohibition applies to ID-token `sub`; verification tokens are not OIDC ID tokens.