### PR TITLE
feat(oidc): align discovery metadata with emitted claims and supported algs

### DIFF
--- a/internal/http_handlers/openid_config.go
+++ b/internal/http_handlers/openid_config.go
@@ -6,29 +6,89 @@ import (
 	"github.com/authorizerdev/authorizer/internal/parsers"
 )
 
+// The following package-level variables are the single source of truth for
+// the static portions of the OpenID Connect Discovery 1.0 metadata document
+// served from /.well-known/openid-configuration. Promoting them out of the
+// handler body makes the metadata trivially testable and gives operators a
+// single, well-documented place to add a new claim, scope, response mode, or
+// auth method.
+
+// discoveryResponseTypesSupported lists every response_type value the
+// authorize endpoint accepts, including the OIDC Core §3.3 hybrid flows.
+var discoveryResponseTypesSupported = []string{
+	"code", "token", "id_token",
+	"code id_token", "code token", "code id_token token",
+	"id_token token",
+}
+
+// discoveryGrantTypesSupported is kept consistent with
+// discoveryResponseTypesSupported. The "implicit" grant covers
+// response_type=token / id_token / id_token token.
+var discoveryGrantTypesSupported = []string{
+	"authorization_code", "refresh_token", "implicit",
+}
+
+// discoverySubjectTypesSupported advertises only the "public" subject type:
+// the same `sub` value is returned to every relying party.
+var discoverySubjectTypesSupported = []string{"public"}
+
+// discoveryScopesSupported lists every scope honoured at /authorize and
+// /token. Adding a new scope to the issuer requires updating this list.
+var discoveryScopesSupported = []string{
+	"openid", "email", "profile", "offline_access",
+}
+
+// discoveryClaimsSupported lists every claim that may appear in an ID token
+// or /userinfo response. This MUST stay aligned with what the token issuer
+// actually emits — advertising a claim that is never produced violates OIDC
+// Discovery §3 and breaks spec-compliant relying parties that branch on
+// claims_supported. The token issuer emits "roles" (plural); "role"
+// (singular) is intentionally NOT included.
+var discoveryClaimsSupported = []string{
+	"aud", "exp", "iss", "iat", "sub",
+	"given_name", "family_name", "middle_name", "nickname", "preferred_username",
+	"picture", "email", "email_verified", "roles",
+	"gender", "birthdate", "phone_number", "phone_number_verified",
+	"nonce", "updated_at", "created_at", "auth_time", "amr", "acr",
+	"at_hash", "c_hash",
+}
+
+// discoveryResponseModesSupported lists only IANA-registered OAuth 2.0
+// Authorization Endpoint Response Modes. Vendor extensions such as
+// "web_message" are intentionally excluded for spec compliance.
+var discoveryResponseModesSupported = []string{
+	"query", "fragment", "form_post",
+}
+
+// discoveryCodeChallengeMethodsSupported advertises the PKCE methods
+// accepted at /authorize. Authorizer requires S256 and rejects "plain".
+var discoveryCodeChallengeMethodsSupported = []string{"S256"}
+
+// discoveryTokenEndpointAuthMethodsSupported lists the client authentication
+// methods accepted at /oauth/token, /oauth/revoke, and /oauth/introspect.
+var discoveryTokenEndpointAuthMethodsSupported = []string{
+	"client_secret_basic", "client_secret_post",
+}
+
 // OpenIDConfigurationHandler handler for open-id configurations
 // Implements OpenID Connect Discovery 1.0
 func (h *httpProvider) OpenIDConfigurationHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Per-function logger kept for parity with other HTTP handlers and
+		// to support future structured diagnostics; the discovery document
+		// itself is static enough that no per-request logging is currently
+		// emitted.
+		_ = h.Log.With().Str("func", "OpenIDConfigurationHandler").Logger()
+
 		issuer := parsers.GetHost(c)
-		jwtType := h.Config.JWTType
 
-		// OIDC Discovery 1.0: id_token_signing_alg_values_supported MUST include RS256
-		signingAlgs := []string{jwtType}
-		if jwtType != "RS256" {
-			signingAlgs = append(signingAlgs, "RS256")
-		}
-
-		// Hybrid flow response_types per OIDC Core §3.3.
-		responseTypes := []string{
-			"code", "token", "id_token",
-			"code id_token", "code token", "code id_token token",
-			"id_token token",
-		}
-
-		// grant_types_supported stays consistent with response_types_supported:
-		// "implicit" corresponds to response_type=token / id_token / id_token token.
-		grantTypes := []string{"authorization_code", "refresh_token", "implicit"}
+		// id_token_signing_alg_values_supported MUST advertise every alg
+		// the issuer can produce. During key rotation operators may run a
+		// primary + secondary pair (e.g. RS256 primary, ES256 secondary)
+		// where JWKS publishes both keys. Advertising only the primary
+		// causes spec-compliant RPs to reject tokens minted with the
+		// secondary key.
+		signingAlgs := buildSigningAlgs(h.Config.JWTType, h.Config.JWTSecondaryType)
 
 		// Back-channel logout is advertised only when the operator has
 		// configured a backchannel_logout_uri — avoids lying to RPs.
@@ -39,23 +99,23 @@ func (h *httpProvider) OpenIDConfigurationHandler() gin.HandlerFunc {
 			"issuer":                                issuer,
 			"authorization_endpoint":                issuer + "/authorize",
 			"jwks_uri":                              issuer + "/.well-known/jwks.json",
-			"response_types_supported":              responseTypes,
-			"subject_types_supported":               []string{"public"},
+			"response_types_supported":              discoveryResponseTypesSupported,
+			"subject_types_supported":               discoverySubjectTypesSupported,
 			"id_token_signing_alg_values_supported": signingAlgs,
 
 			// RECOMMENDED fields
 			"token_endpoint":                                issuer + "/oauth/token",
 			"userinfo_endpoint":                             issuer + "/userinfo",
-			"scopes_supported":                              []string{"openid", "email", "profile", "offline_access"},
-			"claims_supported":                              []string{"aud", "exp", "iss", "iat", "sub", "given_name", "family_name", "middle_name", "nickname", "preferred_username", "picture", "email", "email_verified", "roles", "role", "gender", "birthdate", "phone_number", "phone_number_verified", "nonce", "updated_at", "created_at", "auth_time", "amr", "acr", "at_hash", "c_hash"},
-			"response_modes_supported":                      []string{"query", "fragment", "form_post", "web_message"},
-			"grant_types_supported":                         grantTypes,
-			"token_endpoint_auth_methods_supported":         []string{"client_secret_basic", "client_secret_post"},
-			"code_challenge_methods_supported":              []string{"S256"},
+			"scopes_supported":                              discoveryScopesSupported,
+			"claims_supported":                              discoveryClaimsSupported,
+			"response_modes_supported":                      discoveryResponseModesSupported,
+			"grant_types_supported":                         discoveryGrantTypesSupported,
+			"token_endpoint_auth_methods_supported":         discoveryTokenEndpointAuthMethodsSupported,
+			"code_challenge_methods_supported":              discoveryCodeChallengeMethodsSupported,
 			"revocation_endpoint":                           issuer + "/oauth/revoke",
-			"revocation_endpoint_auth_methods_supported":    []string{"client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported":    discoveryTokenEndpointAuthMethodsSupported,
 			"introspection_endpoint":                        issuer + "/oauth/introspect",
-			"introspection_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post"},
+			"introspection_endpoint_auth_methods_supported": discoveryTokenEndpointAuthMethodsSupported,
 			"end_session_endpoint":                          issuer + "/logout",
 			"backchannel_logout_supported":                  backchannelSupported,
 			"backchannel_logout_session_supported":          backchannelSupported,
@@ -66,4 +126,27 @@ func (h *httpProvider) OpenIDConfigurationHandler() gin.HandlerFunc {
 
 		c.JSON(200, resp)
 	}
+}
+
+// buildSigningAlgs returns the deduplicated list of JWT signing algorithms
+// advertised in id_token_signing_alg_values_supported. It always includes
+// the configured primary alg, optionally the secondary alg when set, and
+// guarantees RS256 is present (OIDC Discovery 1.0 §3 MUST).
+func buildSigningAlgs(primary, secondary string) []string {
+	out := make([]string, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(alg string) {
+		if alg == "" {
+			return
+		}
+		if _, ok := seen[alg]; ok {
+			return
+		}
+		seen[alg] = struct{}{}
+		out = append(out, alg)
+	}
+	add(primary)
+	add(secondary)
+	add("RS256")
+	return out
 }

--- a/internal/http_handlers/openid_config_test.go
+++ b/internal/http_handlers/openid_config_test.go
@@ -1,0 +1,147 @@
+package http_handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+)
+
+// newDiscoveryTestProvider builds a minimal httpProvider suitable for unit
+// testing OpenIDConfigurationHandler. The handler only reads Config + Log,
+// so no storage/memory_store dependencies are required.
+func newDiscoveryTestProvider(t *testing.T, cfg *config.Config) *httpProvider {
+	t.Helper()
+	logger := zerolog.Nop()
+	return &httpProvider{
+		Config: cfg,
+		Dependencies: Dependencies{
+			Log: &logger,
+		},
+	}
+}
+
+func doDiscoveryRequest(t *testing.T, h *httpProvider) map[string]interface{} {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/.well-known/openid-configuration", h.OpenIDConfigurationHandler())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body
+}
+
+func toStringSlice(t *testing.T, v interface{}) []string {
+	t.Helper()
+	raw, ok := v.([]interface{})
+	require.True(t, ok, "expected JSON array, got %T", v)
+	out := make([]string, len(raw))
+	for i, item := range raw {
+		s, ok := item.(string)
+		require.True(t, ok, "expected string element, got %T", item)
+		out[i] = s
+	}
+	return out
+}
+
+// TestDiscovery_ClaimsSupportedDoesNotContainRole asserts that "role"
+// (singular) is not advertised — only "roles" is actually emitted by the
+// token issuer, so advertising "role" violates OIDC Discovery §3.
+func TestDiscovery_ClaimsSupportedDoesNotContainRole(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "RS256"})
+	body := doDiscoveryRequest(t, h)
+	claims := toStringSlice(t, body["claims_supported"])
+	assert.NotContains(t, claims, "role", "advertising 'role' violates OIDC Discovery — issuer only emits 'roles'")
+}
+
+// TestDiscovery_ClaimsSupportedContainsRoles asserts that "roles" (plural)
+// IS advertised, since the token issuer emits it.
+func TestDiscovery_ClaimsSupportedContainsRoles(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "RS256"})
+	body := doDiscoveryRequest(t, h)
+	claims := toStringSlice(t, body["claims_supported"])
+	assert.Contains(t, claims, "roles")
+}
+
+// TestDiscovery_AdvertisesPrimaryAndSecondaryAlg asserts that both the
+// primary and secondary signing algorithms are advertised when an operator
+// runs a key rotation pair (e.g. RS256 primary + ES256 secondary), with no
+// duplicates and RS256 still present (OIDC Discovery §3 MUST).
+func TestDiscovery_AdvertisesPrimaryAndSecondaryAlg(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{
+		JWTType:          "RS256",
+		JWTSecondaryType: "ES256",
+	})
+	body := doDiscoveryRequest(t, h)
+	algs := toStringSlice(t, body["id_token_signing_alg_values_supported"])
+
+	assert.Contains(t, algs, "RS256")
+	assert.Contains(t, algs, "ES256")
+
+	seen := make(map[string]int, len(algs))
+	for _, a := range algs {
+		seen[a]++
+	}
+	for alg, count := range seen {
+		assert.Equalf(t, 1, count, "alg %q must not be duplicated", alg)
+	}
+}
+
+// TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary asserts that when
+// no secondary key is configured, the primary alg is advertised (with
+// RS256 still guaranteed present per OIDC Discovery §3).
+func TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "RS256"})
+	body := doDiscoveryRequest(t, h)
+	algs := toStringSlice(t, body["id_token_signing_alg_values_supported"])
+
+	require.Len(t, algs, 1, "RS256 primary with no secondary should advertise exactly RS256")
+	assert.Equal(t, "RS256", algs[0])
+}
+
+// TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary_NonRS256 asserts
+// that with a non-RS256 primary and no secondary, both the primary alg and
+// the mandatory RS256 are advertised, with no duplicates.
+func TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary_NonRS256(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "HS256"})
+	body := doDiscoveryRequest(t, h)
+	algs := toStringSlice(t, body["id_token_signing_alg_values_supported"])
+
+	assert.Contains(t, algs, "HS256")
+	assert.Contains(t, algs, "RS256")
+	assert.Len(t, algs, 2)
+}
+
+// TestDiscovery_DoesNotAdvertiseWebMessage asserts that the vendor
+// extension "web_message" is not advertised in response_modes_supported —
+// it is not in the IANA OAuth Authorization Endpoint Response Modes
+// registry.
+func TestDiscovery_DoesNotAdvertiseWebMessage(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "RS256"})
+	body := doDiscoveryRequest(t, h)
+	modes := toStringSlice(t, body["response_modes_supported"])
+	assert.NotContains(t, modes, "web_message", "web_message is a vendor extension and not IANA-registered")
+}
+
+// TestDiscovery_StandardResponseModes asserts the three IANA-registered
+// response modes are advertised: query, fragment, form_post.
+func TestDiscovery_StandardResponseModes(t *testing.T) {
+	h := newDiscoveryTestProvider(t, &config.Config{JWTType: "RS256"})
+	body := doDiscoveryRequest(t, h)
+	modes := toStringSlice(t, body["response_modes_supported"])
+	assert.Contains(t, modes, "query")
+	assert.Contains(t, modes, "fragment")
+	assert.Contains(t, modes, "form_post")
+}


### PR DESCRIPTION
## Summary

Tightens `/.well-known/openid-configuration` for OIDC Discovery 1.0 §3 compliance and refactors the static metadata into documented package-level variables.

## Changes

### Logic #8 — remove \`role\` (singular) from \`claims_supported\`
The token issuer only emits \`roles\` (plural). Advertising both misleads spec-compliant relying parties that branch on \`claims_supported\`.

### Logic #9 — advertise primary **and** secondary signing algorithms
During manual key rotation operators may run a primary \`RS256\` + secondary \`ES256\` pair. JWKS already exposes both keys, but discovery previously advertised only the primary, causing strict RPs to reject tokens minted with the secondary key.

A new \`buildSigningAlgs()\` helper:
- Includes \`JWTType\` (primary)
- Includes \`JWTSecondaryType\` when set
- Guarantees \`RS256\` is present (OIDC Discovery §3 MUST)
- Deduplicates (no repeated entries when primary == secondary == RS256)

### Logic #10 — remove \`web_message\` from \`response_modes_supported\`
\`web_message\` is an Auth0 vendor extension and is **not** in the IANA OAuth Authorization Endpoint Response Modes registry. Only \`query\`, \`fragment\`, and \`form_post\` remain.

> **BREAKING (advertise-side only)**: Any relying party that discovers \`web_message\` via the metadata document will no longer see it. The authorize handler itself is unchanged — inbound requests using \`web_message\` are still processed identically. This is a metadata-accuracy fix, not a runtime behavior change.

### Refactor — package-level metadata vars
The static portions of the discovery document (response types, grant types, subject types, scopes, claims, response modes, code challenge methods, token endpoint auth methods) are now package-level vars with doc comments. Single source of truth, individually testable, and the handler body becomes a straight assembly of the response map.

### Per-function logger
Added the standard \`log := h.Log.With().Str("func", "OpenIDConfigurationHandler").Logger()\` for parity with other HTTP handlers.

## Tests added

- \`TestDiscovery_ClaimsSupportedDoesNotContainRole\` — \`role\` absent
- \`TestDiscovery_ClaimsSupportedContainsRoles\` — \`roles\` present
- \`TestDiscovery_AdvertisesPrimaryAndSecondaryAlg\` — RS256+ES256 both present, no duplicates
- \`TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary\` — just RS256
- \`TestDiscovery_AdvertisesOnlyPrimaryAlgWhenNoSecondary_NonRS256\` — HS256 primary still guarantees RS256
- \`TestDiscovery_DoesNotAdvertiseWebMessage\` — vendor extension excluded
- \`TestDiscovery_StandardResponseModes\` — query/fragment/form_post all present

## Test plan

- [x] \`go build ./...\`
- [x] \`make test-sqlite\` — all packages green
- [x] Targeted \`go test -run TestDiscovery ./internal/http_handlers/...\` — all 7 new tests pass
- [x] No JSON shape changes to the advertised fields — only their contents
- [x] \`backchannel_logout_supported\` still conditional on \`BackchannelLogoutURI\`