### PR TITLE
feat(oidc): harden JWKS handler logging and error responses

### DIFF
--- a/internal/http_handlers/jwks.go
+++ b/internal/http_handlers/jwks.go
@@ -2,6 +2,7 @@ package http_handlers
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 
@@ -39,22 +40,32 @@ func (h *httpProvider) generateJWKBasedOnEnv() (string, error) {
 }
 
 func (h *httpProvider) JWKsHandler() gin.HandlerFunc {
-	log := h.Log.With().Str("func", "JWKsHandler").Logger()
 	return func(c *gin.Context) {
+		log := h.Log.With().Str("func", "JWKsHandler").Logger()
 		var keys []map[string]string
 
 		// Primary key.
 		primaryJWK, err := generateJWKFromKey(h.JWTType, h.JWTPublicKey, "", h.ClientID)
 		if err != nil {
-			log.Debug().Err(err).Msg("Error generating primary JWK")
-			c.JSON(500, gin.H{"error": err.Error()})
+			// Server-side fault: full failure to publish the JWK set.
+			// Log at Error so production operators (with debug filtered
+			// out) can see this. Return a generic OAuth2-style error to
+			// avoid leaking parser internals to clients.
+			log.Error().Err(err).Msg("failed to generate primary JWK")
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":             "server_error",
+				"error_description": "failed to publish JWK set",
+			})
 			return
 		}
 		if primaryJWK != "" {
 			var data map[string]string
 			if err := json.Unmarshal([]byte(primaryJWK), &data); err != nil {
-				log.Debug().Err(err).Msg("Error unmarshalling primary JWK")
-				c.JSON(500, gin.H{"error": err.Error()})
+				log.Error().Err(err).Msg("failed to unmarshal primary JWK")
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error":             "server_error",
+					"error_description": "failed to publish JWK set",
+				})
 				return
 			}
 			keys = append(keys, data)
@@ -62,17 +73,18 @@ func (h *httpProvider) JWKsHandler() gin.HandlerFunc {
 
 		// Secondary key (optional). Only published when both algorithm
 		// and public key are configured. HMAC secondary keys are
-		// silently dropped by generateJWKFromKey.
+		// silently dropped by generateJWKFromKey. Failures here are
+		// degraded service (primary still served), so log at Warn.
 		if h.JWTSecondaryType != "" && h.JWTSecondaryPublicKey != "" {
 			// Append "-secondary" to the kid to guarantee uniqueness even
 			// when primary and secondary use the same algorithm + client ID.
 			secondaryJWK, err := generateJWKFromKey(h.JWTSecondaryType, h.JWTSecondaryPublicKey, "-secondary", h.ClientID)
 			if err != nil {
-				log.Debug().Err(err).Msg("Error generating secondary JWK - ignoring secondary")
+				log.Warn().Err(err).Msg("failed to generate secondary JWK - ignoring secondary")
 			} else if secondaryJWK != "" {
 				var data map[string]string
 				if err := json.Unmarshal([]byte(secondaryJWK), &data); err != nil {
-					log.Debug().Err(err).Msg("Error unmarshalling secondary JWK - ignoring secondary")
+					log.Warn().Err(err).Msg("failed to unmarshal secondary JWK - ignoring secondary")
 				} else {
 					keys = append(keys, data)
 				}
@@ -83,6 +95,6 @@ func (h *httpProvider) JWKsHandler() gin.HandlerFunc {
 			// Ensure JSON emits [] not null.
 			keys = []map[string]string{}
 		}
-		c.JSON(200, gin.H{"keys": keys})
+		c.JSON(http.StatusOK, gin.H{"keys": keys})
 	}
 }

--- a/internal/http_handlers/jwks_test.go
+++ b/internal/http_handlers/jwks_test.go
@@ -1,0 +1,130 @@
+package http_handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+)
+
+// newJWKsTestProvider builds a minimal httpProvider suitable for unit
+// testing JWKsHandler. It does not require any storage/memory_store
+// dependencies because the handler only reads JWT config + logger.
+func newJWKsTestProvider(t *testing.T, cfg *config.Config) *httpProvider {
+	t.Helper()
+	logger := zerolog.Nop()
+	return &httpProvider{
+		Config: cfg,
+		Dependencies: Dependencies{
+			Log: &logger,
+		},
+	}
+}
+
+func doJWKsRequest(t *testing.T, h *httpProvider) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/.well-known/jwks.json", h.JWKsHandler())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// TestJWKsHandler_Success_ContentType verifies a happy-path RSA primary
+// key is published as a valid JWK set with HTTP 200 + JSON content type.
+func TestJWKsHandler_Success_ContentType(t *testing.T) {
+	clientID := "test-client"
+	_, _, publicKey, _, err := crypto.NewRSAKey("RS256", clientID)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		ClientID:     clientID,
+		JWTType:      "RS256",
+		JWTPublicKey: publicKey,
+	}
+	h := newJWKsTestProvider(t, cfg)
+
+	w := doJWKsRequest(t, h)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	keys, ok := body["keys"].([]interface{})
+	require.True(t, ok, "response MUST contain a keys array")
+	require.Len(t, keys, 1, "exactly one primary key MUST be published")
+
+	jwk, ok := keys[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "RSA", jwk["kty"])
+	assert.NotEmpty(t, jwk["kid"])
+	assert.NotEmpty(t, jwk["n"])
+	assert.NotEmpty(t, jwk["e"])
+}
+
+// TestJWKsHandler_PrimaryKeyError_GenericResponse verifies that when
+// primary key generation fails, the response body contains the generic
+// OAuth2 server_error code and does NOT leak the underlying parser error.
+func TestJWKsHandler_PrimaryKeyError_GenericResponse(t *testing.T) {
+	cfg := &config.Config{
+		ClientID:     "test-client",
+		JWTType:      "RS256",
+		JWTPublicKey: "this-is-not-a-valid-pem-block",
+	}
+	h := newJWKsTestProvider(t, cfg)
+
+	w := doJWKsRequest(t, h)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "server_error", body["error"])
+	assert.Equal(t, "failed to publish JWK set", body["error_description"])
+
+	// MUST NOT leak the raw parser error message back to clients.
+	rawBody := w.Body.String()
+	assert.NotContains(t, strings.ToLower(rawBody), "pem")
+	assert.NotContains(t, strings.ToLower(rawBody), "parse")
+}
+
+// TestJWKsHandler_SecondaryKeyError_StillReturnsPrimary verifies that a
+// broken secondary key configuration is treated as degraded service:
+// the primary key is still served and the response is HTTP 200.
+func TestJWKsHandler_SecondaryKeyError_StillReturnsPrimary(t *testing.T) {
+	clientID := "test-client"
+	_, _, publicKey, _, err := crypto.NewRSAKey("RS256", clientID)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		ClientID:              clientID,
+		JWTType:               "RS256",
+		JWTPublicKey:          publicKey,
+		JWTSecondaryType:      "RS256",
+		JWTSecondaryPublicKey: "this-is-not-a-valid-pem-block",
+	}
+	h := newJWKsTestProvider(t, cfg)
+
+	w := doJWKsRequest(t, h)
+	require.Equal(t, http.StatusOK, w.Code, "broken secondary MUST NOT take down JWKS")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	keys, ok := body["keys"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, keys, 1, "only the primary key MUST be published when secondary fails")
+
+	jwk, ok := keys[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "RSA", jwk["kty"])
+}


### PR DESCRIPTION
## Summary

Hardens `internal/http_handlers/jwks.go` so that server-side faults are visible in production log pipelines and clients receive a standards-compliant OAuth2 error shape that does not leak parser internals.

The published JWK set payload shape is unchanged — only error paths and log levels differ. Clients depending on `/.well-known/jwks.json` are unaffected.

## Findings addressed

- **Log level for 5xx**: primary-key generation and primary-JWK unmarshal failures (both 500-producing) were logged at `Debug`, which is filtered out in production. Bumped to `Error`. Secondary-key failures are degraded service (primary is still served) and are now logged at `Warn` instead of `Debug`.
- **Magic HTTP status codes**: replaced bare integers (`500`, `200`) with `http.StatusInternalServerError` / `http.StatusOK`.
- **Error response shape**: previously returned `gin.H{"error": err.Error()}` which leaked raw PEM/x509 parser errors and did not match the OAuth2 error JSON shape. Replaced with `{"error":"server_error","error_description":"failed to publish JWK set"}`. The underlying cause is still logged server-side.
- **Per-request logger**: moved `log := h.Log.With().Str("func","JWKsHandler").Logger()` inside the request closure so each log entry is tied to an actual request, matching the pattern used by other handlers in this package.

## New tests (`internal/http_handlers/jwks_test.go`)

Three unit tests that drive `JWKsHandler` directly (no storage/memory_store dependency):

- `TestJWKsHandler_Success_ContentType` — happy path RSA primary key returns 200 with `application/json` and a valid JWK containing `kty`, `kid`, `n`, `e`.
- `TestJWKsHandler_PrimaryKeyError_GenericResponse` — when primary key PEM parsing fails, response is 500 with generic `server_error`, and the body does NOT contain the raw parser error (`pem`/`parse`).
- `TestJWKsHandler_SecondaryKeyError_StillReturnsPrimary` — a broken secondary key configuration MUST NOT take down JWKS; primary key is still served and the response is 200.

## Test plan

- [x] `go build ./...`
- [x] `go test -run TestJWKsHandler -v ./internal/http_handlers/` — 3/3 pass
- [x] `make test-sqlite` — all packages green, including `internal/http_handlers` and `internal/integration_tests`
- [x] No out-of-scope file changes (only `jwks.go` + `jwks_test.go`)
- [x] JWK set payload shape unchanged (`{"keys":[...]}` with identical JWK fields)