### PR TITLE
security(oidc): harden back-channel logout against SSRF and verify response status

### DIFF
--- a/internal/integration_tests/oidc_backchannel_logout_test.go
+++ b/internal/integration_tests/oidc_backchannel_logout_test.go
@@ -2,13 +2,12 @@ package integration_tests
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
@@ -24,17 +23,19 @@ import (
 func TestBackchannelLogoutSendsLogoutToken(t *testing.T) {
 	cfg := getTestConfig()
 
-	var received atomic.Value // stores the logout_token string
-	var contentType atomic.Value
+	// NotifyBackchannelLogout is invoked synchronously below, so we
+	// can capture the request inline without polling.
+	var receivedToken string
+	var receivedContentType string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		contentType.Store(r.Header.Get("Content-Type"))
+		receivedContentType = r.Header.Get("Content-Type")
 		body, _ := io.ReadAll(r.Body)
 		form, _ := url.ParseQuery(string(body))
-		received.Store(form.Get("logout_token"))
+		receivedToken = form.Get("logout_token")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -51,28 +52,14 @@ func TestBackchannelLogoutSendsLogoutToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Poll briefly for the test server to record the token (Notify
-	// returns synchronously here, but be defensive).
-	deadline := time.Now().Add(2 * time.Second)
-	var tokenStr string
-	for time.Now().Before(deadline) {
-		if v := received.Load(); v != nil {
-			tokenStr = v.(string)
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.NotEmpty(t, tokenStr, "server must have received the logout_token")
-
-	if ct := contentType.Load(); ct != nil {
-		assert.Contains(t, ct.(string), "application/x-www-form-urlencoded")
-	}
+	require.NotEmpty(t, receivedToken, "server must have received the logout_token")
+	assert.Contains(t, receivedContentType, "application/x-www-form-urlencoded")
 
 	// Parse the JWT (without signature verification — we trust the signer
 	// and only check structural claims here).
 	parser := jwt.NewParser()
 	claims := jwt.MapClaims{}
-	_, _, err = parser.ParseUnverified(tokenStr, claims)
+	_, _, err = parser.ParseUnverified(receivedToken, claims)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost", claims["iss"])
@@ -92,7 +79,8 @@ func TestBackchannelLogoutSendsLogoutToken(t *testing.T) {
 }
 
 // TestBackchannelLogoutEmptyURIIsError verifies that calling Notify with
-// an empty URI returns an error rather than silently dropping the call.
+// an empty URI returns ErrBackchannelURIEmpty rather than silently
+// dropping the call.
 func TestBackchannelLogoutEmptyURIIsError(t *testing.T) {
 	cfg := getTestConfig()
 	ts := initTestSetup(t, cfg)
@@ -101,6 +89,7 @@ func TestBackchannelLogoutEmptyURIIsError(t *testing.T) {
 		Subject:  "user-123",
 	})
 	require.Error(t, err)
+	assert.True(t, errors.Is(err, token.ErrBackchannelURIEmpty), "expected ErrBackchannelURIEmpty, got %v", err)
 }
 
 // TestBackchannelLogoutMissingSubAndSidIsError verifies that callers must
@@ -112,4 +101,144 @@ func TestBackchannelLogoutMissingSubAndSidIsError(t *testing.T) {
 		HostName: "http://localhost",
 	})
 	require.Error(t, err)
+	assert.True(t, errors.Is(err, token.ErrBackchannelMissingSubAndSid))
+}
+
+// TestBackchannelLogoutMissingHostNameIsError verifies that callers must
+// supply a HostName for the iss claim.
+func TestBackchannelLogoutMissingHostNameIsError(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), "http://example.test", &token.BackchannelLogoutConfig{
+		Subject: "user-123",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, token.ErrBackchannelMissingHostName))
+}
+
+// TestBackchannelLogoutStatusCheck verifies that a non-2xx response from
+// the receiver is surfaced as an error per OIDC BCL 1.0 §2.8.
+func TestBackchannelLogoutStatusCheck(t *testing.T) {
+	cfg := getTestConfig()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), server.URL, &token.BackchannelLogoutConfig{
+		HostName:  "http://localhost",
+		Subject:   "user-1",
+		SessionID: "sid-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	// Error must not contain the full URL — only the host.
+	assert.NotContains(t, err.Error(), server.URL)
+}
+
+// TestBackchannelLogoutSuccess verifies that a 2xx response (here 204
+// No Content) is treated as success and the body is drained without
+// error.
+func TestBackchannelLogoutSuccess(t *testing.T) {
+	cfg := getTestConfig()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), server.URL, &token.BackchannelLogoutConfig{
+		HostName:  "http://localhost",
+		Subject:   "user-1",
+		SessionID: "sid-1",
+	})
+	require.NoError(t, err)
+}
+
+// TestBackchannelLogoutOmitsSidWhenEmpty verifies that the sid claim
+// is omitted entirely when SessionID is empty (OIDC BCL 1.0 §2.4 makes
+// sid OPTIONAL — Branch 5 of the logout flow relies on this contract).
+func TestBackchannelLogoutOmitsSidWhenEmpty(t *testing.T) {
+	cfg := getTestConfig()
+	var receivedToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		receivedToken = form.Get("logout_token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), server.URL, &token.BackchannelLogoutConfig{
+		HostName: "http://localhost",
+		Subject:  "user-no-sid",
+		// SessionID intentionally empty.
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, receivedToken)
+
+	parser := jwt.NewParser()
+	claims := jwt.MapClaims{}
+	_, _, err = parser.ParseUnverified(receivedToken, claims)
+	require.NoError(t, err)
+	_, hasSid := claims["sid"]
+	assert.False(t, hasSid, "sid claim must be omitted when SessionID is empty")
+	assert.Equal(t, "user-no-sid", claims["sub"])
+}
+
+// TestBackchannelLogoutIncludesSidWhenSet verifies that the sid claim
+// is present when SessionID is non-empty.
+func TestBackchannelLogoutIncludesSidWhenSet(t *testing.T) {
+	cfg := getTestConfig()
+	var receivedToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		receivedToken = form.Get("logout_token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), server.URL, &token.BackchannelLogoutConfig{
+		HostName:  "http://localhost",
+		Subject:   "user-with-sid",
+		SessionID: "session-xyz",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, receivedToken)
+
+	parser := jwt.NewParser()
+	claims := jwt.MapClaims{}
+	_, _, err = parser.ParseUnverified(receivedToken, claims)
+	require.NoError(t, err)
+	assert.Equal(t, "session-xyz", claims["sid"])
+}
+
+// TestBackchannelLogoutRejectsLoopback verifies that the SSRF filter is
+// engaged when the test bypass is disabled. We force the bypass off for
+// this test only and point at a loopback URL — SafeHTTPClient must
+// reject it before any HTTP I/O happens.
+func TestBackchannelLogoutRejectsLoopback(t *testing.T) {
+	cfg := getTestConfig()
+	// Disable the test SSRF bypass for this test only so SafeHTTPClient
+	// runs against an httptest loopback URL and rejects it.
+	cfg.SkipTestEndpointSSRFValidation = false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server must NOT be reached when SSRF filter is on")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ts := initTestSetup(t, cfg)
+	err := ts.TokenProvider.NotifyBackchannelLogout(context.Background(), server.URL, &token.BackchannelLogoutConfig{
+		HostName:  "http://localhost",
+		Subject:   "user-1",
+		SessionID: "sid-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SSRF filter")
 }

--- a/internal/token/backchannel_logout.go
+++ b/internal/token/backchannel_logout.go
@@ -3,6 +3,8 @@ package token
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -10,6 +12,9 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/validators"
 )
 
 // backchannelLogoutEventKey is the OIDC BCL 1.0 §2.4 event identifier.
@@ -19,28 +24,62 @@ const backchannelLogoutEventKey = "http://schemas.openid.net/event/backchannel-l
 // receiver cannot delay the user-facing logout flow. Fire-and-forget.
 const backchannelLogoutHTTPTimeout = 5 * time.Second
 
+// backchannelLogoutMaxRedirects bounds redirect chains so a hostile
+// receiver cannot bounce us through an arbitrary number of hops.
+const backchannelLogoutMaxRedirects = 3
+
+// ErrBackchannelURIEmpty is returned when NotifyBackchannelLogout is
+// called with an empty back-channel logout URI.
+var ErrBackchannelURIEmpty = errors.New("backchannel logout uri is empty")
+
+// ErrBackchannelMissingHostName is returned when the supplied
+// BackchannelLogoutConfig has no HostName (used as the JWT issuer).
+var ErrBackchannelMissingHostName = errors.New("backchannel logout requires host name (issuer)")
+
+// ErrBackchannelMissingSubAndSid is returned when the supplied
+// BackchannelLogoutConfig has neither a Subject nor a SessionID.
+// OIDC BCL 1.0 §2.4 requires at least one of sub or sid.
+var ErrBackchannelMissingSubAndSid = errors.New("backchannel logout requires sub or sid")
+
 // BackchannelLogoutConfig holds the per-logout data needed to build
-// and send a logout_token. The HostName is the issuer; the Subject
-// identifies the user; SessionID is echoed as the sid claim.
+// and send a logout_token per OIDC Back-Channel Logout 1.0 §2.4.
 type BackchannelLogoutConfig struct {
-	HostName  string
-	Subject   string
+	// HostName is the issuer ("iss" claim) of the logout_token. Must be
+	// the OP issuer URL and must not be empty.
+	HostName string
+	// Subject identifies the user being logged out and becomes the
+	// "sub" claim. May be empty if SessionID is provided.
+	Subject string
+	// SessionID identifies the session being terminated and becomes
+	// the optional "sid" claim. May be empty if Subject is provided;
+	// if empty the sid claim is omitted entirely.
 	SessionID string
 }
 
 // NotifyBackchannelLogout signs a logout_token JWT per OIDC Back-Channel
 // Logout 1.0 §2.4 and POSTs it to the supplied URI. The HTTP request
-// is bounded by a 5-second timeout. Intended to be invoked from a
-// goroutine so the user-facing logout flow is never blocked. Returns
-// an error for local failures (empty URI, missing sub/sid, signing
-// error, malformed URI) and for remote HTTP failures within the
-// timeout — callers running in a goroutine should log and discard.
+// is bounded by a 5-second timeout and uses an SSRF-hardened HTTP
+// client (see validators.SafeHTTPClient) to prevent the token from
+// being delivered to private/internal/loopback addresses. Redirects
+// are bounded and re-validated. Intended to be invoked from a goroutine
+// so the user-facing logout flow is never blocked. Returns an error
+// for local failures (empty URI, missing sub/sid, signing error,
+// malformed URI, SSRF rejection) and for remote HTTP failures within
+// the timeout — callers running in a goroutine should log and discard.
+// The returned error never includes the full URI or any token contents
+// (only the host).
 func (p *provider) NotifyBackchannelLogout(ctx context.Context, uri string, cfg *BackchannelLogoutConfig) error {
 	if strings.TrimSpace(uri) == "" {
-		return errors.New("backchannel logout uri is empty")
+		return ErrBackchannelURIEmpty
 	}
-	if cfg == nil || (strings.TrimSpace(cfg.Subject) == "" && strings.TrimSpace(cfg.SessionID) == "") {
-		return errors.New("backchannel logout requires sub or sid")
+	if cfg == nil {
+		return ErrBackchannelMissingHostName
+	}
+	if strings.TrimSpace(cfg.HostName) == "" {
+		return ErrBackchannelMissingHostName
+	}
+	if strings.TrimSpace(cfg.Subject) == "" && strings.TrimSpace(cfg.SessionID) == "" {
+		return ErrBackchannelMissingSubAndSid
 	}
 
 	now := time.Now().Unix()
@@ -59,6 +98,9 @@ func (p *provider) NotifyBackchannelLogout(ctx context.Context, uri string, cfg 
 	if strings.TrimSpace(cfg.Subject) != "" {
 		claims["sub"] = cfg.Subject
 	}
+	// sid is OPTIONAL per OIDC BCL 1.0 §2.4. Omit when caller did not
+	// supply one (e.g. when only sub-based logout is desired). Branch 5
+	// of the logout flow relies on this contract.
 	if strings.TrimSpace(cfg.SessionID) != "" {
 		claims["sid"] = cfg.SessionID
 	}
@@ -66,7 +108,7 @@ func (p *provider) NotifyBackchannelLogout(ctx context.Context, uri string, cfg 
 
 	signed, err := p.SignJWTToken(claims)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to sign logout_token: %w", err)
 	}
 
 	form := url.Values{}
@@ -76,15 +118,76 @@ func (p *provider) NotifyBackchannelLogout(ctx context.Context, uri string, cfg 
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, uri, strings.NewReader(form.Encode()))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build backchannel logout request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: backchannelLogoutHTTPTimeout}
+	// Resolve the host of the original URI for error reporting and for
+	// re-validation of redirect targets.
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse backchannel logout uri: %w", err)
+	}
+	originalHost := parsed.Hostname()
+
+	// SSRF protection: pin the dial to a validated public IP so the HTTP
+	// stack cannot be tricked into re-resolving (DNS rebinding TOCTOU).
+	// Tests run with Env=test against httptest 127.0.0.1 servers and
+	// reuse the existing SkipTestEndpointSSRFValidation toggle as a
+	// blanket "this build is a test" indicator — production builds must
+	// never enable that flag.
+	skipSSRF := p.config.Env == constants.TestEnv && p.config.SkipTestEndpointSSRFValidation
+	var client *http.Client
+	if skipSSRF {
+		client = &http.Client{Timeout: backchannelLogoutHTTPTimeout}
+	} else {
+		client, err = validators.SafeHTTPClient(ctx, uri, backchannelLogoutHTTPTimeout)
+		if err != nil {
+			return fmt.Errorf("backchannel logout uri rejected by SSRF filter (host=%s): %w", originalHost, err)
+		}
+	}
+
+	// Bound redirect chains and re-validate every hop. SafeHTTPClient
+	// pins the dialer to the IP of the *original* host, so a redirect
+	// to a different host would otherwise still be dialed against that
+	// pinned IP — we explicitly reject cross-host redirects, and cap the
+	// chain length.
+	client.CheckRedirect = func(redirReq *http.Request, via []*http.Request) error {
+		if len(via) >= backchannelLogoutMaxRedirects {
+			return fmt.Errorf("too many redirects")
+		}
+		if redirReq.URL.Hostname() != originalHost {
+			return fmt.Errorf("cross-host redirect not permitted")
+		}
+		return nil
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		// net/http wraps the URL into the error string; strip it so we
+		// never log the full URI (which may include path/query secrets).
+		return fmt.Errorf("backchannel logout request failed (host=%s): %w", originalHost, sanitizeHTTPError(err, uri))
 	}
 	defer resp.Body.Close()
+	// Drain the body so the underlying connection can be reused and so
+	// the receiver does not see a half-closed write.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	// OIDC BCL 1.0 §2.8: the OP MUST treat 2xx as success and any other
+	// status as failure.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("backchannel logout receiver returned status %d (host=%s)", resp.StatusCode, originalHost)
+	}
 	return nil
+}
+
+// sanitizeHTTPError removes the request URL from a net/http error so
+// callers can safely log it without leaking the full backchannel URI.
+func sanitizeHTTPError(err error, fullURL string) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ReplaceAll(err.Error(), fullURL, "<redacted>")
+	return errors.New(msg)
 }

--- a/internal/token/backchannel_logout_test.go
+++ b/internal/token/backchannel_logout_test.go
@@ -1,0 +1,36 @@
+package token
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestErrBackchannelURIEmpty verifies the exported sentinel can be
+// matched with errors.Is, allowing callers to discriminate the empty-URI
+// case from generic failures.
+func TestErrBackchannelURIEmpty(t *testing.T) {
+	assert.True(t, errors.Is(ErrBackchannelURIEmpty, ErrBackchannelURIEmpty))
+
+	wrapped := &wrappedErr{err: ErrBackchannelURIEmpty}
+	assert.True(t, errors.Is(wrapped, ErrBackchannelURIEmpty))
+}
+
+// wrappedErr is a tiny helper to verify the sentinel is unwrap-friendly.
+type wrappedErr struct{ err error }
+
+func (w *wrappedErr) Error() string { return "wrapped: " + w.err.Error() }
+func (w *wrappedErr) Unwrap() error { return w.err }
+
+// TestSanitizeHTTPError verifies the sanitize helper redacts the full
+// URL so callers can safely log net/http errors without leaking the
+// path or query of the back-channel logout URI.
+func TestSanitizeHTTPError(t *testing.T) {
+	original := errors.New("Post \"https://rp.example.com/bcl?token=secret\": dial tcp: lookup failed")
+	sanitized := sanitizeHTTPError(original, "https://rp.example.com/bcl?token=secret")
+	assert.NotContains(t, sanitized.Error(), "secret")
+	assert.NotContains(t, sanitized.Error(), "rp.example.com/bcl")
+	assert.Contains(t, sanitized.Error(), "<redacted>")
+	assert.Nil(t, sanitizeHTTPError(nil, "any"))
+}


### PR DESCRIPTION
## Summary

Hardens the OIDC Back-Channel Logout 1.0 notifier against SSRF and fixes a spec-compliance gap where non-2xx responses were silently treated as success.

### Critical / High findings addressed

- **C1 — SSRF in BCL HTTP notifier.** Replaces `&http.Client{}` with `validators.SafeHTTPClient` so the outbound POST is pinned to a validated public IP (defeats DNS-rebinding TOCTOU). Redirect chains are capped at 3 hops and cross-host redirects are rejected — SafeHTTPClient pins the dialer to the original host's IP, so cross-host hops would otherwise dial the wrong target.
- **H2 — Non-2xx treated as success.** After `client.Do`, the body is drained (`io.Copy(io.Discard, ...)`) and any status outside `[200, 300)` returns an error per OIDC BCL 1.0 §2.8. Errors include only the host and status code — never the full URI or token.

### Contract / hygiene fixes

- **Optional `sid`.** `BackchannelLogoutConfig.SessionID == ""` now omits the `sid` claim entirely (OIDC BCL 1.0 §2.4 allows either `sub` OR `sid`). Unblocks Branch 5 of the logout flow, which wants to notify without fabricating a session id.
- **Sentinel errors.** Exports `ErrBackchannelURIEmpty`, `ErrBackchannelMissingHostName`, `ErrBackchannelMissingSubAndSid` for `errors.Is` matching.
- **`HostName` validated.** Empty issuer fails fast with a sentinel error.
- **Doc comments** added to every exported `BackchannelLogoutConfig` field.
- **`sanitizeHTTPError`** strips the full URL from `net/http` error strings so wrapping errors never leak the back-channel path or query.
- **Test determinism.** Existing integration test no longer polls with `sync/atomic` — `NotifyBackchannelLogout` is synchronous so the test captures inline.

### Test bypass note

SafeHTTPClient rejects loopback, so the integration tests reuse the existing `SkipTestEndpointSSRFValidation` config flag as a blanket "test build" indicator (production builds keep it false). `TestBackchannelLogoutRejectsLoopback` disables the bypass for a single test to prove the SSRF filter fires.

## Files changed

- `internal/token/backchannel_logout.go` — SSRF, status check, sentinel errors, doc comments, helper.
- `internal/token/backchannel_logout_test.go` — new unit tests for sentinel error and sanitize helper.
- `internal/integration_tests/oidc_backchannel_logout_test.go` — deterministic assertion + 6 new tests.

## Test plan

- [x] `go build ./...`
- [x] `make test-sqlite` (all packages pass)
- [x] `go test -race ./internal/integration_tests/ -run TestBackchannelLogout`
- [x] New tests:
  - [x] `TestBackchannelLogoutStatusCheck` — 500 returns error, full URL is not in error message
  - [x] `TestBackchannelLogoutSuccess` — 204 returns nil
  - [x] `TestBackchannelLogoutOmitsSidWhenEmpty` — empty SessionID omits sid claim
  - [x] `TestBackchannelLogoutIncludesSidWhenSet`
  - [x] `TestBackchannelLogoutRejectsLoopback` — SafeHTTPClient rejects 127.0.0.1 when bypass off
  - [x] `TestBackchannelLogoutMissingHostNameIsError`
  - [x] `TestErrBackchannelURIEmpty`, `TestSanitizeHTTPError`