### PR TITLE
fix: trigger scorecard on default branch events, not releases

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,17 @@
 
 name: Scorecard supply-chain security
 
+# Scorecard only supports the repository's default branch. Release/tag events
+# check out a tag ref and fail with "only default branch is supported", so we
+# trigger on the OSSF-recommended events instead: pushes to the default branch,
+# a weekly schedule, and branch-protection-rule changes.
 on:
-  release:
-    types: [created]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, Mondays at 07:20 UTC.
+    - cron: '20 7 * * 1'
+  branch_protection_rule:
 
 # Top-level read-all permissions; jobs override what they need.
 permissions: read-all


### PR DESCRIPTION
## Problem

The Scorecard supply-chain workflow runs `on: release: [created]`. The OSSF Scorecard action **only supports the repository's default branch** — a release event checks out the tag ref (e.g. `2.3.0-rc.1`), so the action aborts:

```
refs/tags/2.3.0-rc.1 not supported with release event.
Only the default branch main is supported.
creating scorecard entrypoint: validating options: only default branch is supported
```

This means the scorecard job fails on **every** RC/release. See run: https://github.com/authorizerdev/authorizer/actions/runs/26877785127/job/79269599505

## Fix

Replace the `release` trigger with the OSSF-recommended events:

- `push` to `main` — re-score on every merge to the default branch
- `schedule` — weekly cron (Mon 07:20 UTC) so the published score stays fresh
- `branch_protection_rule` — re-score when branch protection changes (a scored check)

No change to permissions, publishing, or the action version.