### PR TITLE
ci: publish proto schema to the Buf Schema Registry

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,49 @@
+---
+name: Buf
+
+# Proto schema CI for the `proto/` module (buf.build/authorizerdev/authorizer):
+# lint + breaking-change detection on PRs, publish to the BSR on push to main.
+on:
+  pull_request:
+    paths:
+      - "proto/**"
+      - ".github/workflows/buf.yml"
+  push:
+    branches: [main]
+    paths:
+      - "proto/**"
+      - ".github/workflows/buf.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  buf:
+    name: Lint, breaking & push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint
+        run: buf lint proto
+
+      # Compare the proposed schema against the published module so a PR that
+      # would break wire/source compatibility fails before it lands.
+      - name: Breaking-change check
+        run: buf breaking proto --against buf.build/authorizerdev/authorizer
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+
+      # Publish only from main. buf de-dupes identical schemas, so commits that
+      # don't touch protos are no-ops.
+      - name: Push to BSR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: buf push proto
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, ci/buf-push]
+    branches: [main]
   release:
     types: [created]
 
@@ -43,20 +43,3 @@ jobs:
       # freshly built binary (see internal/e2e/smoke_test.go).
       - name: Run smoke tests
         run: make smoke
-
-  buf-push:
-    name: Publish proto to BSR
-    runs-on: ubuntu-latest
-    # Only publish on real pushes (main), never on PRs.
-    if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: buf push
-        env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: buf push proto --create --create-visibility public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, ci/buf-push]
   release:
     types: [created]
 
@@ -43,3 +43,20 @@ jobs:
       # freshly built binary (see internal/e2e/smoke_test.go).
       - name: Run smoke tests
         run: make smoke
+
+  buf-push:
+    name: Publish proto to BSR
+    runs-on: ubuntu-latest
+    # Only publish on real pushes (main), never on PRs.
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: buf push
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: buf push proto --create --create-visibility public


### PR DESCRIPTION
Adds a dedicated `Buf` workflow for the `proto/` module
(`buf.build/authorizerdev/authorizer`):

- **PRs** touching `proto/**`: `buf lint` + `buf breaking` (against the published module).
- **Push to `main`**: `buf push` publishes the schema to the BSR.

Kept out of the Go test/smoke pipeline (`ci.yml`) so proto concerns stay isolated.
`buf` de-dupes identical schemas, so non-proto commits are no-ops. Uses the existing
`BUF_TOKEN` secret. The module is already published (verified), so consumers can codegen via
`module: buf.build/authorizerdev/authorizer`.