### PR TITLE
fix(storage): clear legacy unique email/phone objects name-agnostically (< 2.3.0 upgrades)

### DIFF
--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -98,11 +98,21 @@ func NewProvider(
 		{&schemas.OTP{}, "authorizer_otps", "phone_number"},
 	}
 
-	// 1) Drop stale unique CONSTRAINTs by their well-known names.
-	//    "<table>_<col>_key" is the Postgres/MySQL default; "uni_<table>_<col>" is
-	//    GORM's default unique-constraint name.
+	// 1) Drop stale unique CONSTRAINTs by their well-known names. A unique
+	//    constraint's backing index can't be removed with DROP INDEX, so it has
+	//    to go via DROP CONSTRAINT — and GORM's GetIndexes does not surface
+	//    constraint-backed indexes, so step 2 below would miss these. The three
+	//    names cover every form seen in the field:
+	//      "<table>_<col>_key"   Postgres/MySQL default for a gorm:"unique" tag
+	//      "uni_<table>_<col>"   GORM's default unique-constraint name
+	//      "idx_<table>_<col>"   a v1 gorm:"uniqueIndex" that the DB promoted to
+	//                            a UNIQUE constraint of the same name
 	for _, c := range staleUniqueColumns {
-		for _, name := range []string{c.table + "_" + c.col + "_key", "uni_" + c.table + "_" + c.col} {
+		for _, name := range []string{
+			c.table + "_" + c.col + "_key",
+			"uni_" + c.table + "_" + c.col,
+			"idx_" + c.table + "_" + c.col,
+		} {
 			if sqlDB.Migrator().HasConstraint(c.model, name) {
 				if dropErr := sqlDB.Migrator().DropConstraint(c.model, name); dropErr != nil {
 					deps.Log.Debug().Err(dropErr).Str("constraint", name).Msg("failed to drop stale unique constraint")
@@ -111,11 +121,15 @@ func NewProvider(
 		}
 	}
 
-	// 2) Drop stale standalone UNIQUE INDEXes on the same columns (e.g.
-	//    idx_authorizer_otps_phone_number created by a v1 gorm:"uniqueIndex").
-	//    This is name-agnostic: only single-column UNIQUE indexes on email /
-	//    phone_number are removed, so the current schema's non-unique indexes are
-	//    left intact and AutoMigrate recreates anything it needs as non-unique.
+	// 2) Drop any remaining stale UNIQUE index on the same columns, name-agnostic.
+	//    Only single-column UNIQUE indexes on email / phone_number are removed,
+	//    so the current schema's non-unique indexes are left intact and
+	//    AutoMigrate recreates anything it needs as non-unique. The discovered
+	//    object may be either a standalone unique index (a v1 gorm:"uniqueIndex"
+	//    stored as `CREATE UNIQUE INDEX idx_<table>_<col>`) or a UNIQUE
+	//    constraint whose backing index shares that name — the latter cannot be
+	//    dropped with DROP INDEX ("constraint ... requires it"), so it must go
+	//    via DROP CONSTRAINT. Pick the right one.
 	uniqueColTargets := map[string]bool{"email": true, "phone_number": true}
 	for _, model := range []any{&schemas.User{}, &schemas.OTP{}} {
 		indexes, idxErr := sqlDB.Migrator().GetIndexes(model)
@@ -132,10 +146,13 @@ func NewProvider(
 			if len(cols) != 1 || !uniqueColTargets[cols[0]] {
 				continue
 			}
-			if dropErr := sqlDB.Migrator().DropIndex(model, idx.Name()); dropErr != nil {
-				// Constraint-backed indexes (handled in step 1) can't be dropped
-				// directly on Postgres — that's expected and harmless here.
-				deps.Log.Debug().Err(dropErr).Str("index", idx.Name()).Msg("failed to drop stale unique index")
+			name := idx.Name()
+			if sqlDB.Migrator().HasConstraint(model, name) {
+				if dropErr := sqlDB.Migrator().DropConstraint(model, name); dropErr != nil {
+					deps.Log.Debug().Err(dropErr).Str("constraint", name).Msg("failed to drop stale unique constraint")
+				}
+			} else if dropErr := sqlDB.Migrator().DropIndex(model, name); dropErr != nil {
+				deps.Log.Debug().Err(dropErr).Str("index", name).Msg("failed to drop stale unique index")
 			}
 		}
 	}

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -74,88 +74,21 @@ func NewProvider(
 		return nil, err
 	}
 
-	// v1 declared the email and phone_number columns of authorizer_users and
-	// authorizer_otps as UNIQUE. v2 keeps plain (non-unique) indexes and enforces
-	// uniqueness in the application layer (see AddUser/UpdateUser) so behaviour is
-	// identical across all supported databases and these fields can stay optional
-	// (email-only or phone-only signups).
+	// Older Authorizer releases (< 2.3.0) declared the email and phone_number
+	// columns of authorizer_users and authorizer_otps as UNIQUE. v2 keeps plain
+	// (non-unique) indexes and enforces uniqueness in the application layer (see
+	// AddUser/UpdateUser), so behaviour is identical across all supported
+	// databases and these fields can stay optional (email-only / phone-only
+	// signups).
 	//
-	// On an upgraded SQL database those columns are still unique, so GORM
-	// AutoMigrate tries to DROP CONSTRAINT "uni_<table>_<col>" — a name that does
-	// not match what the database actually created — failing with SQLSTATE 42704
-	// ("constraint does not exist") and aborting the whole migration. Depending on
-	// the v1 release, the old uniqueness exists either as a CONSTRAINT
-	// (<table>_<col>_key) or as a standalone UNIQUE INDEX (idx_<table>_<col>), so
-	// we clear both forms before AutoMigrate. Non-fatal: fresh installs have
-	// nothing to drop.
-	staleUniqueColumns := []struct {
-		model      any
-		table, col string
-	}{
-		{&schemas.User{}, "authorizer_users", "email"},
-		{&schemas.User{}, "authorizer_users", "phone_number"},
-		{&schemas.OTP{}, "authorizer_otps", "email"},
-		{&schemas.OTP{}, "authorizer_otps", "phone_number"},
-	}
-
-	// 1) Drop stale unique CONSTRAINTs by their well-known names. A unique
-	//    constraint's backing index can't be removed with DROP INDEX, so it has
-	//    to go via DROP CONSTRAINT — and GORM's GetIndexes does not surface
-	//    constraint-backed indexes, so step 2 below would miss these. The three
-	//    names cover every form seen in the field:
-	//      "<table>_<col>_key"   Postgres/MySQL default for a gorm:"unique" tag
-	//      "uni_<table>_<col>"   GORM's default unique-constraint name
-	//      "idx_<table>_<col>"   a v1 gorm:"uniqueIndex" that the DB promoted to
-	//                            a UNIQUE constraint of the same name
-	for _, c := range staleUniqueColumns {
-		for _, name := range []string{
-			c.table + "_" + c.col + "_key",
-			"uni_" + c.table + "_" + c.col,
-			"idx_" + c.table + "_" + c.col,
-		} {
-			if sqlDB.Migrator().HasConstraint(c.model, name) {
-				if dropErr := sqlDB.Migrator().DropConstraint(c.model, name); dropErr != nil {
-					deps.Log.Debug().Err(dropErr).Str("constraint", name).Msg("failed to drop stale unique constraint")
-				}
-			}
-		}
-	}
-
-	// 2) Drop any remaining stale UNIQUE index on the same columns, name-agnostic.
-	//    Only single-column UNIQUE indexes on email / phone_number are removed,
-	//    so the current schema's non-unique indexes are left intact and
-	//    AutoMigrate recreates anything it needs as non-unique. The discovered
-	//    object may be either a standalone unique index (a v1 gorm:"uniqueIndex"
-	//    stored as `CREATE UNIQUE INDEX idx_<table>_<col>`) or a UNIQUE
-	//    constraint whose backing index shares that name — the latter cannot be
-	//    dropped with DROP INDEX ("constraint ... requires it"), so it must go
-	//    via DROP CONSTRAINT. Pick the right one.
-	uniqueColTargets := map[string]bool{"email": true, "phone_number": true}
-	for _, model := range []any{&schemas.User{}, &schemas.OTP{}} {
-		indexes, idxErr := sqlDB.Migrator().GetIndexes(model)
-		if idxErr != nil {
-			deps.Log.Debug().Err(idxErr).Msg("failed to list indexes while clearing stale unique indexes")
-			continue
-		}
-		for _, idx := range indexes {
-			unique, ok := idx.Unique()
-			if !ok || !unique {
-				continue
-			}
-			cols := idx.Columns()
-			if len(cols) != 1 || !uniqueColTargets[cols[0]] {
-				continue
-			}
-			name := idx.Name()
-			if sqlDB.Migrator().HasConstraint(model, name) {
-				if dropErr := sqlDB.Migrator().DropConstraint(model, name); dropErr != nil {
-					deps.Log.Debug().Err(dropErr).Str("constraint", name).Msg("failed to drop stale unique constraint")
-				}
-			} else if dropErr := sqlDB.Migrator().DropIndex(model, name); dropErr != nil {
-				deps.Log.Debug().Err(dropErr).Str("index", name).Msg("failed to drop stale unique index")
-			}
-		}
-	}
+	// On an upgraded SQL database those columns are still unique, so GORM 1.25.x
+	// AutoMigrate reconciles them by issuing DROP CONSTRAINT "uni_<table>_<col>"
+	// — a fixed name (NamingStrategy.UniqueName) that rarely matches what the old
+	// DB actually created (authorizer_users_email_key, idx_authorizer_otps_phone_number,
+	// or any custom name) — failing with "constraint does not exist" (Postgres
+	// SQLSTATE 42704) and aborting startup. Clear the legacy uniqueness up front,
+	// name-agnostically, before AutoMigrate runs.
+	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
 	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{})
 	if err != nil {
@@ -205,4 +138,81 @@ func (p *provider) Close() error {
 		return err
 	}
 	return sqlDB.Close()
+}
+
+// clearLegacyColumnUniqueness removes any single-column UNIQUE constraint or
+// index on the email / phone_number columns of authorizer_users and
+// authorizer_otps, regardless of its name. See the call site in NewProvider for
+// why this must run before AutoMigrate. Best-effort and non-fatal: fresh
+// installs, and catalogs without information_schema (sqlite), simply find
+// nothing to drop.
+func clearLegacyColumnUniqueness(db *gorm.DB, log *zerolog.Logger) {
+	targets := map[string]bool{"email": true, "phone_number": true}
+	tables := []struct {
+		model any
+		name  string
+	}{
+		{&schemas.User{}, "authorizer_users"},
+		{&schemas.OTP{}, "authorizer_otps"},
+	}
+
+	for _, t := range tables {
+		// 1) Drop single-column UNIQUE *constraints* by their real names, read
+		//    from the same catalog GORM uses (information_schema). This matches
+		//    ANY name — ..._key, uni_..., idx_..., or custom — which is what
+		//    actually prevents the DROP CONSTRAINT "uni_..." 42704 abort. A
+		//    constraint's backing index cannot be removed with DROP INDEX, so it
+		//    must go via DropConstraint.
+		var rows []struct {
+			ConstraintName string `gorm:"column:constraint_name"`
+			ColumnName     string `gorm:"column:column_name"`
+		}
+		const q = `SELECT tc.constraint_name AS constraint_name, kcu.column_name AS column_name
+			FROM information_schema.table_constraints tc
+			JOIN information_schema.key_column_usage kcu
+			  ON tc.constraint_name = kcu.constraint_name
+			 AND tc.table_schema = kcu.table_schema
+			 AND tc.table_name = kcu.table_name
+			WHERE tc.constraint_type = 'UNIQUE' AND tc.table_name = ?`
+		if err := db.Raw(q, t.name).Scan(&rows).Error; err != nil {
+			// sqlite and other catalogs without information_schema land here; they
+			// are not affected by the GORM unique-reconciliation behaviour.
+			log.Debug().Err(err).Str("table", t.name).Msg("skip legacy unique-constraint scan")
+		} else {
+			columnsByConstraint := map[string][]string{}
+			for _, r := range rows {
+				columnsByConstraint[r.ConstraintName] = append(columnsByConstraint[r.ConstraintName], r.ColumnName)
+			}
+			for name, cols := range columnsByConstraint {
+				if len(cols) == 1 && targets[cols[0]] {
+					if err := db.Migrator().DropConstraint(t.model, name); err != nil {
+						log.Debug().Err(err).Str("constraint", name).Msg("failed to drop legacy unique constraint")
+					}
+				}
+			}
+		}
+
+		// 2) Drop any standalone single-column UNIQUE *index* (CREATE UNIQUE
+		//    INDEX, not a constraint) on the same columns. These do not cause the
+		//    abort — GORM reads column-uniqueness from table_constraints only —
+		//    but removing them makes the column genuinely non-unique, matching the
+		//    v2 application-layer model. GetIndexes already excludes
+		//    constraint-backed indexes, so this only sees the standalone form;
+		//    AutoMigrate then recreates the plain non-unique search index.
+		indexes, err := db.Migrator().GetIndexes(t.model)
+		if err != nil {
+			log.Debug().Err(err).Str("table", t.name).Msg("skip legacy unique-index scan")
+			continue
+		}
+		for _, idx := range indexes {
+			if unique, ok := idx.Unique(); !ok || !unique {
+				continue
+			}
+			if cols := idx.Columns(); len(cols) == 1 && targets[cols[0]] {
+				if err := db.Migrator().DropIndex(t.model, idx.Name()); err != nil {
+					log.Debug().Err(err).Str("index", idx.Name()).Msg("failed to drop legacy unique index")
+				}
+			}
+		}
+	}
 }

--- a/internal/storage/db/sql/provider_migration_test.go
+++ b/internal/storage/db/sql/provider_migration_test.go
@@ -187,16 +187,29 @@ func TestStaleUniqueConstraintMigration(t *testing.T) {
 			p1, err := NewProvider(cfg, deps)
 			require.NoError(t, err)
 
-			// Simulate a v1 database: a UNIQUE CONSTRAINT on users.email and a
-			// standalone UNIQUE INDEX on otps.phone_number — the two real-world
-			// forms reported in the field. Idempotent so reruns against the shared
-			// test DB don't fail on pre-existing objects.
-			require.NoError(t, p1.db.Exec(`ALTER TABLE authorizer_users DROP CONSTRAINT IF EXISTS authorizer_users_email_key`).Error)
-			require.NoError(t, p1.db.Exec(`ALTER TABLE authorizer_users ADD CONSTRAINT authorizer_users_email_key UNIQUE (email)`).Error)
-			require.NoError(t, p1.db.Exec(`DROP INDEX IF EXISTS idx_authorizer_otps_phone_number`).Error)
-			require.NoError(t, p1.db.Exec(`CREATE UNIQUE INDEX idx_authorizer_otps_phone_number ON authorizer_otps (phone_number)`).Error)
+			// Simulate a v1 database, covering all three real-world stale forms:
+			//   - users.email:        UNIQUE CONSTRAINT "authorizer_users_email_key"
+			//                         (Postgres default for a gorm:"unique" tag)
+			//   - otps.phone_number:  UNIQUE CONSTRAINT "idx_authorizer_otps_phone_number"
+			//                         (idx_-named constraint; its backing index can NOT
+			//                         be dropped with DROP INDEX — field-reported case)
+			//   - otps.email:         standalone UNIQUE INDEX "idx_authorizer_otps_email"
+			// Idempotent so reruns against the shared test DB don't clash.
+			for _, stmt := range []string{
+				`ALTER TABLE authorizer_users DROP CONSTRAINT IF EXISTS authorizer_users_email_key`,
+				`ALTER TABLE authorizer_users ADD CONSTRAINT authorizer_users_email_key UNIQUE (email)`,
+				`ALTER TABLE authorizer_otps DROP CONSTRAINT IF EXISTS idx_authorizer_otps_phone_number`,
+				`DROP INDEX IF EXISTS idx_authorizer_otps_phone_number`,
+				`ALTER TABLE authorizer_otps ADD CONSTRAINT idx_authorizer_otps_phone_number UNIQUE (phone_number)`,
+				`DROP INDEX IF EXISTS idx_authorizer_otps_email`,
+				`CREATE UNIQUE INDEX idx_authorizer_otps_email ON authorizer_otps (email)`,
+			} {
+				require.NoError(t, p1.db.Exec(stmt).Error, stmt)
+			}
 			require.True(t, p1.db.Migrator().HasConstraint(&schemas.User{}, "authorizer_users_email_key"),
 				"precondition: stale unique constraint seeded")
+			require.True(t, p1.db.Migrator().HasConstraint(&schemas.OTP{}, "idx_authorizer_otps_phone_number"),
+				"precondition: idx_-named unique constraint seeded")
 
 			// Second boot must clear the stale uniqueness and complete migration.
 			p2, err := NewProvider(cfg, deps)
@@ -204,6 +217,8 @@ func TestStaleUniqueConstraintMigration(t *testing.T) {
 
 			assert.False(t, p2.db.Migrator().HasConstraint(&schemas.User{}, "authorizer_users_email_key"),
 				"stale unique constraint should be dropped")
+			assert.False(t, p2.db.Migrator().HasConstraint(&schemas.OTP{}, "idx_authorizer_otps_phone_number"),
+				"stale idx_-named unique constraint should be dropped")
 
 			// The search index is preserved, just no longer unique: AutoMigrate
 			// recreates idx_authorizer_otps_phone_number as a non-unique index.

--- a/internal/storage/db/sql/provider_migration_test.go
+++ b/internal/storage/db/sql/provider_migration_test.go
@@ -187,17 +187,23 @@ func TestStaleUniqueConstraintMigration(t *testing.T) {
 			p1, err := NewProvider(cfg, deps)
 			require.NoError(t, err)
 
-			// Simulate a v1 database, covering all three real-world stale forms:
-			//   - users.email:        UNIQUE CONSTRAINT "authorizer_users_email_key"
-			//                         (Postgres default for a gorm:"unique" tag)
-			//   - otps.phone_number:  UNIQUE CONSTRAINT "idx_authorizer_otps_phone_number"
-			//                         (idx_-named constraint; its backing index can NOT
-			//                         be dropped with DROP INDEX — field-reported case)
-			//   - otps.email:         standalone UNIQUE INDEX "idx_authorizer_otps_email"
+			// Simulate a v1 database, covering every real-world stale form so the
+			// name-agnostic cleanup is exercised end-to-end:
+			//   - users.email:         UNIQUE CONSTRAINT "authorizer_users_email_key"
+			//                          (Postgres default for a gorm:"unique" tag)
+			//   - users.phone_number:  UNIQUE CONSTRAINT "my_legacy_phone_uq"
+			//                          (arbitrary/custom name — only a catalog-driven
+			//                          drop, not name enumeration, can catch this)
+			//   - otps.phone_number:   UNIQUE CONSTRAINT "idx_authorizer_otps_phone_number"
+			//                          (idx_-named constraint; backing index can NOT
+			//                          be dropped with DROP INDEX — field-reported case)
+			//   - otps.email:          standalone UNIQUE INDEX "idx_authorizer_otps_email"
 			// Idempotent so reruns against the shared test DB don't clash.
 			for _, stmt := range []string{
 				`ALTER TABLE authorizer_users DROP CONSTRAINT IF EXISTS authorizer_users_email_key`,
 				`ALTER TABLE authorizer_users ADD CONSTRAINT authorizer_users_email_key UNIQUE (email)`,
+				`ALTER TABLE authorizer_users DROP CONSTRAINT IF EXISTS my_legacy_phone_uq`,
+				`ALTER TABLE authorizer_users ADD CONSTRAINT my_legacy_phone_uq UNIQUE (phone_number)`,
 				`ALTER TABLE authorizer_otps DROP CONSTRAINT IF EXISTS idx_authorizer_otps_phone_number`,
 				`DROP INDEX IF EXISTS idx_authorizer_otps_phone_number`,
 				`ALTER TABLE authorizer_otps ADD CONSTRAINT idx_authorizer_otps_phone_number UNIQUE (phone_number)`,
@@ -208,6 +214,8 @@ func TestStaleUniqueConstraintMigration(t *testing.T) {
 			}
 			require.True(t, p1.db.Migrator().HasConstraint(&schemas.User{}, "authorizer_users_email_key"),
 				"precondition: stale unique constraint seeded")
+			require.True(t, p1.db.Migrator().HasConstraint(&schemas.User{}, "my_legacy_phone_uq"),
+				"precondition: custom-named unique constraint seeded")
 			require.True(t, p1.db.Migrator().HasConstraint(&schemas.OTP{}, "idx_authorizer_otps_phone_number"),
 				"precondition: idx_-named unique constraint seeded")
 
@@ -217,6 +225,8 @@ func TestStaleUniqueConstraintMigration(t *testing.T) {
 
 			assert.False(t, p2.db.Migrator().HasConstraint(&schemas.User{}, "authorizer_users_email_key"),
 				"stale unique constraint should be dropped")
+			assert.False(t, p2.db.Migrator().HasConstraint(&schemas.User{}, "my_legacy_phone_uq"),
+				"custom-named unique constraint should be dropped")
 			assert.False(t, p2.db.Migrator().HasConstraint(&schemas.OTP{}, "idx_authorizer_otps_phone_number"),
 				"stale idx_-named unique constraint should be dropped")
 


### PR DESCRIPTION
Follow-up to #628, hardened so **no** Authorizer `< 2.3.0` upgrader hits the startup failure, regardless of how their unique constraint was named.

## Background

GORM 1.25.x `AutoMigrate` (`migrator.MigrateColumnUnique`) reconciles a column that is UNIQUE in the DB but non-unique in the model by issuing `DROP CONSTRAINT "uni_<table>_<col>"` — a **fixed** name from `NamingStrategy.UniqueName`. Older Authorizer DBs created the unique objects under different names, so the drop fails with `constraint ... does not exist` (Postgres SQLSTATE 42704) and the whole migration aborts (`failed to create storage provider`). This regression came from the GORM `v1.25.5 -> v1.25.10` bump in 2.3.0-rc.1; the schema itself was unchanged.

#628 enumerated three name conventions (`*_key`, `uni_*`, `idx_*`). Verified on Postgres that a **custom-named** constraint still aborts under that approach — name enumeration fixes instances, not the class.

## Change

Replace the name guessing with a **catalog-driven** sweep before `AutoMigrate`:

1. Read the actual single-column UNIQUE constraint names on `authorizer_users` / `authorizer_otps` `email` & `phone_number` from `information_schema.table_constraints` — the same source GORM reads to decide a column is unique — and `DROP CONSTRAINT` each by its real name. Matches any name (`_key`, `uni_`, `idx_`, custom).
2. Drop any standalone single-column UNIQUE **index** on those columns (does not cause the abort, but makes the column genuinely non-unique per the v2 app-layer model).

Non-fatal/best-effort. sqlite (no `information_schema`; unaffected by the bug) and fresh installs are no-ops.

## Verified on real Postgres

`TestStaleUniqueConstraintMigration` seeds all four forms together and asserts startup succeeds + each object is gone:
- `authorizer_users_email_key` (`_key` constraint)
- `my_legacy_phone_uq` (**custom-named** constraint — the case #628 missed)
- `idx_authorizer_otps_phone_number` (`idx_`-named constraint, backing index undroppable via DROP INDEX)
- `idx_authorizer_otps_email` (standalone unique index)

## Test plan
- [x] `go vet`
- [x] `TEST_DBS=postgres go test ./internal/storage/db/sql/ -run 'TestStaleUniqueConstraintMigration|TestProviderEmailPhoneUpdatesAndUniqueness'` — PASS
- [x] `TEST_DBS=sqlite` — PASS
