### PR TITLE
fix(storage): silence GORM logger in legacy-uniqueness cleanup (fixes smoke mcp_stdio)

### DIFF
--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 	"gorm.io/gorm/schema"
 
 	"github.com/authorizerdev/authorizer/internal/config"
@@ -147,6 +148,13 @@ func (p *provider) Close() error {
 // installs, and catalogs without information_schema (sqlite), simply find
 // nothing to drop.
 func clearLegacyColumnUniqueness(db *gorm.DB, log *zerolog.Logger) {
+	// Run through a discarding GORM logger. The information_schema probe below
+	// intentionally errors on databases without that catalog (sqlite); GORM's
+	// default logger writes such errors to os.Stdout, which corrupts the MCP
+	// server's stdio JSON-RPC stream. We already surface anything actionable via
+	// the zerolog `log` (stderr), so GORM's own logging here is redundant.
+	db = db.Session(&gorm.Session{Logger: logger.Discard})
+
 	targets := map[string]bool{"email": true, "phone_number": true}
 	tables := []struct {
 		model any


### PR DESCRIPTION
## Problem

`make smoke` fails on `main` at `TestReleaseSmoke/mcp_stdio` with `unexpected end of JSON input`.

## Cause

#629's `clearLegacyColumnUniqueness` probes `information_schema.table_constraints` to find legacy unique constraints. On sqlite that catalog does not exist, so the query errors (`no such table: information_schema.table_constraints`). The SQL provider sets **no GORM logger**, so GORM uses `logger.Default`, which writes query errors to **`os.Stdout`** (at Warn level; see `gorm/logger/logger.go`). The MCP server speaks JSON-RPC over **stdio**, so that stray stdout line corrupts the stream and the client reads a non-JSON line → `unexpected end of JSON input`.

Only the smoke test hits it because it's the one path that combines **sqlite** (erroring probe) with the **MCP stdio** transport. (App/MCP zerolog goes to stderr and is unaffected.)

## Fix

Run the cleanup through a discarding GORM logger:

```go
db = db.Session(&gorm.Session{Logger: logger.Discard})
```

The probe's expected errors are already surfaced via the zerolog logger (stderr); GORM's stdout logging of them is redundant and unsafe for the stdio server. No change to the migration behaviour.

## Verified

- `make smoke` → **PASS** (was FAIL on `main`); reproduced the failure on clean `main` first, then confirmed the fix.
- `TEST_DBS=sqlite go test ./internal/storage/db/sql/ -run 'TestProviderEmailPhoneUpdatesAndUniqueness|TestStaleUniqueConstraintMigration'` → PASS
- `go vet` clean

## Note

The deeper latent issue is that the SQL provider's GORM logger writes to stdout at all, which is hazardous for the stdio MCP server — any future query error/slow-query log during MCP startup would corrupt it. Worth routing the provider's GORM logger to stderr (or the app logger) separately; out of scope here.
