### PR TITLE
build(docker): expose gRPC port 9091

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,10 @@ USER authorizer
 #   127.0.0.1, so other containers cannot scrape until you pass --metrics-host=0.0.0.0.
 #   Even then: do not map 8081 to the public internet; keep scraping on internal networks
 #   only (Docker internal network, Kubernetes ClusterIP / pod network).
-EXPOSE 8080 8081
+# - 9091: gRPC API (AuthorizerService + AuthorizerAdminService). Binds to --host
+#   (0.0.0.0 by default), so it is reachable once published with -p 9091:9091. Served
+#   as plaintext h2c — terminate TLS at an ingress/proxy before exposing it publicly.
+EXPOSE 8080 8081 9091
 
 # Liveness uses the main HTTP server only (metrics may be loopback-only).
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- http://127.0.0.1:8080/healthz || exit 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,5 +4,6 @@ services:
     build: .
     ports:
       - 8080:8080
+      - 9091:9091
     env_file:
       - .env


### PR DESCRIPTION
## Why

The gRPC server binds to `--host:9091` (default `0.0.0.0:9091`) and serves both `AuthorizerService` and `AuthorizerAdminService`. But the image only `EXPOSE`d `8080`/`8081` and `docker-compose.yaml` only published `8080`, so external gRPC clients could not reach it without manually mapping the port.

## Changes

- **Dockerfile**: `EXPOSE 8080 8081 9091` with a comment noting it binds to `--host`, is reachable via `-p 9091:9091`, and is served as plaintext h2c (terminate TLS at an ingress/proxy before public exposure).
- **docker-compose.yaml**: publish `9091:9091`.

## Notes

- `EXPOSE` is documentation-only; the compose mapping is what actually publishes the port.
- For container-to-container calls on the same Docker network, no host publishing is needed — dial the service name (e.g. `authorizer:9091`).
- Docs updated in a companion authorizer-docs PR (deployment/docker, core/grpc, core/rest-api).