### PR TITLE
feat(m2m): service layer + admin GraphQL API for ServiceAccount + TrustedIssuer [Phase 1 — PR 3/5]

### DIFF
--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -90,6 +90,11 @@ type ComplexityRoot struct {
 		Results func(childComplexity int) int
 	}
 
+	CreateServiceAccountResponse struct {
+		ClientSecret   func(childComplexity int) int
+		ServiceAccount func(childComplexity int) int
+	}
+
 	EmailTemplate struct {
 		CreatedAt func(childComplexity int) int
 		Design    func(childComplexity int) int
@@ -254,42 +259,49 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddEmailTemplate    func(childComplexity int, params model.AddEmailTemplateRequest) int
-		AddWebhook          func(childComplexity int, params model.AddWebhookRequest) int
-		AdminLogin          func(childComplexity int, params model.AdminLoginRequest) int
-		AdminLogout         func(childComplexity int) int
-		AdminSignup         func(childComplexity int, params model.AdminSignupRequest) int
-		DeactivateAccount   func(childComplexity int) int
-		DeleteEmailTemplate func(childComplexity int, params model.DeleteEmailTemplateRequest) int
-		DeleteUser          func(childComplexity int, params model.DeleteUserRequest) int
-		DeleteWebhook       func(childComplexity int, params model.WebhookRequest) int
-		EnableAccess        func(childComplexity int, param model.UpdateAccessRequest) int
-		FgaDeleteTuples     func(childComplexity int, params model.FgaWriteTuplesInput) int
-		FgaReset            func(childComplexity int) int
-		FgaWriteModel       func(childComplexity int, params model.FgaWriteModelInput) int
-		FgaWriteTuples      func(childComplexity int, params model.FgaWriteTuplesInput) int
-		ForgotPassword      func(childComplexity int, params model.ForgotPasswordRequest) int
-		GenerateJwtKeys     func(childComplexity int, params model.GenerateJWTKeysRequest) int
-		InviteMembers       func(childComplexity int, params model.InviteMemberRequest) int
-		Login               func(childComplexity int, params model.LoginRequest) int
-		Logout              func(childComplexity int) int
-		MagicLinkLogin      func(childComplexity int, params model.MagicLinkLoginRequest) int
-		MobileLogin         func(childComplexity int, params model.MobileLoginRequest) int
-		MobileSignup        func(childComplexity int, params *model.MobileSignUpRequest) int
-		ResendOtp           func(childComplexity int, params model.ResendOTPRequest) int
-		ResendVerifyEmail   func(childComplexity int, params model.ResendVerifyEmailRequest) int
-		ResetPassword       func(childComplexity int, params model.ResetPasswordRequest) int
-		Revoke              func(childComplexity int, params model.OAuthRevokeRequest) int
-		RevokeAccess        func(childComplexity int, param model.UpdateAccessRequest) int
-		Signup              func(childComplexity int, params model.SignUpRequest) int
-		TestEndpoint        func(childComplexity int, params model.TestEndpointRequest) int
-		UpdateEmailTemplate func(childComplexity int, params model.UpdateEmailTemplateRequest) int
-		UpdateEnv           func(childComplexity int, params model.UpdateEnvRequest) int
-		UpdateProfile       func(childComplexity int, params model.UpdateProfileRequest) int
-		UpdateUser          func(childComplexity int, params model.UpdateUserRequest) int
-		UpdateWebhook       func(childComplexity int, params model.UpdateWebhookRequest) int
-		VerifyEmail         func(childComplexity int, params model.VerifyEmailRequest) int
-		VerifyOtp           func(childComplexity int, params model.VerifyOTPRequest) int
+		AddEmailTemplate           func(childComplexity int, params model.AddEmailTemplateRequest) int
+		AddTrustedIssuer           func(childComplexity int, params model.AddTrustedIssuerRequest) int
+		AddWebhook                 func(childComplexity int, params model.AddWebhookRequest) int
+		AdminLogin                 func(childComplexity int, params model.AdminLoginRequest) int
+		AdminLogout                func(childComplexity int) int
+		AdminSignup                func(childComplexity int, params model.AdminSignupRequest) int
+		CreateServiceAccount       func(childComplexity int, params model.CreateServiceAccountRequest) int
+		DeactivateAccount          func(childComplexity int) int
+		DeleteEmailTemplate        func(childComplexity int, params model.DeleteEmailTemplateRequest) int
+		DeleteServiceAccount       func(childComplexity int, params model.ServiceAccountRequest) int
+		DeleteTrustedIssuer        func(childComplexity int, params model.TrustedIssuerRequest) int
+		DeleteUser                 func(childComplexity int, params model.DeleteUserRequest) int
+		DeleteWebhook              func(childComplexity int, params model.WebhookRequest) int
+		EnableAccess               func(childComplexity int, param model.UpdateAccessRequest) int
+		FgaDeleteTuples            func(childComplexity int, params model.FgaWriteTuplesInput) int
+		FgaReset                   func(childComplexity int) int
+		FgaWriteModel              func(childComplexity int, params model.FgaWriteModelInput) int
+		FgaWriteTuples             func(childComplexity int, params model.FgaWriteTuplesInput) int
+		ForgotPassword             func(childComplexity int, params model.ForgotPasswordRequest) int
+		GenerateJwtKeys            func(childComplexity int, params model.GenerateJWTKeysRequest) int
+		InviteMembers              func(childComplexity int, params model.InviteMemberRequest) int
+		Login                      func(childComplexity int, params model.LoginRequest) int
+		Logout                     func(childComplexity int) int
+		MagicLinkLogin             func(childComplexity int, params model.MagicLinkLoginRequest) int
+		MobileLogin                func(childComplexity int, params model.MobileLoginRequest) int
+		MobileSignup               func(childComplexity int, params *model.MobileSignUpRequest) int
+		ResendOtp                  func(childComplexity int, params model.ResendOTPRequest) int
+		ResendVerifyEmail          func(childComplexity int, params model.ResendVerifyEmailRequest) int
+		ResetPassword              func(childComplexity int, params model.ResetPasswordRequest) int
+		Revoke                     func(childComplexity int, params model.OAuthRevokeRequest) int
+		RevokeAccess               func(childComplexity int, param model.UpdateAccessRequest) int
+		RotateServiceAccountSecret func(childComplexity int, params model.ServiceAccountRequest) int
+		Signup                     func(childComplexity int, params model.SignUpRequest) int
+		TestEndpoint               func(childComplexity int, params model.TestEndpointRequest) int
+		UpdateEmailTemplate        func(childComplexity int, params model.UpdateEmailTemplateRequest) int
+		UpdateEnv                  func(childComplexity int, params model.UpdateEnvRequest) int
+		UpdateProfile              func(childComplexity int, params model.UpdateProfileRequest) int
+		UpdateServiceAccount       func(childComplexity int, params model.UpdateServiceAccountRequest) int
+		UpdateTrustedIssuer        func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
+		UpdateUser                 func(childComplexity int, params model.UpdateUserRequest) int
+		UpdateWebhook              func(childComplexity int, params model.UpdateWebhookRequest) int
+		VerifyEmail                func(childComplexity int, params model.VerifyEmailRequest) int
+		VerifyOtp                  func(childComplexity int, params model.VerifyOTPRequest) int
 	}
 
 	Pagination struct {
@@ -324,7 +336,11 @@ type ComplexityRoot struct {
 		ListPermissions      func(childComplexity int, params model.ListPermissionsInput) int
 		Meta                 func(childComplexity int) int
 		Profile              func(childComplexity int) int
+		ServiceAccount       func(childComplexity int, params model.ServiceAccountRequest) int
+		ServiceAccounts      func(childComplexity int, params *model.ListServiceAccountsRequest) int
 		Session              func(childComplexity int, params *model.SessionQueryRequest) int
+		TrustedIssuer        func(childComplexity int, params model.TrustedIssuerRequest) int
+		TrustedIssuers       func(childComplexity int, params *model.ListTrustedIssuersRequest) int
 		User                 func(childComplexity int, params model.GetUserRequest) int
 		Users                func(childComplexity int, params *model.PaginatedRequest) int
 		ValidateJwtToken     func(childComplexity int, params model.ValidateJWTTokenRequest) int
@@ -339,9 +355,45 @@ type ComplexityRoot struct {
 		Message func(childComplexity int) int
 	}
 
+	ServiceAccount struct {
+		AllowedScopes func(childComplexity int) int
+		CreatedAt     func(childComplexity int) int
+		Description   func(childComplexity int) int
+		ID            func(childComplexity int) int
+		IsActive      func(childComplexity int) int
+		Name          func(childComplexity int) int
+		UpdatedAt     func(childComplexity int) int
+	}
+
+	ServiceAccounts struct {
+		Pagination      func(childComplexity int) int
+		ServiceAccounts func(childComplexity int) int
+	}
+
 	TestEndpointResponse struct {
 		HTTPStatus func(childComplexity int) int
 		Response   func(childComplexity int) int
+	}
+
+	TrustedIssuer struct {
+		CreatedAt                func(childComplexity int) int
+		ExpectedAud              func(childComplexity int) int
+		ID                       func(childComplexity int) int
+		IsActive                 func(childComplexity int) int
+		IssuerType               func(childComplexity int) int
+		IssuerURL                func(childComplexity int) int
+		JwksURL                  func(childComplexity int) int
+		KeySourceType            func(childComplexity int) int
+		Name                     func(childComplexity int) int
+		ServiceAccountID         func(childComplexity int) int
+		SpiffeRefreshHintSeconds func(childComplexity int) int
+		SubjectClaim             func(childComplexity int) int
+		UpdatedAt                func(childComplexity int) int
+	}
+
+	TrustedIssuers struct {
+		Pagination     func(childComplexity int) int
+		TrustedIssuers func(childComplexity int) int
 	}
 
 	User struct {
@@ -460,6 +512,13 @@ type MutationResolver interface {
 	AddWebhook(ctx context.Context, params model.AddWebhookRequest) (*model.Response, error)
 	UpdateWebhook(ctx context.Context, params model.UpdateWebhookRequest) (*model.Response, error)
 	DeleteWebhook(ctx context.Context, params model.WebhookRequest) (*model.Response, error)
+	CreateServiceAccount(ctx context.Context, params model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, error)
+	UpdateServiceAccount(ctx context.Context, params model.UpdateServiceAccountRequest) (*model.ServiceAccount, error)
+	DeleteServiceAccount(ctx context.Context, params model.ServiceAccountRequest) (*model.Response, error)
+	RotateServiceAccountSecret(ctx context.Context, params model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, error)
+	AddTrustedIssuer(ctx context.Context, params model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error)
+	UpdateTrustedIssuer(ctx context.Context, params model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error)
+	DeleteTrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.Response, error)
 	TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error)
 	AddEmailTemplate(ctx context.Context, params model.AddEmailTemplateRequest) (*model.Response, error)
 	UpdateEmailTemplate(ctx context.Context, params model.UpdateEmailTemplateRequest) (*model.Response, error)
@@ -484,6 +543,10 @@ type QueryResolver interface {
 	Webhook(ctx context.Context, params model.WebhookRequest) (*model.Webhook, error)
 	Webhooks(ctx context.Context, params *model.PaginatedRequest) (*model.Webhooks, error)
 	WebhookLogs(ctx context.Context, params *model.ListWebhookLogRequest) (*model.WebhookLogs, error)
+	ServiceAccount(ctx context.Context, params model.ServiceAccountRequest) (*model.ServiceAccount, error)
+	ServiceAccounts(ctx context.Context, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, error)
+	TrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.TrustedIssuer, error)
+	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
 	EmailTemplates(ctx context.Context, params *model.PaginatedRequest) (*model.EmailTemplates, error)
 	AuditLogs(ctx context.Context, params *model.ListAuditLogRequest) (*model.AuditLogs, error)
 	FgaGetModel(ctx context.Context) (*model.FgaModel, error)
@@ -715,6 +778,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CheckPermissionsResponse.Results(childComplexity), true
+
+	case "CreateServiceAccountResponse.client_secret":
+		if e.complexity.CreateServiceAccountResponse.ClientSecret == nil {
+			break
+		}
+
+		return e.complexity.CreateServiceAccountResponse.ClientSecret(childComplexity), true
+
+	case "CreateServiceAccountResponse.service_account":
+		if e.complexity.CreateServiceAccountResponse.ServiceAccount == nil {
+			break
+		}
+
+		return e.complexity.CreateServiceAccountResponse.ServiceAccount(childComplexity), true
 
 	case "EmailTemplate.created_at":
 		if e.complexity.EmailTemplate.CreatedAt == nil {
@@ -1575,6 +1652,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.AddEmailTemplate(childComplexity, args["params"].(model.AddEmailTemplateRequest)), true
 
+	case "Mutation._add_trusted_issuer":
+		if e.complexity.Mutation.AddTrustedIssuer == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__add_trusted_issuer_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddTrustedIssuer(childComplexity, args["params"].(model.AddTrustedIssuerRequest)), true
+
 	case "Mutation._add_webhook":
 		if e.complexity.Mutation.AddWebhook == nil {
 			break
@@ -1618,6 +1707,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.AdminSignup(childComplexity, args["params"].(model.AdminSignupRequest)), true
 
+	case "Mutation._create_service_account":
+		if e.complexity.Mutation.CreateServiceAccount == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_service_account_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateServiceAccount(childComplexity, args["params"].(model.CreateServiceAccountRequest)), true
+
 	case "Mutation.deactivate_account":
 		if e.complexity.Mutation.DeactivateAccount == nil {
 			break
@@ -1636,6 +1737,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteEmailTemplate(childComplexity, args["params"].(model.DeleteEmailTemplateRequest)), true
+
+	case "Mutation._delete_service_account":
+		if e.complexity.Mutation.DeleteServiceAccount == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_service_account_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteServiceAccount(childComplexity, args["params"].(model.ServiceAccountRequest)), true
+
+	case "Mutation._delete_trusted_issuer":
+		if e.complexity.Mutation.DeleteTrustedIssuer == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_trusted_issuer_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTrustedIssuer(childComplexity, args["params"].(model.TrustedIssuerRequest)), true
 
 	case "Mutation._delete_user":
 		if e.complexity.Mutation.DeleteUser == nil {
@@ -1867,6 +1992,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.RevokeAccess(childComplexity, args["param"].(model.UpdateAccessRequest)), true
 
+	case "Mutation._rotate_service_account_secret":
+		if e.complexity.Mutation.RotateServiceAccountSecret == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__rotate_service_account_secret_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RotateServiceAccountSecret(childComplexity, args["params"].(model.ServiceAccountRequest)), true
+
 	case "Mutation.signup":
 		if e.complexity.Mutation.Signup == nil {
 			break
@@ -1926,6 +2063,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateProfile(childComplexity, args["params"].(model.UpdateProfileRequest)), true
+
+	case "Mutation._update_service_account":
+		if e.complexity.Mutation.UpdateServiceAccount == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_service_account_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateServiceAccount(childComplexity, args["params"].(model.UpdateServiceAccountRequest)), true
+
+	case "Mutation._update_trusted_issuer":
+		if e.complexity.Mutation.UpdateTrustedIssuer == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_trusted_issuer_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTrustedIssuer(childComplexity, args["params"].(model.UpdateTrustedIssuerRequest)), true
 
 	case "Mutation._update_user":
 		if e.complexity.Mutation.UpdateUser == nil {
@@ -2164,6 +2325,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.Profile(childComplexity), true
 
+	case "Query._service_account":
+		if e.complexity.Query.ServiceAccount == nil {
+			break
+		}
+
+		args, err := ec.field_Query__service_account_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ServiceAccount(childComplexity, args["params"].(model.ServiceAccountRequest)), true
+
+	case "Query._service_accounts":
+		if e.complexity.Query.ServiceAccounts == nil {
+			break
+		}
+
+		args, err := ec.field_Query__service_accounts_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ServiceAccounts(childComplexity, args["params"].(*model.ListServiceAccountsRequest)), true
+
 	case "Query.session":
 		if e.complexity.Query.Session == nil {
 			break
@@ -2175,6 +2360,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Session(childComplexity, args["params"].(*model.SessionQueryRequest)), true
+
+	case "Query._trusted_issuer":
+		if e.complexity.Query.TrustedIssuer == nil {
+			break
+		}
+
+		args, err := ec.field_Query__trusted_issuer_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TrustedIssuer(childComplexity, args["params"].(model.TrustedIssuerRequest)), true
+
+	case "Query._trusted_issuers":
+		if e.complexity.Query.TrustedIssuers == nil {
+			break
+		}
+
+		args, err := ec.field_Query__trusted_issuers_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TrustedIssuers(childComplexity, args["params"].(*model.ListTrustedIssuersRequest)), true
 
 	case "Query._user":
 		if e.complexity.Query.User == nil {
@@ -2279,6 +2488,69 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Response.Message(childComplexity), true
 
+	case "ServiceAccount.allowed_scopes":
+		if e.complexity.ServiceAccount.AllowedScopes == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.AllowedScopes(childComplexity), true
+
+	case "ServiceAccount.created_at":
+		if e.complexity.ServiceAccount.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.CreatedAt(childComplexity), true
+
+	case "ServiceAccount.description":
+		if e.complexity.ServiceAccount.Description == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.Description(childComplexity), true
+
+	case "ServiceAccount.id":
+		if e.complexity.ServiceAccount.ID == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.ID(childComplexity), true
+
+	case "ServiceAccount.is_active":
+		if e.complexity.ServiceAccount.IsActive == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.IsActive(childComplexity), true
+
+	case "ServiceAccount.name":
+		if e.complexity.ServiceAccount.Name == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.Name(childComplexity), true
+
+	case "ServiceAccount.updated_at":
+		if e.complexity.ServiceAccount.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccount.UpdatedAt(childComplexity), true
+
+	case "ServiceAccounts.pagination":
+		if e.complexity.ServiceAccounts.Pagination == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccounts.Pagination(childComplexity), true
+
+	case "ServiceAccounts.service_accounts":
+		if e.complexity.ServiceAccounts.ServiceAccounts == nil {
+			break
+		}
+
+		return e.complexity.ServiceAccounts.ServiceAccounts(childComplexity), true
+
 	case "TestEndpointResponse.http_status":
 		if e.complexity.TestEndpointResponse.HTTPStatus == nil {
 			break
@@ -2292,6 +2564,111 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TestEndpointResponse.Response(childComplexity), true
+
+	case "TrustedIssuer.created_at":
+		if e.complexity.TrustedIssuer.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.CreatedAt(childComplexity), true
+
+	case "TrustedIssuer.expected_aud":
+		if e.complexity.TrustedIssuer.ExpectedAud == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.ExpectedAud(childComplexity), true
+
+	case "TrustedIssuer.id":
+		if e.complexity.TrustedIssuer.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.ID(childComplexity), true
+
+	case "TrustedIssuer.is_active":
+		if e.complexity.TrustedIssuer.IsActive == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.IsActive(childComplexity), true
+
+	case "TrustedIssuer.issuer_type":
+		if e.complexity.TrustedIssuer.IssuerType == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.IssuerType(childComplexity), true
+
+	case "TrustedIssuer.issuer_url":
+		if e.complexity.TrustedIssuer.IssuerURL == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.IssuerURL(childComplexity), true
+
+	case "TrustedIssuer.jwks_url":
+		if e.complexity.TrustedIssuer.JwksURL == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.JwksURL(childComplexity), true
+
+	case "TrustedIssuer.key_source_type":
+		if e.complexity.TrustedIssuer.KeySourceType == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.KeySourceType(childComplexity), true
+
+	case "TrustedIssuer.name":
+		if e.complexity.TrustedIssuer.Name == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.Name(childComplexity), true
+
+	case "TrustedIssuer.service_account_id":
+		if e.complexity.TrustedIssuer.ServiceAccountID == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.ServiceAccountID(childComplexity), true
+
+	case "TrustedIssuer.spiffe_refresh_hint_seconds":
+		if e.complexity.TrustedIssuer.SpiffeRefreshHintSeconds == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.SpiffeRefreshHintSeconds(childComplexity), true
+
+	case "TrustedIssuer.subject_claim":
+		if e.complexity.TrustedIssuer.SubjectClaim == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.SubjectClaim(childComplexity), true
+
+	case "TrustedIssuer.updated_at":
+		if e.complexity.TrustedIssuer.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuer.UpdatedAt(childComplexity), true
+
+	case "TrustedIssuers.pagination":
+		if e.complexity.TrustedIssuers.Pagination == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuers.Pagination(childComplexity), true
+
+	case "TrustedIssuers.trusted_issuers":
+		if e.complexity.TrustedIssuers.TrustedIssuers == nil {
+			break
+		}
+
+		return e.complexity.TrustedIssuers.TrustedIssuers(childComplexity), true
 
 	case "User.app_data":
 		if e.complexity.User.AppData == nil {
@@ -2694,10 +3071,12 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAddEmailTemplateRequest,
+		ec.unmarshalInputAddTrustedIssuerRequest,
 		ec.unmarshalInputAddWebhookRequest,
 		ec.unmarshalInputAdminLoginRequest,
 		ec.unmarshalInputAdminSignupRequest,
 		ec.unmarshalInputCheckPermissionsInput,
+		ec.unmarshalInputCreateServiceAccountRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
 		ec.unmarshalInputDeleteUserRequest,
 		ec.unmarshalInputFgaExpandInput,
@@ -2713,6 +3092,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInviteMemberRequest,
 		ec.unmarshalInputListAuditLogRequest,
 		ec.unmarshalInputListPermissionsInput,
+		ec.unmarshalInputListServiceAccountsRequest,
+		ec.unmarshalInputListTrustedIssuersRequest,
 		ec.unmarshalInputListWebhookLogRequest,
 		ec.unmarshalInputLoginRequest,
 		ec.unmarshalInputMagicLinkLoginRequest,
@@ -2725,13 +3106,17 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputResendOTPRequest,
 		ec.unmarshalInputResendVerifyEmailRequest,
 		ec.unmarshalInputResetPasswordRequest,
+		ec.unmarshalInputServiceAccountRequest,
 		ec.unmarshalInputSessionQueryRequest,
 		ec.unmarshalInputSignUpRequest,
 		ec.unmarshalInputTestEndpointRequest,
+		ec.unmarshalInputTrustedIssuerRequest,
 		ec.unmarshalInputUpdateAccessRequest,
 		ec.unmarshalInputUpdateEmailTemplateRequest,
 		ec.unmarshalInputUpdateEnvRequest,
 		ec.unmarshalInputUpdateProfileRequest,
+		ec.unmarshalInputUpdateServiceAccountRequest,
+		ec.unmarshalInputUpdateTrustedIssuerRequest,
 		ec.unmarshalInputUpdateUserRequest,
 		ec.unmarshalInputUpdateWebhookRequest,
 		ec.unmarshalInputValidateJWTTokenRequest,
@@ -3138,6 +3523,51 @@ type Webhooks {
   webhooks: [Webhook!]!
 }
 
+type ServiceAccount {
+  id: ID!
+  name: String!
+  description: String
+  allowed_scopes: [String!]!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+  # client_secret is NEVER returned here. It is returned exactly once in
+  # CreateServiceAccountResponse (creation and rotation) and never again.
+}
+
+type CreateServiceAccountResponse {
+  service_account: ServiceAccount!
+  # client_secret is returned ONCE at creation and ONCE at rotation. Store it
+  # securely; it can never be retrieved again.
+  client_secret: String!
+}
+
+type ServiceAccounts {
+  pagination: Pagination!
+  service_accounts: [ServiceAccount!]!
+}
+
+type TrustedIssuer {
+  id: ID!
+  service_account_id: String!
+  name: String!
+  issuer_url: String!
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  subject_claim: String!
+  issuer_type: String!
+  is_active: Boolean!
+  spiffe_refresh_hint_seconds: Int64
+  created_at: Int64
+  updated_at: Int64
+}
+
+type TrustedIssuers {
+  pagination: Pagination!
+  trusted_issuers: [TrustedIssuer!]!
+}
+
 type WebhookLog {
   id: ID!
   http_status: Int64
@@ -3507,6 +3937,62 @@ input WebhookRequest {
   id: ID!
 }
 
+input CreateServiceAccountRequest {
+  name: String!
+  description: String
+  # allowed_scopes MUST contain at least one non-empty scope after trimming.
+  allowed_scopes: [String!]!
+}
+
+input UpdateServiceAccountRequest {
+  id: ID!
+  name: String
+  description: String
+  allowed_scopes: [String!]
+  is_active: Boolean
+}
+
+input ServiceAccountRequest {
+  id: ID!
+}
+
+input ListServiceAccountsRequest {
+  pagination: PaginatedRequest
+}
+
+input AddTrustedIssuerRequest {
+  service_account_id: String!
+  name: String!
+  issuer_url: String!
+  # key_source_type: "oidc_discovery" | "static_jwks_url" | "spiffe_bundle_endpoint"
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  # subject_claim defaults to "sub" if omitted
+  subject_claim: String
+  # issuer_type: "kubernetes_sa" | "spiffe_jwt" | "oidc" | "cloud_oidc"
+  issuer_type: String!
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input UpdateTrustedIssuerRequest {
+  id: ID!
+  name: String
+  jwks_url: String
+  expected_aud: String
+  is_active: Boolean
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input TrustedIssuerRequest {
+  id: ID!
+}
+
+input ListTrustedIssuersRequest {
+  service_account_id: String
+  pagination: PaginatedRequest
+}
+
 input TestEndpointRequest {
   endpoint: String!
   event_name: String!
@@ -3682,6 +4168,15 @@ type Mutation {
   _add_webhook(params: AddWebhookRequest!): Response!
   _update_webhook(params: UpdateWebhookRequest!): Response!
   _delete_webhook(params: WebhookRequest!): Response!
+  # Service accounts (machine/workload identity)
+  _create_service_account(params: CreateServiceAccountRequest!): CreateServiceAccountResponse!
+  _update_service_account(params: UpdateServiceAccountRequest!): ServiceAccount!
+  _delete_service_account(params: ServiceAccountRequest!): Response!
+  _rotate_service_account_secret(params: ServiceAccountRequest!): CreateServiceAccountResponse!
+  # Trusted issuers (external JWT issuers bound to a service account)
+  _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
+  _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
+  _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -3712,6 +4207,12 @@ type Query {
   _webhook(params: WebhookRequest!): Webhook!
   _webhooks(params: PaginatedRequest): Webhooks!
   _webhook_logs(params: ListWebhookLogRequest): WebhookLogs!
+  # Service accounts (machine/workload identity)
+  _service_account(params: ServiceAccountRequest!): ServiceAccount!
+  _service_accounts(params: ListServiceAccountsRequest): ServiceAccounts!
+  # Trusted issuers
+  _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
+  _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)
@@ -3756,6 +4257,34 @@ func (ec *executionContext) field_Mutation__add_email_template_argsParams(
 	}
 
 	var zeroVal model.AddEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__add_trusted_issuer_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__add_trusted_issuer_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__add_trusted_issuer_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.AddTrustedIssuerRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.AddTrustedIssuerRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNAddTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddTrustedIssuerRequest(ctx, tmp)
+	}
+
+	var zeroVal model.AddTrustedIssuerRequest
 	return zeroVal, nil
 }
 
@@ -3843,6 +4372,34 @@ func (ec *executionContext) field_Mutation__admin_signup_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_service_account_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_service_account_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_service_account_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateServiceAccountRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateServiceAccountRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateServiceAccountRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__delete_email_template_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -3868,6 +4425,62 @@ func (ec *executionContext) field_Mutation__delete_email_template_argsParams(
 	}
 
 	var zeroVal model.DeleteEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_service_account_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_service_account_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_service_account_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ServiceAccountRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ServiceAccountRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ServiceAccountRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_trusted_issuer_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_trusted_issuer_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_trusted_issuer_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.TrustedIssuerRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.TrustedIssuerRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuerRequest(ctx, tmp)
+	}
+
+	var zeroVal model.TrustedIssuerRequest
 	return zeroVal, nil
 }
 
@@ -4123,6 +4736,34 @@ func (ec *executionContext) field_Mutation__revoke_access_argsParam(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__rotate_service_account_secret_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__rotate_service_account_secret_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__rotate_service_account_secret_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ServiceAccountRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ServiceAccountRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ServiceAccountRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__test_endpoint_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -4204,6 +4845,62 @@ func (ec *executionContext) field_Mutation__update_env_argsParams(
 	}
 
 	var zeroVal model.UpdateEnvRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_service_account_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_service_account_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_service_account_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateServiceAccountRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateServiceAccountRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateServiceAccountRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateServiceAccountRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_trusted_issuer_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_trusted_issuer_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_trusted_issuer_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateTrustedIssuerRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateTrustedIssuerRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateTrustedIssuerRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateTrustedIssuerRequest
 	return zeroVal, nil
 }
 
@@ -4792,6 +5489,118 @@ func (ec *executionContext) field_Query__fga_read_tuples_argsParams(
 	}
 
 	var zeroVal model.FgaReadTuplesInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__service_account_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__service_account_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__service_account_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ServiceAccountRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ServiceAccountRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ServiceAccountRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__service_accounts_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__service_accounts_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__service_accounts_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*model.ListServiceAccountsRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal *model.ListServiceAccountsRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalOListServiceAccountsRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListServiceAccountsRequest(ctx, tmp)
+	}
+
+	var zeroVal *model.ListServiceAccountsRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__trusted_issuer_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__trusted_issuer_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__trusted_issuer_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.TrustedIssuerRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.TrustedIssuerRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuerRequest(ctx, tmp)
+	}
+
+	var zeroVal model.TrustedIssuerRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__trusted_issuers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__trusted_issuers_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__trusted_issuers_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*model.ListTrustedIssuersRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal *model.ListTrustedIssuersRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalOListTrustedIssuersRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListTrustedIssuersRequest(ctx, tmp)
+	}
+
+	var zeroVal *model.ListTrustedIssuersRequest
 	return zeroVal, nil
 }
 
@@ -6515,6 +7324,110 @@ func (ec *executionContext) fieldContext_CheckPermissionsResponse_results(_ cont
 				return ec.fieldContext_PermissionCheckResult_allowed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PermissionCheckResult", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateServiceAccountResponse_service_account(ctx context.Context, field graphql.CollectedField, obj *model.CreateServiceAccountResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateServiceAccountResponse_service_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceAccount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceAccount)
+	fc.Result = res
+	return ec.marshalNServiceAccount2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateServiceAccountResponse_service_account(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateServiceAccountResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ServiceAccount_id(ctx, field)
+			case "name":
+				return ec.fieldContext_ServiceAccount_name(ctx, field)
+			case "description":
+				return ec.fieldContext_ServiceAccount_description(ctx, field)
+			case "allowed_scopes":
+				return ec.fieldContext_ServiceAccount_allowed_scopes(ctx, field)
+			case "is_active":
+				return ec.fieldContext_ServiceAccount_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ServiceAccount_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ServiceAccount_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceAccount", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateServiceAccountResponse_client_secret(ctx context.Context, field graphql.CollectedField, obj *model.CreateServiceAccountResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateServiceAccountResponse_client_secret(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClientSecret, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateServiceAccountResponse_client_secret(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateServiceAccountResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -13540,6 +14453,483 @@ func (ec *executionContext) fieldContext_Mutation__delete_webhook(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_service_account(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_service_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateServiceAccount(rctx, fc.Args["params"].(model.CreateServiceAccountRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreateServiceAccountResponse)
+	fc.Result = res
+	return ec.marshalNCreateServiceAccountResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_service_account(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "service_account":
+				return ec.fieldContext_CreateServiceAccountResponse_service_account(ctx, field)
+			case "client_secret":
+				return ec.fieldContext_CreateServiceAccountResponse_client_secret(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateServiceAccountResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_service_account_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_service_account(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_service_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateServiceAccount(rctx, fc.Args["params"].(model.UpdateServiceAccountRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceAccount)
+	fc.Result = res
+	return ec.marshalNServiceAccount2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_service_account(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ServiceAccount_id(ctx, field)
+			case "name":
+				return ec.fieldContext_ServiceAccount_name(ctx, field)
+			case "description":
+				return ec.fieldContext_ServiceAccount_description(ctx, field)
+			case "allowed_scopes":
+				return ec.fieldContext_ServiceAccount_allowed_scopes(ctx, field)
+			case "is_active":
+				return ec.fieldContext_ServiceAccount_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ServiceAccount_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ServiceAccount_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceAccount", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_service_account_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_service_account(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_service_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteServiceAccount(rctx, fc.Args["params"].(model.ServiceAccountRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_service_account(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_service_account_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__rotate_service_account_secret(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__rotate_service_account_secret(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RotateServiceAccountSecret(rctx, fc.Args["params"].(model.ServiceAccountRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreateServiceAccountResponse)
+	fc.Result = res
+	return ec.marshalNCreateServiceAccountResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__rotate_service_account_secret(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "service_account":
+				return ec.fieldContext_CreateServiceAccountResponse_service_account(ctx, field)
+			case "client_secret":
+				return ec.fieldContext_CreateServiceAccountResponse_client_secret(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateServiceAccountResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__rotate_service_account_secret_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__add_trusted_issuer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__add_trusted_issuer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddTrustedIssuer(rctx, fc.Args["params"].(model.AddTrustedIssuerRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TrustedIssuer)
+	fc.Result = res
+	return ec.marshalNTrustedIssuer2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__add_trusted_issuer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustedIssuer_id(ctx, field)
+			case "service_account_id":
+				return ec.fieldContext_TrustedIssuer_service_account_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustedIssuer_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_TrustedIssuer_issuer_url(ctx, field)
+			case "key_source_type":
+				return ec.fieldContext_TrustedIssuer_key_source_type(ctx, field)
+			case "jwks_url":
+				return ec.fieldContext_TrustedIssuer_jwks_url(ctx, field)
+			case "expected_aud":
+				return ec.fieldContext_TrustedIssuer_expected_aud(ctx, field)
+			case "subject_claim":
+				return ec.fieldContext_TrustedIssuer_subject_claim(ctx, field)
+			case "issuer_type":
+				return ec.fieldContext_TrustedIssuer_issuer_type(ctx, field)
+			case "is_active":
+				return ec.fieldContext_TrustedIssuer_is_active(ctx, field)
+			case "spiffe_refresh_hint_seconds":
+				return ec.fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field)
+			case "created_at":
+				return ec.fieldContext_TrustedIssuer_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_TrustedIssuer_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustedIssuer", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__add_trusted_issuer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_trusted_issuer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_trusted_issuer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTrustedIssuer(rctx, fc.Args["params"].(model.UpdateTrustedIssuerRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TrustedIssuer)
+	fc.Result = res
+	return ec.marshalNTrustedIssuer2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_trusted_issuer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustedIssuer_id(ctx, field)
+			case "service_account_id":
+				return ec.fieldContext_TrustedIssuer_service_account_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustedIssuer_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_TrustedIssuer_issuer_url(ctx, field)
+			case "key_source_type":
+				return ec.fieldContext_TrustedIssuer_key_source_type(ctx, field)
+			case "jwks_url":
+				return ec.fieldContext_TrustedIssuer_jwks_url(ctx, field)
+			case "expected_aud":
+				return ec.fieldContext_TrustedIssuer_expected_aud(ctx, field)
+			case "subject_claim":
+				return ec.fieldContext_TrustedIssuer_subject_claim(ctx, field)
+			case "issuer_type":
+				return ec.fieldContext_TrustedIssuer_issuer_type(ctx, field)
+			case "is_active":
+				return ec.fieldContext_TrustedIssuer_is_active(ctx, field)
+			case "spiffe_refresh_hint_seconds":
+				return ec.fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field)
+			case "created_at":
+				return ec.fieldContext_TrustedIssuer_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_TrustedIssuer_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustedIssuer", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_trusted_issuer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_trusted_issuer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_trusted_issuer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTrustedIssuer(rctx, fc.Args["params"].(model.TrustedIssuerRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_trusted_issuer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_trusted_issuer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__test_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__test_endpoint(ctx, field)
 	if err != nil {
@@ -15478,6 +16868,282 @@ func (ec *executionContext) fieldContext_Query__webhook_logs(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query__service_account(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__service_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ServiceAccount(rctx, fc.Args["params"].(model.ServiceAccountRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceAccount)
+	fc.Result = res
+	return ec.marshalNServiceAccount2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__service_account(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ServiceAccount_id(ctx, field)
+			case "name":
+				return ec.fieldContext_ServiceAccount_name(ctx, field)
+			case "description":
+				return ec.fieldContext_ServiceAccount_description(ctx, field)
+			case "allowed_scopes":
+				return ec.fieldContext_ServiceAccount_allowed_scopes(ctx, field)
+			case "is_active":
+				return ec.fieldContext_ServiceAccount_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ServiceAccount_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ServiceAccount_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceAccount", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__service_account_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__service_accounts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__service_accounts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ServiceAccounts(rctx, fc.Args["params"].(*model.ListServiceAccountsRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceAccounts)
+	fc.Result = res
+	return ec.marshalNServiceAccounts2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccounts(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__service_accounts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_ServiceAccounts_pagination(ctx, field)
+			case "service_accounts":
+				return ec.fieldContext_ServiceAccounts_service_accounts(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceAccounts", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__service_accounts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__trusted_issuer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__trusted_issuer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TrustedIssuer(rctx, fc.Args["params"].(model.TrustedIssuerRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TrustedIssuer)
+	fc.Result = res
+	return ec.marshalNTrustedIssuer2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__trusted_issuer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustedIssuer_id(ctx, field)
+			case "service_account_id":
+				return ec.fieldContext_TrustedIssuer_service_account_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustedIssuer_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_TrustedIssuer_issuer_url(ctx, field)
+			case "key_source_type":
+				return ec.fieldContext_TrustedIssuer_key_source_type(ctx, field)
+			case "jwks_url":
+				return ec.fieldContext_TrustedIssuer_jwks_url(ctx, field)
+			case "expected_aud":
+				return ec.fieldContext_TrustedIssuer_expected_aud(ctx, field)
+			case "subject_claim":
+				return ec.fieldContext_TrustedIssuer_subject_claim(ctx, field)
+			case "issuer_type":
+				return ec.fieldContext_TrustedIssuer_issuer_type(ctx, field)
+			case "is_active":
+				return ec.fieldContext_TrustedIssuer_is_active(ctx, field)
+			case "spiffe_refresh_hint_seconds":
+				return ec.fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field)
+			case "created_at":
+				return ec.fieldContext_TrustedIssuer_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_TrustedIssuer_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustedIssuer", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__trusted_issuer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__trusted_issuers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__trusted_issuers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TrustedIssuers(rctx, fc.Args["params"].(*model.ListTrustedIssuersRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TrustedIssuers)
+	fc.Result = res
+	return ec.marshalNTrustedIssuers2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuers(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__trusted_issuers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_TrustedIssuers_pagination(ctx, field)
+			case "trusted_issuers":
+				return ec.fieldContext_TrustedIssuers_trusted_issuers(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustedIssuers", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__trusted_issuers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query__email_templates(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query__email_templates(ctx, field)
 	if err != nil {
@@ -16126,6 +17792,419 @@ func (ec *executionContext) fieldContext_Response_message(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _ServiceAccount_id(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_name(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_description(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_allowed_scopes(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_allowed_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllowedScopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_allowed_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_is_active(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_is_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_is_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_created_at(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccount) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccount_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccount_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccounts_pagination(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccounts) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccounts_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccounts_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccounts",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccounts_service_accounts(ctx context.Context, field graphql.CollectedField, obj *model.ServiceAccounts) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceAccounts_service_accounts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceAccounts, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.ServiceAccount)
+	fc.Result = res
+	return ec.marshalNServiceAccount2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceAccounts_service_accounts(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccounts",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ServiceAccount_id(ctx, field)
+			case "name":
+				return ec.fieldContext_ServiceAccount_name(ctx, field)
+			case "description":
+				return ec.fieldContext_ServiceAccount_description(ctx, field)
+			case "allowed_scopes":
+				return ec.fieldContext_ServiceAccount_allowed_scopes(ctx, field)
+			case "is_active":
+				return ec.fieldContext_ServiceAccount_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ServiceAccount_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ServiceAccount_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceAccount", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TestEndpointResponse_http_status(ctx context.Context, field graphql.CollectedField, obj *model.TestEndpointResponse) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TestEndpointResponse_http_status(ctx, field)
 	if err != nil {
@@ -16203,6 +18282,692 @@ func (ec *executionContext) fieldContext_TestEndpointResponse_response(_ context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_id(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_service_account_id(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_service_account_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceAccountID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_service_account_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_name(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_issuer_url(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_issuer_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IssuerURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_issuer_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_key_source_type(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_key_source_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KeySourceType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_key_source_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_jwks_url(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_jwks_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.JwksURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_jwks_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_expected_aud(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_expected_aud(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExpectedAud, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_expected_aud(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_subject_claim(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_subject_claim(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SubjectClaim, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_subject_claim(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_issuer_type(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_issuer_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IssuerType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_issuer_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_is_active(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_is_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_is_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_spiffe_refresh_hint_seconds(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpiffeRefreshHintSeconds, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_created_at(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuer_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuer_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuer_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuers_pagination(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuers) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuers_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuers_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuers",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustedIssuers_trusted_issuers(ctx context.Context, field graphql.CollectedField, obj *model.TrustedIssuers) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustedIssuers_trusted_issuers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustedIssuers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.TrustedIssuer)
+	fc.Result = res
+	return ec.marshalNTrustedIssuer2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuerᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustedIssuers_trusted_issuers(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustedIssuers",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustedIssuer_id(ctx, field)
+			case "service_account_id":
+				return ec.fieldContext_TrustedIssuer_service_account_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustedIssuer_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_TrustedIssuer_issuer_url(ctx, field)
+			case "key_source_type":
+				return ec.fieldContext_TrustedIssuer_key_source_type(ctx, field)
+			case "jwks_url":
+				return ec.fieldContext_TrustedIssuer_jwks_url(ctx, field)
+			case "expected_aud":
+				return ec.fieldContext_TrustedIssuer_expected_aud(ctx, field)
+			case "subject_claim":
+				return ec.fieldContext_TrustedIssuer_subject_claim(ctx, field)
+			case "issuer_type":
+				return ec.fieldContext_TrustedIssuer_issuer_type(ctx, field)
+			case "is_active":
+				return ec.fieldContext_TrustedIssuer_is_active(ctx, field)
+			case "spiffe_refresh_hint_seconds":
+				return ec.fieldContext_TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field)
+			case "created_at":
+				return ec.fieldContext_TrustedIssuer_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_TrustedIssuer_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustedIssuer", field.Name)
 		},
 	}
 	return fc, nil
@@ -20738,6 +23503,89 @@ func (ec *executionContext) unmarshalInputAddEmailTemplateRequest(ctx context.Co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputAddTrustedIssuerRequest(ctx context.Context, obj any) (model.AddTrustedIssuerRequest, error) {
+	var it model.AddTrustedIssuerRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"service_account_id", "name", "issuer_url", "key_source_type", "jwks_url", "expected_aud", "subject_claim", "issuer_type", "spiffe_refresh_hint_seconds"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "service_account_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_account_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceAccountID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "issuer_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issuer_url"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IssuerURL = data
+		case "key_source_type":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key_source_type"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KeySourceType = data
+		case "jwks_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("jwks_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.JwksURL = data
+		case "expected_aud":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expected_aud"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExpectedAud = data
+		case "subject_claim":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subject_claim"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SubjectClaim = data
+		case "issuer_type":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issuer_type"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IssuerType = data
+		case "spiffe_refresh_hint_seconds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spiffe_refresh_hint_seconds"))
+			data, err := ec.unmarshalOInt642ᚖint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpiffeRefreshHintSeconds = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputAddWebhookRequest(ctx context.Context, obj any) (model.AddWebhookRequest, error) {
 	var it model.AddWebhookRequest
 	asMap := map[string]any{}
@@ -20875,6 +23723,47 @@ func (ec *executionContext) unmarshalInputCheckPermissionsInput(ctx context.Cont
 				return it, err
 			}
 			it.User = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCreateServiceAccountRequest(ctx context.Context, obj any) (model.CreateServiceAccountRequest, error) {
+	var it model.CreateServiceAccountRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "description", "allowed_scopes"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "allowed_scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowed_scopes"))
+			data, err := ec.unmarshalNString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowedScopes = data
 		}
 	}
 
@@ -21441,6 +24330,67 @@ func (ec *executionContext) unmarshalInputListPermissionsInput(ctx context.Conte
 				return it, err
 			}
 			it.User = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListServiceAccountsRequest(ctx context.Context, obj any) (model.ListServiceAccountsRequest, error) {
+	var it model.ListServiceAccountsRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListTrustedIssuersRequest(ctx context.Context, obj any) (model.ListTrustedIssuersRequest, error) {
+	var it model.ListTrustedIssuersRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"service_account_id", "pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "service_account_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_account_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceAccountID = data
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
 		}
 	}
 
@@ -22058,6 +25008,33 @@ func (ec *executionContext) unmarshalInputResetPasswordRequest(ctx context.Conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputServiceAccountRequest(ctx context.Context, obj any) (model.ServiceAccountRequest, error) {
+	var it model.ServiceAccountRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputSessionQueryRequest(ctx context.Context, obj any) (model.SessionQueryRequest, error) {
 	var it model.SessionQueryRequest
 	asMap := map[string]any{}
@@ -22287,6 +25264,33 @@ func (ec *executionContext) unmarshalInputTestEndpointRequest(ctx context.Contex
 				return it, err
 			}
 			it.Headers = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTrustedIssuerRequest(ctx context.Context, obj any) (model.TrustedIssuerRequest, error) {
+	var it model.TrustedIssuerRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
 		}
 	}
 
@@ -22947,6 +25951,123 @@ func (ec *executionContext) unmarshalInputUpdateProfileRequest(ctx context.Conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateServiceAccountRequest(ctx context.Context, obj any) (model.UpdateServiceAccountRequest, error) {
+	var it model.UpdateServiceAccountRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "description", "allowed_scopes", "is_active"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "allowed_scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowed_scopes"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowedScopes = data
+		case "is_active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsActive = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateTrustedIssuerRequest(ctx context.Context, obj any) (model.UpdateTrustedIssuerRequest, error) {
+	var it model.UpdateTrustedIssuerRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "jwks_url", "expected_aud", "is_active", "spiffe_refresh_hint_seconds"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "jwks_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("jwks_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.JwksURL = data
+		case "expected_aud":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expected_aud"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExpectedAud = data
+		case "is_active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsActive = data
+		case "spiffe_refresh_hint_seconds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spiffe_refresh_hint_seconds"))
+			data, err := ec.unmarshalOInt642ᚖint64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpiffeRefreshHintSeconds = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateUserRequest(ctx context.Context, obj any) (model.UpdateUserRequest, error) {
 	var it model.UpdateUserRequest
 	asMap := map[string]any{}
@@ -23573,6 +26694,50 @@ func (ec *executionContext) _CheckPermissionsResponse(ctx context.Context, sel a
 			out.Values[i] = graphql.MarshalString("CheckPermissionsResponse")
 		case "results":
 			out.Values[i] = ec._CheckPermissionsResponse_results(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var createServiceAccountResponseImplementors = []string{"CreateServiceAccountResponse"}
+
+func (ec *executionContext) _CreateServiceAccountResponse(ctx context.Context, sel ast.SelectionSet, obj *model.CreateServiceAccountResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createServiceAccountResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateServiceAccountResponse")
+		case "service_account":
+			out.Values[i] = ec._CreateServiceAccountResponse_service_account(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "client_secret":
+			out.Values[i] = ec._CreateServiceAccountResponse_client_secret(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -24712,6 +27877,55 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_service_account":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_service_account(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_service_account":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_service_account(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_service_account":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_service_account(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_rotate_service_account_secret":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__rotate_service_account_secret(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_add_trusted_issuer":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__add_trusted_issuer(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_trusted_issuer":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_trusted_issuer(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_trusted_issuer":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_trusted_issuer(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_test_endpoint":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__test_endpoint(ctx, field)
@@ -25265,6 +28479,94 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_service_account":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__service_account(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_service_accounts":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__service_accounts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_trusted_issuer":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__trusted_issuer(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_trusted_issuers":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__trusted_issuers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "_email_templates":
 			field := field
 
@@ -25511,6 +28813,110 @@ func (ec *executionContext) _Response(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var serviceAccountImplementors = []string{"ServiceAccount"}
+
+func (ec *executionContext) _ServiceAccount(ctx context.Context, sel ast.SelectionSet, obj *model.ServiceAccount) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, serviceAccountImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ServiceAccount")
+		case "id":
+			out.Values[i] = ec._ServiceAccount_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._ServiceAccount_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "description":
+			out.Values[i] = ec._ServiceAccount_description(ctx, field, obj)
+		case "allowed_scopes":
+			out.Values[i] = ec._ServiceAccount_allowed_scopes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "is_active":
+			out.Values[i] = ec._ServiceAccount_is_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._ServiceAccount_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._ServiceAccount_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var serviceAccountsImplementors = []string{"ServiceAccounts"}
+
+func (ec *executionContext) _ServiceAccounts(ctx context.Context, sel ast.SelectionSet, obj *model.ServiceAccounts) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, serviceAccountsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ServiceAccounts")
+		case "pagination":
+			out.Values[i] = ec._ServiceAccounts_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "service_accounts":
+			out.Values[i] = ec._ServiceAccounts_service_accounts(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var testEndpointResponseImplementors = []string{"TestEndpointResponse"}
 
 func (ec *executionContext) _TestEndpointResponse(ctx context.Context, sel ast.SelectionSet, obj *model.TestEndpointResponse) graphql.Marshaler {
@@ -25526,6 +28932,137 @@ func (ec *executionContext) _TestEndpointResponse(ctx context.Context, sel ast.S
 			out.Values[i] = ec._TestEndpointResponse_http_status(ctx, field, obj)
 		case "response":
 			out.Values[i] = ec._TestEndpointResponse_response(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustedIssuerImplementors = []string{"TrustedIssuer"}
+
+func (ec *executionContext) _TrustedIssuer(ctx context.Context, sel ast.SelectionSet, obj *model.TrustedIssuer) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustedIssuerImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustedIssuer")
+		case "id":
+			out.Values[i] = ec._TrustedIssuer_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "service_account_id":
+			out.Values[i] = ec._TrustedIssuer_service_account_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._TrustedIssuer_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "issuer_url":
+			out.Values[i] = ec._TrustedIssuer_issuer_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "key_source_type":
+			out.Values[i] = ec._TrustedIssuer_key_source_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "jwks_url":
+			out.Values[i] = ec._TrustedIssuer_jwks_url(ctx, field, obj)
+		case "expected_aud":
+			out.Values[i] = ec._TrustedIssuer_expected_aud(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "subject_claim":
+			out.Values[i] = ec._TrustedIssuer_subject_claim(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "issuer_type":
+			out.Values[i] = ec._TrustedIssuer_issuer_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "is_active":
+			out.Values[i] = ec._TrustedIssuer_is_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "spiffe_refresh_hint_seconds":
+			out.Values[i] = ec._TrustedIssuer_spiffe_refresh_hint_seconds(ctx, field, obj)
+		case "created_at":
+			out.Values[i] = ec._TrustedIssuer_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._TrustedIssuer_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustedIssuersImplementors = []string{"TrustedIssuers"}
+
+func (ec *executionContext) _TrustedIssuers(ctx context.Context, sel ast.SelectionSet, obj *model.TrustedIssuers) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustedIssuersImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustedIssuers")
+		case "pagination":
+			out.Values[i] = ec._TrustedIssuers_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "trusted_issuers":
+			out.Values[i] = ec._TrustedIssuers_trusted_issuers(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -26398,6 +29935,11 @@ func (ec *executionContext) unmarshalNAddEmailTemplateRequest2githubᚗcomᚋaut
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNAddTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddTrustedIssuerRequest(ctx context.Context, v any) (model.AddTrustedIssuerRequest, error) {
+	res, err := ec.unmarshalInputAddTrustedIssuerRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNAddWebhookRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddWebhookRequest(ctx context.Context, v any) (model.AddWebhookRequest, error) {
 	res, err := ec.unmarshalInputAddWebhookRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -26542,6 +30084,25 @@ func (ec *executionContext) marshalNCheckPermissionsResponse2ᚖgithubᚗcomᚋa
 		return graphql.Null
 	}
 	return ec._CheckPermissionsResponse(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreateServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountRequest(ctx context.Context, v any) (model.CreateServiceAccountRequest, error) {
+	res, err := ec.unmarshalInputCreateServiceAccountRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateServiceAccountResponse2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountResponse(ctx context.Context, sel ast.SelectionSet, v model.CreateServiceAccountResponse) graphql.Marshaler {
+	return ec._CreateServiceAccountResponse(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateServiceAccountResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateServiceAccountResponse(ctx context.Context, sel ast.SelectionSet, v *model.CreateServiceAccountResponse) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateServiceAccountResponse(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteEmailTemplateRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteEmailTemplateRequest(ctx context.Context, v any) (model.DeleteEmailTemplateRequest, error) {
@@ -27110,6 +30671,83 @@ func (ec *executionContext) marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋa
 	return ec._Response(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNServiceAccount2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx context.Context, sel ast.SelectionSet, v model.ServiceAccount) graphql.Marshaler {
+	return ec._ServiceAccount(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNServiceAccount2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.ServiceAccount) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNServiceAccount2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNServiceAccount2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccount(ctx context.Context, sel ast.SelectionSet, v *model.ServiceAccount) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ServiceAccount(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccountRequest(ctx context.Context, v any) (model.ServiceAccountRequest, error) {
+	res, err := ec.unmarshalInputServiceAccountRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNServiceAccounts2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccounts(ctx context.Context, sel ast.SelectionSet, v model.ServiceAccounts) graphql.Marshaler {
+	return ec._ServiceAccounts(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNServiceAccounts2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐServiceAccounts(ctx context.Context, sel ast.SelectionSet, v *model.ServiceAccounts) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ServiceAccounts(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNSignUpRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSignUpRequest(ctx context.Context, v any) (model.SignUpRequest, error) {
 	res, err := ec.unmarshalInputSignUpRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -27180,6 +30818,83 @@ func (ec *executionContext) marshalNTestEndpointResponse2ᚖgithubᚗcomᚋautho
 	return ec._TestEndpointResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNTrustedIssuer2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx context.Context, sel ast.SelectionSet, v model.TrustedIssuer) graphql.Marshaler {
+	return ec._TrustedIssuer(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustedIssuer2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuerᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TrustedIssuer) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrustedIssuer2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTrustedIssuer2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuer(ctx context.Context, sel ast.SelectionSet, v *model.TrustedIssuer) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustedIssuer(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuerRequest(ctx context.Context, v any) (model.TrustedIssuerRequest, error) {
+	res, err := ec.unmarshalInputTrustedIssuerRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTrustedIssuers2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuers(ctx context.Context, sel ast.SelectionSet, v model.TrustedIssuers) graphql.Marshaler {
+	return ec._TrustedIssuers(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustedIssuers2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐTrustedIssuers(ctx context.Context, sel ast.SelectionSet, v *model.TrustedIssuers) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustedIssuers(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNUpdateAccessRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateAccessRequest(ctx context.Context, v any) (model.UpdateAccessRequest, error) {
 	res, err := ec.unmarshalInputUpdateAccessRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -27197,6 +30912,16 @@ func (ec *executionContext) unmarshalNUpdateEnvRequest2githubᚗcomᚋauthorizer
 
 func (ec *executionContext) unmarshalNUpdateProfileRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateProfileRequest(ctx context.Context, v any) (model.UpdateProfileRequest, error) {
 	res, err := ec.unmarshalInputUpdateProfileRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateServiceAccountRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateServiceAccountRequest(ctx context.Context, v any) (model.UpdateServiceAccountRequest, error) {
+	res, err := ec.unmarshalInputUpdateServiceAccountRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateTrustedIssuerRequest(ctx context.Context, v any) (model.UpdateTrustedIssuerRequest, error) {
+	res, err := ec.unmarshalInputUpdateTrustedIssuerRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -27898,6 +31623,22 @@ func (ec *executionContext) unmarshalOListAuditLogRequest2ᚖgithubᚗcomᚋauth
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputListAuditLogRequest(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOListServiceAccountsRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListServiceAccountsRequest(ctx context.Context, v any) (*model.ListServiceAccountsRequest, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputListServiceAccountsRequest(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOListTrustedIssuersRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListTrustedIssuersRequest(ctx context.Context, v any) (*model.ListTrustedIssuersRequest, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputListTrustedIssuersRequest(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -9,6 +9,18 @@ type AddEmailTemplateRequest struct {
 	Design    *string `json:"design,omitempty"`
 }
 
+type AddTrustedIssuerRequest struct {
+	ServiceAccountID         string  `json:"service_account_id"`
+	Name                     string  `json:"name"`
+	IssuerURL                string  `json:"issuer_url"`
+	KeySourceType            string  `json:"key_source_type"`
+	JwksURL                  *string `json:"jwks_url,omitempty"`
+	ExpectedAud              string  `json:"expected_aud"`
+	SubjectClaim             *string `json:"subject_claim,omitempty"`
+	IssuerType               string  `json:"issuer_type"`
+	SpiffeRefreshHintSeconds *int64  `json:"spiffe_refresh_hint_seconds,omitempty"`
+}
+
 type AddWebhookRequest struct {
 	EventName        string         `json:"event_name"`
 	EventDescription *string        `json:"event_description,omitempty"`
@@ -72,6 +84,17 @@ type CheckPermissionsInput struct {
 
 type CheckPermissionsResponse struct {
 	Results []*PermissionCheckResult `json:"results"`
+}
+
+type CreateServiceAccountRequest struct {
+	Name          string   `json:"name"`
+	Description   *string  `json:"description,omitempty"`
+	AllowedScopes []string `json:"allowed_scopes"`
+}
+
+type CreateServiceAccountResponse struct {
+	ServiceAccount *ServiceAccount `json:"service_account"`
+	ClientSecret   string          `json:"client_secret"`
 }
 
 type DeleteEmailTemplateRequest struct {
@@ -297,6 +320,15 @@ type ListPermissionsResponse struct {
 	Truncated   bool          `json:"truncated"`
 }
 
+type ListServiceAccountsRequest struct {
+	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+}
+
+type ListTrustedIssuersRequest struct {
+	ServiceAccountID *string           `json:"service_account_id,omitempty"`
+	Pagination       *PaginatedRequest `json:"pagination,omitempty"`
+}
+
 type ListWebhookLogRequest struct {
 	Pagination *PaginationRequest `json:"pagination,omitempty"`
 	WebhookID  *string            `json:"webhook_id,omitempty"`
@@ -437,6 +469,25 @@ type Response struct {
 	Message string `json:"message"`
 }
 
+type ServiceAccount struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Description   *string  `json:"description,omitempty"`
+	AllowedScopes []string `json:"allowed_scopes"`
+	IsActive      bool     `json:"is_active"`
+	CreatedAt     *int64   `json:"created_at,omitempty"`
+	UpdatedAt     *int64   `json:"updated_at,omitempty"`
+}
+
+type ServiceAccountRequest struct {
+	ID string `json:"id"`
+}
+
+type ServiceAccounts struct {
+	Pagination      *Pagination       `json:"pagination"`
+	ServiceAccounts []*ServiceAccount `json:"service_accounts"`
+}
+
 type SessionQueryRequest struct {
 	Roles             []string            `json:"roles,omitempty"`
 	Scope             []string            `json:"scope,omitempty"`
@@ -474,6 +525,31 @@ type TestEndpointRequest struct {
 type TestEndpointResponse struct {
 	HTTPStatus *int64  `json:"http_status,omitempty"`
 	Response   *string `json:"response,omitempty"`
+}
+
+type TrustedIssuer struct {
+	ID                       string  `json:"id"`
+	ServiceAccountID         string  `json:"service_account_id"`
+	Name                     string  `json:"name"`
+	IssuerURL                string  `json:"issuer_url"`
+	KeySourceType            string  `json:"key_source_type"`
+	JwksURL                  *string `json:"jwks_url,omitempty"`
+	ExpectedAud              string  `json:"expected_aud"`
+	SubjectClaim             string  `json:"subject_claim"`
+	IssuerType               string  `json:"issuer_type"`
+	IsActive                 bool    `json:"is_active"`
+	SpiffeRefreshHintSeconds *int64  `json:"spiffe_refresh_hint_seconds,omitempty"`
+	CreatedAt                *int64  `json:"created_at,omitempty"`
+	UpdatedAt                *int64  `json:"updated_at,omitempty"`
+}
+
+type TrustedIssuerRequest struct {
+	ID string `json:"id"`
+}
+
+type TrustedIssuers struct {
+	Pagination     *Pagination      `json:"pagination"`
+	TrustedIssuers []*TrustedIssuer `json:"trusted_issuers"`
 }
 
 type UpdateAccessRequest struct {
@@ -568,6 +644,23 @@ type UpdateProfileRequest struct {
 	Picture                  *string        `json:"picture,omitempty"`
 	IsMultiFactorAuthEnabled *bool          `json:"is_multi_factor_auth_enabled,omitempty"`
 	AppData                  map[string]any `json:"app_data,omitempty"`
+}
+
+type UpdateServiceAccountRequest struct {
+	ID            string   `json:"id"`
+	Name          *string  `json:"name,omitempty"`
+	Description   *string  `json:"description,omitempty"`
+	AllowedScopes []string `json:"allowed_scopes,omitempty"`
+	IsActive      *bool    `json:"is_active,omitempty"`
+}
+
+type UpdateTrustedIssuerRequest struct {
+	ID                       string  `json:"id"`
+	Name                     *string `json:"name,omitempty"`
+	JwksURL                  *string `json:"jwks_url,omitempty"`
+	ExpectedAud              *string `json:"expected_aud,omitempty"`
+	IsActive                 *bool   `json:"is_active,omitempty"`
+	SpiffeRefreshHintSeconds *int64  `json:"spiffe_refresh_hint_seconds,omitempty"`
 }
 
 type UpdateUserRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -300,6 +300,51 @@ type Webhooks {
   webhooks: [Webhook!]!
 }
 
+type ServiceAccount {
+  id: ID!
+  name: String!
+  description: String
+  allowed_scopes: [String!]!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+  # client_secret is NEVER returned here. It is returned exactly once in
+  # CreateServiceAccountResponse (creation and rotation) and never again.
+}
+
+type CreateServiceAccountResponse {
+  service_account: ServiceAccount!
+  # client_secret is returned ONCE at creation and ONCE at rotation. Store it
+  # securely; it can never be retrieved again.
+  client_secret: String!
+}
+
+type ServiceAccounts {
+  pagination: Pagination!
+  service_accounts: [ServiceAccount!]!
+}
+
+type TrustedIssuer {
+  id: ID!
+  service_account_id: String!
+  name: String!
+  issuer_url: String!
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  subject_claim: String!
+  issuer_type: String!
+  is_active: Boolean!
+  spiffe_refresh_hint_seconds: Int64
+  created_at: Int64
+  updated_at: Int64
+}
+
+type TrustedIssuers {
+  pagination: Pagination!
+  trusted_issuers: [TrustedIssuer!]!
+}
+
 type WebhookLog {
   id: ID!
   http_status: Int64
@@ -669,6 +714,62 @@ input WebhookRequest {
   id: ID!
 }
 
+input CreateServiceAccountRequest {
+  name: String!
+  description: String
+  # allowed_scopes MUST contain at least one non-empty scope after trimming.
+  allowed_scopes: [String!]!
+}
+
+input UpdateServiceAccountRequest {
+  id: ID!
+  name: String
+  description: String
+  allowed_scopes: [String!]
+  is_active: Boolean
+}
+
+input ServiceAccountRequest {
+  id: ID!
+}
+
+input ListServiceAccountsRequest {
+  pagination: PaginatedRequest
+}
+
+input AddTrustedIssuerRequest {
+  service_account_id: String!
+  name: String!
+  issuer_url: String!
+  # key_source_type: "oidc_discovery" | "static_jwks_url" | "spiffe_bundle_endpoint"
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  # subject_claim defaults to "sub" if omitted
+  subject_claim: String
+  # issuer_type: "kubernetes_sa" | "spiffe_jwt" | "oidc" | "cloud_oidc"
+  issuer_type: String!
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input UpdateTrustedIssuerRequest {
+  id: ID!
+  name: String
+  jwks_url: String
+  expected_aud: String
+  is_active: Boolean
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input TrustedIssuerRequest {
+  id: ID!
+}
+
+input ListTrustedIssuersRequest {
+  service_account_id: String
+  pagination: PaginatedRequest
+}
+
 input TestEndpointRequest {
   endpoint: String!
   event_name: String!
@@ -844,6 +945,15 @@ type Mutation {
   _add_webhook(params: AddWebhookRequest!): Response!
   _update_webhook(params: UpdateWebhookRequest!): Response!
   _delete_webhook(params: WebhookRequest!): Response!
+  # Service accounts (machine/workload identity)
+  _create_service_account(params: CreateServiceAccountRequest!): CreateServiceAccountResponse!
+  _update_service_account(params: UpdateServiceAccountRequest!): ServiceAccount!
+  _delete_service_account(params: ServiceAccountRequest!): Response!
+  _rotate_service_account_secret(params: ServiceAccountRequest!): CreateServiceAccountResponse!
+  # Trusted issuers (external JWT issuers bound to a service account)
+  _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
+  _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
+  _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -874,6 +984,12 @@ type Query {
   _webhook(params: WebhookRequest!): Webhook!
   _webhooks(params: PaginatedRequest): Webhooks!
   _webhook_logs(params: ListWebhookLogRequest): WebhookLogs!
+  # Service accounts (machine/workload identity)
+  _service_account(params: ServiceAccountRequest!): ServiceAccount!
+  _service_accounts(params: ListServiceAccountsRequest): ServiceAccounts!
+  # Trusted issuers
+  _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
+  _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -152,6 +152,41 @@ func (r *mutationResolver) DeleteWebhook(ctx context.Context, params model.Webho
 	return r.GraphQLProvider.DeleteWebhook(ctx, &params)
 }
 
+// CreateServiceAccount is the resolver for the _create_service_account field.
+func (r *mutationResolver) CreateServiceAccount(ctx context.Context, params model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, error) {
+	return r.GraphQLProvider.CreateServiceAccount(ctx, &params)
+}
+
+// UpdateServiceAccount is the resolver for the _update_service_account field.
+func (r *mutationResolver) UpdateServiceAccount(ctx context.Context, params model.UpdateServiceAccountRequest) (*model.ServiceAccount, error) {
+	return r.GraphQLProvider.UpdateServiceAccount(ctx, &params)
+}
+
+// DeleteServiceAccount is the resolver for the _delete_service_account field.
+func (r *mutationResolver) DeleteServiceAccount(ctx context.Context, params model.ServiceAccountRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteServiceAccount(ctx, &params)
+}
+
+// RotateServiceAccountSecret is the resolver for the _rotate_service_account_secret field.
+func (r *mutationResolver) RotateServiceAccountSecret(ctx context.Context, params model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, error) {
+	return r.GraphQLProvider.RotateServiceAccountSecret(ctx, &params)
+}
+
+// AddTrustedIssuer is the resolver for the _add_trusted_issuer field.
+func (r *mutationResolver) AddTrustedIssuer(ctx context.Context, params model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	return r.GraphQLProvider.AddTrustedIssuer(ctx, &params)
+}
+
+// UpdateTrustedIssuer is the resolver for the _update_trusted_issuer field.
+func (r *mutationResolver) UpdateTrustedIssuer(ctx context.Context, params model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	return r.GraphQLProvider.UpdateTrustedIssuer(ctx, &params)
+}
+
+// DeleteTrustedIssuer is the resolver for the _delete_trusted_issuer field.
+func (r *mutationResolver) DeleteTrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteTrustedIssuer(ctx, &params)
+}
+
 // TestEndpoint is the resolver for the _test_endpoint field.
 func (r *mutationResolver) TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error) {
 	return r.GraphQLProvider.TestEndpoint(ctx, &params)
@@ -260,6 +295,26 @@ func (r *queryResolver) Webhooks(ctx context.Context, params *model.PaginatedReq
 // WebhookLogs is the resolver for the _webhook_logs field.
 func (r *queryResolver) WebhookLogs(ctx context.Context, params *model.ListWebhookLogRequest) (*model.WebhookLogs, error) {
 	return r.GraphQLProvider.WebhookLogs(ctx, params)
+}
+
+// ServiceAccount is the resolver for the _service_account field.
+func (r *queryResolver) ServiceAccount(ctx context.Context, params model.ServiceAccountRequest) (*model.ServiceAccount, error) {
+	return r.GraphQLProvider.ServiceAccount(ctx, &params)
+}
+
+// ServiceAccounts is the resolver for the _service_accounts field.
+func (r *queryResolver) ServiceAccounts(ctx context.Context, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, error) {
+	return r.GraphQLProvider.ServiceAccounts(ctx, params)
+}
+
+// TrustedIssuer is the resolver for the _trusted_issuer field.
+func (r *queryResolver) TrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	return r.GraphQLProvider.TrustedIssuer(ctx, &params)
+}
+
+// TrustedIssuers is the resolver for the _trusted_issuers field.
+func (r *queryResolver) TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error) {
+	return r.GraphQLProvider.TrustedIssuers(ctx, params)
 }
 
 // EmailTemplates is the resolver for the _email_templates field.

--- a/internal/graphql/add_trusted_issuer.go
+++ b/internal/graphql/add_trusted_issuer.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// AddTrustedIssuer delegates to the transport-agnostic service layer. Resolver
+// is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) AddTrustedIssuer(ctx context.Context, params *model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().AddTrustedIssuer(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/create_service_account.go
+++ b/internal/graphql/create_service_account.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateServiceAccount delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) CreateServiceAccount(ctx context.Context, params *model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateServiceAccount(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/delete_service_account.go
+++ b/internal/graphql/delete_service_account.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// DeleteServiceAccount delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteServiceAccount(ctx context.Context, params *model.ServiceAccountRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteServiceAccount(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/delete_trusted_issuer.go
+++ b/internal/graphql/delete_trusted_issuer.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// DeleteTrustedIssuer delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteTrustedIssuer(ctx context.Context, params *model.TrustedIssuerRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteTrustedIssuer(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -206,6 +206,39 @@ type Provider interface {
 	// Webhooks is the method to list webhooks.
 	// Permissions: authorizer:admin
 	Webhooks(ctx context.Context, in *model.PaginatedRequest) (*model.Webhooks, error)
+	// CreateServiceAccount creates a machine/workload service account.
+	// Permissions: authorizer:admin
+	CreateServiceAccount(ctx context.Context, params *model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, error)
+	// UpdateServiceAccount updates a service account.
+	// Permissions: authorizer:admin
+	UpdateServiceAccount(ctx context.Context, params *model.UpdateServiceAccountRequest) (*model.ServiceAccount, error)
+	// DeleteServiceAccount deletes a service account (cascades to trusted issuers).
+	// Permissions: authorizer:admin
+	DeleteServiceAccount(ctx context.Context, params *model.ServiceAccountRequest) (*model.Response, error)
+	// RotateServiceAccountSecret rotates a service account's client secret.
+	// Permissions: authorizer:admin
+	RotateServiceAccountSecret(ctx context.Context, params *model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, error)
+	// ServiceAccount returns a single service account by id.
+	// Permissions: authorizer:admin
+	ServiceAccount(ctx context.Context, params *model.ServiceAccountRequest) (*model.ServiceAccount, error)
+	// ServiceAccounts lists service accounts.
+	// Permissions: authorizer:admin
+	ServiceAccounts(ctx context.Context, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, error)
+	// AddTrustedIssuer registers an external JWT issuer for a service account.
+	// Permissions: authorizer:admin
+	AddTrustedIssuer(ctx context.Context, params *model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error)
+	// UpdateTrustedIssuer updates a trusted issuer.
+	// Permissions: authorizer:admin
+	UpdateTrustedIssuer(ctx context.Context, params *model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error)
+	// DeleteTrustedIssuer deletes a trusted issuer.
+	// Permissions: authorizer:admin
+	DeleteTrustedIssuer(ctx context.Context, params *model.TrustedIssuerRequest) (*model.Response, error)
+	// TrustedIssuer returns a single trusted issuer by id.
+	// Permissions: authorizer:admin
+	TrustedIssuer(ctx context.Context, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, error)
+	// TrustedIssuers lists trusted issuers, optionally filtered by service account.
+	// Permissions: authorizer:admin
+	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
 	// FgaWriteModel installs a new fine-grained authorization model.
 	// Permissions: authorizer:admin
 	FgaWriteModel(ctx context.Context, params *model.FgaWriteModelInput) (*model.FgaModel, error)

--- a/internal/graphql/rotate_service_account_secret.go
+++ b/internal/graphql/rotate_service_account_secret.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// RotateServiceAccountSecret delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) RotateServiceAccountSecret(ctx context.Context, params *model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RotateServiceAccountSecret(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/service_account.go
+++ b/internal/graphql/service_account.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// ServiceAccount delegates to the transport-agnostic service layer. Resolver is
+// a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) ServiceAccount(ctx context.Context, params *model.ServiceAccountRequest) (*model.ServiceAccount, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ServiceAccount(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/service_accounts.go
+++ b/internal/graphql/service_accounts.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// ServiceAccounts delegates to the transport-agnostic service layer. Resolver is
+// a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) ServiceAccounts(ctx context.Context, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ServiceAccounts(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/trusted_issuer.go
+++ b/internal/graphql/trusted_issuer.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// TrustedIssuer delegates to the transport-agnostic service layer. Resolver is a
+// thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) TrustedIssuer(ctx context.Context, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().TrustedIssuer(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/trusted_issuers.go
+++ b/internal/graphql/trusted_issuers.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// TrustedIssuers delegates to the transport-agnostic service layer. Resolver is
+// a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().TrustedIssuers(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/update_service_account.go
+++ b/internal/graphql/update_service_account.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// UpdateServiceAccount delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) UpdateServiceAccount(ctx context.Context, params *model.UpdateServiceAccountRequest) (*model.ServiceAccount, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateServiceAccount(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/update_trusted_issuer.go
+++ b/internal/graphql/update_trusted_issuer.go
@@ -1,0 +1,25 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// UpdateTrustedIssuer delegates to the transport-agnostic service layer.
+// Resolver is a thin transport adapter.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) UpdateTrustedIssuer(ctx context.Context, params *model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateTrustedIssuer(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/integration_tests/service_account_test.go
+++ b/internal/integration_tests/service_account_test.go
@@ -1,0 +1,179 @@
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+func TestServiceAccountAdmin(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	t.Run("should reject non-super-admin caller", func(t *testing.T) {
+		// No admin cookie set yet on the fresh request.
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "unauthorized",
+			AllowedScopes: []string{"read"},
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	// Everything below runs as super-admin.
+	setAdminCookie(t, ts)
+
+	t.Run("should reject empty/whitespace-only allowed_scopes", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "empty-scopes-" + uuid.NewString(),
+			AllowedScopes: []string{"  ", "", "\t"},
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("should create and return the plaintext secret exactly once", func(t *testing.T) {
+		name := "payments-worker-" + uuid.NewString()
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:        name,
+			Description: refs.NewStringRef("payments background worker"),
+			// Duplicates and whitespace are normalized away.
+			AllowedScopes: []string{"read", " write ", "read", ""},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.NotNil(t, res.ServiceAccount)
+
+		// Plaintext secret is returned once and is NOT the stored hash.
+		require.NotEmpty(t, res.ClientSecret)
+		assert.Equal(t, name, res.ServiceAccount.Name)
+		assert.True(t, res.ServiceAccount.IsActive)
+		assert.ElementsMatch(t, []string{"read", "write"}, res.ServiceAccount.AllowedScopes)
+
+		// Storage holds only a bcrypt hash (cost 12) of the plaintext — never the
+		// plaintext itself.
+		stored, err := ts.StorageProvider.GetServiceAccountByID(ctx, res.ServiceAccount.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, res.ClientSecret, stored.ClientSecret)
+		cost, err := bcrypt.Cost([]byte(stored.ClientSecret))
+		require.NoError(t, err)
+		assert.Equal(t, 12, cost)
+		require.NoError(t, bcrypt.CompareHashAndPassword([]byte(stored.ClientSecret), []byte(res.ClientSecret)))
+		assert.Equal(t, "read,write", stored.AllowedScopes)
+
+		// A subsequent fetch returns the account but has no way to surface the
+		// secret — the model type has no client_secret field by design.
+		fetched, err := ts.GraphQLProvider.ServiceAccount(ctx, &model.ServiceAccountRequest{ID: res.ServiceAccount.ID})
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		assert.Equal(t, name, fetched.Name)
+	})
+
+	t.Run("rotate changes the stored hash and invalidates the old secret", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "rotate-me-" + uuid.NewString(),
+			AllowedScopes: []string{"read"},
+		})
+		require.NoError(t, err)
+		oldPlaintext := res.ClientSecret
+		id := res.ServiceAccount.ID
+
+		before, err := ts.StorageProvider.GetServiceAccountByID(ctx, id)
+		require.NoError(t, err)
+		oldHash := before.ClientSecret
+
+		rotated, err := ts.GraphQLProvider.RotateServiceAccountSecret(ctx, &model.ServiceAccountRequest{ID: id})
+		require.NoError(t, err)
+		require.NotNil(t, rotated)
+		newPlaintext := rotated.ClientSecret
+		require.NotEmpty(t, newPlaintext)
+		assert.NotEqual(t, oldPlaintext, newPlaintext)
+
+		after, err := ts.StorageProvider.GetServiceAccountByID(ctx, id)
+		require.NoError(t, err)
+		assert.NotEqual(t, oldHash, after.ClientSecret, "stored hash must change on rotation")
+
+		// Old plaintext no longer validates against the new hash; new one does.
+		assert.Error(t, bcrypt.CompareHashAndPassword([]byte(after.ClientSecret), []byte(oldPlaintext)))
+		require.NoError(t, bcrypt.CompareHashAndPassword([]byte(after.ClientSecret), []byte(newPlaintext)))
+	})
+
+	t.Run("update mutates only supplied fields and preserves the rest", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "partial-update-" + uuid.NewString(),
+			Description:   refs.NewStringRef("original description"),
+			AllowedScopes: []string{"read", "write"},
+		})
+		require.NoError(t, err)
+		id := res.ServiceAccount.ID
+
+		// Update only the name.
+		updated, err := ts.GraphQLProvider.UpdateServiceAccount(ctx, &model.UpdateServiceAccountRequest{
+			ID:   id,
+			Name: refs.NewStringRef("renamed"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "renamed", updated.Name)
+		// Untouched columns are preserved.
+		require.NotNil(t, updated.Description)
+		assert.Equal(t, "original description", *updated.Description)
+		assert.ElementsMatch(t, []string{"read", "write"}, updated.AllowedScopes)
+		assert.True(t, updated.IsActive)
+
+		// Toggle is_active off without touching anything else.
+		deactivated, err := ts.GraphQLProvider.UpdateServiceAccount(ctx, &model.UpdateServiceAccountRequest{
+			ID:       id,
+			IsActive: refs.NewBoolRef(false),
+		})
+		require.NoError(t, err)
+		assert.False(t, deactivated.IsActive)
+		assert.Equal(t, "renamed", deactivated.Name)
+	})
+
+	t.Run("update rejects collapsing allowed_scopes to empty", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "no-empty-update-" + uuid.NewString(),
+			AllowedScopes: []string{"read"},
+		})
+		require.NoError(t, err)
+
+		updated, err := ts.GraphQLProvider.UpdateServiceAccount(ctx, &model.UpdateServiceAccountRequest{
+			ID:            res.ServiceAccount.ID,
+			AllowedScopes: []string{" ", ""},
+		})
+		require.Error(t, err)
+		require.Nil(t, updated)
+	})
+
+	t.Run("list returns created accounts without exposing secrets", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.ServiceAccounts(ctx, &model.ListServiceAccountsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.NotNil(t, res.Pagination)
+		assert.Greater(t, len(res.ServiceAccounts), 0)
+	})
+
+	t.Run("delete removes the account", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "delete-me-" + uuid.NewString(),
+			AllowedScopes: []string{"read"},
+		})
+		require.NoError(t, err)
+		id := res.ServiceAccount.ID
+
+		delRes, err := ts.GraphQLProvider.DeleteServiceAccount(ctx, &model.ServiceAccountRequest{ID: id})
+		require.NoError(t, err)
+		require.NotNil(t, delRes)
+
+		_, err = ts.StorageProvider.GetServiceAccountByID(ctx, id)
+		require.Error(t, err)
+	})
+}

--- a/internal/integration_tests/trusted_issuer_test.go
+++ b/internal/integration_tests/trusted_issuer_test.go
@@ -94,6 +94,18 @@ func TestTrustedIssuerAdmin(t *testing.T) {
 		assert.Equal(t, saID, updated.ServiceAccountID)
 	})
 
+	t.Run("update rejects blanking expected_aud", func(t *testing.T) {
+		saID := createSA(t)
+		created, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))
+		require.NoError(t, err)
+
+		_, err = ts.GraphQLProvider.UpdateTrustedIssuer(ctx, &model.UpdateTrustedIssuerRequest{
+			ID:          created.ID,
+			ExpectedAud: refs.NewStringRef("  "),
+		})
+		require.Error(t, err)
+	})
+
 	t.Run("list filters by service_account_id", func(t *testing.T) {
 		saID := createSA(t)
 		_, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))

--- a/internal/integration_tests/trusted_issuer_test.go
+++ b/internal/integration_tests/trusted_issuer_test.go
@@ -1,0 +1,132 @@
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+func TestTrustedIssuerAdmin(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	// Helper: create a service account as admin and return its id.
+	createSA := func(t *testing.T) string {
+		t.Helper()
+		res, err := ts.GraphQLProvider.CreateServiceAccount(ctx, &model.CreateServiceAccountRequest{
+			Name:          "issuer-parent-" + uuid.NewString(),
+			AllowedScopes: []string{"read"},
+		})
+		require.NoError(t, err)
+		return res.ServiceAccount.ID
+	}
+
+	newIssuerReq := func(saID string) *model.AddTrustedIssuerRequest {
+		return &model.AddTrustedIssuerRequest{
+			ServiceAccountID: saID,
+			Name:             "prod-k8s",
+			IssuerURL:        "https://issuer-" + uuid.NewString() + ".example.org",
+			KeySourceType:    "oidc_discovery",
+			ExpectedAud:      "https://authorizer.example.org",
+			IssuerType:       "kubernetes_sa",
+		}
+	}
+
+	t.Run("should reject non-super-admin caller", func(t *testing.T) {
+		// Fresh context without the admin cookie.
+		_, freshCtx := createContext(ts)
+		res, err := ts.GraphQLProvider.AddTrustedIssuer(freshCtx, newIssuerReq(uuid.NewString()))
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	setAdminCookie(t, ts)
+
+	t.Run("should reject an issuer bound to a missing service account", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(uuid.NewString()))
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("should add an issuer and default subject_claim to sub", func(t *testing.T) {
+		saID := createSA(t)
+		res, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, saID, res.ServiceAccountID)
+		assert.Equal(t, "sub", res.SubjectClaim)
+		assert.True(t, res.IsActive)
+
+		fetched, err := ts.GraphQLProvider.TrustedIssuer(ctx, &model.TrustedIssuerRequest{ID: res.ID})
+		require.NoError(t, err)
+		assert.Equal(t, res.ID, fetched.ID)
+	})
+
+	t.Run("should honor an explicit subject_claim", func(t *testing.T) {
+		saID := createSA(t)
+		reqIssuer := newIssuerReq(saID)
+		reqIssuer.SubjectClaim = refs.NewStringRef("email")
+		res, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, reqIssuer)
+		require.NoError(t, err)
+		assert.Equal(t, "email", res.SubjectClaim)
+	})
+
+	t.Run("update mutates only supplied fields", func(t *testing.T) {
+		saID := createSA(t)
+		created, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))
+		require.NoError(t, err)
+
+		updated, err := ts.GraphQLProvider.UpdateTrustedIssuer(ctx, &model.UpdateTrustedIssuerRequest{
+			ID:       created.ID,
+			IsActive: refs.NewBoolRef(false),
+		})
+		require.NoError(t, err)
+		assert.False(t, updated.IsActive)
+		// Untouched columns preserved.
+		assert.Equal(t, created.IssuerURL, updated.IssuerURL)
+		assert.Equal(t, created.ExpectedAud, updated.ExpectedAud)
+		assert.Equal(t, saID, updated.ServiceAccountID)
+	})
+
+	t.Run("list filters by service_account_id", func(t *testing.T) {
+		saID := createSA(t)
+		_, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))
+		require.NoError(t, err)
+
+		res, err := ts.GraphQLProvider.TrustedIssuers(ctx, &model.ListTrustedIssuersRequest{
+			ServiceAccountID: refs.NewStringRef(saID),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, 1, len(res.TrustedIssuers))
+		assert.Equal(t, saID, res.TrustedIssuers[0].ServiceAccountID)
+	})
+
+	t.Run("deleting a service account cascades to its trusted issuers", func(t *testing.T) {
+		saID := createSA(t)
+		issuer, err := ts.GraphQLProvider.AddTrustedIssuer(ctx, newIssuerReq(saID))
+		require.NoError(t, err)
+
+		// Sanity: issuer exists before delete.
+		_, err = ts.StorageProvider.GetTrustedIssuerByID(ctx, issuer.ID)
+		require.NoError(t, err)
+
+		delRes, err := ts.GraphQLProvider.DeleteServiceAccount(ctx, &model.ServiceAccountRequest{ID: saID})
+		require.NoError(t, err)
+		require.NotNil(t, delRes)
+
+		// The trusted issuer must be gone — no orphan left behind.
+		_, err = ts.StorageProvider.GetTrustedIssuerByID(ctx, issuer.ID)
+		require.Error(t, err)
+
+		listRes, _, err := ts.StorageProvider.ListTrustedIssuers(ctx, saID, &model.Pagination{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(listRes))
+	})
+}

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -48,6 +48,21 @@ type AdminProvider interface {
 	WebhookLogs(ctx context.Context, meta RequestMetadata, params *model.ListWebhookLogRequest) (*model.WebhookLogs, *ResponseSideEffects, error)
 	TestEndpoint(ctx context.Context, meta RequestMetadata, params *model.TestEndpointRequest) (*model.TestEndpointResponse, *ResponseSideEffects, error)
 
+	// Service accounts.
+	CreateServiceAccount(ctx context.Context, meta RequestMetadata, params *model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, *ResponseSideEffects, error)
+	UpdateServiceAccount(ctx context.Context, meta RequestMetadata, params *model.UpdateServiceAccountRequest) (*model.ServiceAccount, *ResponseSideEffects, error)
+	DeleteServiceAccount(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.Response, *ResponseSideEffects, error)
+	RotateServiceAccountSecret(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, *ResponseSideEffects, error)
+	ServiceAccount(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.ServiceAccount, *ResponseSideEffects, error)
+	ServiceAccounts(ctx context.Context, meta RequestMetadata, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, *ResponseSideEffects, error)
+
+	// Trusted issuers.
+	AddTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.AddTrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error)
+	UpdateTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error)
+	DeleteTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.Response, *ResponseSideEffects, error)
+	TrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error)
+	TrustedIssuers(ctx context.Context, meta RequestMetadata, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, *ResponseSideEffects, error)
+
 	// Email templates.
 	AddEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.AddEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
 	UpdateEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.UpdateEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)

--- a/internal/service/admin_service_accounts.go
+++ b/internal/service/admin_service_accounts.go
@@ -1,0 +1,309 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	b64 "encoding/base64"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// serviceAccountSecretBytes is the entropy of a generated client secret.
+// 32 bytes (256 bits) base64url-encoded — well above bcrypt's 72-byte input cap.
+const serviceAccountSecretBytes = 32
+
+// serviceAccountSecretCost is the bcrypt cost used for hashing service account
+// client secrets. The schema doc comment on ClientSecret commits to cost 12 —
+// this MUST stay 12, not bcrypt.DefaultCost (10).
+const serviceAccountSecretCost = 12
+
+// generateServiceAccountSecret returns a cryptographically random, URL-safe
+// plaintext client secret. Mirrors the PKCE verifier generation in
+// internal/utils/pkce.go.
+func generateServiceAccountSecret() (string, error) {
+	b := make([]byte, serviceAccountSecretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate client secret: %w", err)
+	}
+	return strings.Trim(b64.URLEncoding.EncodeToString(b), "="), nil
+}
+
+// normalizeScopes trims whitespace, drops empty segments, and dedupes the
+// requested scopes, returning the canonical comma-separated form for storage.
+// An all-empty/whitespace input yields "" — callers MUST reject that, since an
+// empty AllowedScopes is DENY-ALL and must never be persisted (schema §
+// AllowedScopes comment).
+func normalizeScopes(scopes []string) string {
+	seen := make(map[string]struct{}, len(scopes))
+	out := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, ",")
+}
+
+// CreateServiceAccount provisions a new machine/workload identity. It generates
+// a random client secret, stores only its bcrypt hash (cost 12), and returns
+// the plaintext exactly once. Requires super-admin auth.
+func (p *provider) CreateServiceAccount(ctx context.Context, meta RequestMetadata, params *model.CreateServiceAccountRequest) (*model.CreateServiceAccountResponse, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateServiceAccount").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if strings.TrimSpace(params.Name) == "" {
+		log.Debug().Msg("name is required")
+		return nil, nil, fmt.Errorf("name is required")
+	}
+
+	scopes := normalizeScopes(params.AllowedScopes)
+	if scopes == "" {
+		log.Debug().Msg("empty allowed_scopes rejected")
+		return nil, nil, fmt.Errorf("at least one allowed scope is required")
+	}
+
+	secret, err := generateServiceAccountSecret()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to generate client secret")
+		return nil, nil, err
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), serviceAccountSecretCost)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to hash client secret")
+		return nil, nil, err
+	}
+
+	sa, err := p.StorageProvider.AddServiceAccount(ctx, &schemas.ServiceAccount{
+		Name:          strings.TrimSpace(params.Name),
+		Description:   params.Description,
+		ClientSecret:  string(hash),
+		AllowedScopes: scopes,
+		// Set IsActive explicitly — never rely on the GORM `default:true` column
+		// default (a future pre-disabled create path would silently come back
+		// active). There is no create-as-disabled feature in Phase 1.
+		IsActive: true,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to add service account")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditServiceAccountCreatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeServiceAccount,
+		ResourceID:   sa.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.CreateServiceAccountResponse{
+		ServiceAccount: sa.AsAPIServiceAccount(),
+		ClientSecret:   secret,
+	}, nil, nil
+}
+
+// UpdateServiceAccount mutates only the fields present in params (load-then-
+// mutate, so the storage Save does not blank untouched columns). It never
+// touches the client secret. Requires super-admin auth.
+func (p *provider) UpdateServiceAccount(ctx context.Context, meta RequestMetadata, params *model.UpdateServiceAccountRequest) (*model.ServiceAccount, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "UpdateServiceAccount").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	sa, err := p.StorageProvider.GetServiceAccountByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetServiceAccountByID")
+		return nil, nil, err
+	}
+
+	if params.Name != nil {
+		sa.Name = strings.TrimSpace(*params.Name)
+	}
+	if params.Description != nil {
+		sa.Description = params.Description
+	}
+	// A non-nil slice means the client sent allowed_scopes; normalize and reject
+	// if it collapses to empty (defense-in-depth against a zero-scope account).
+	if params.AllowedScopes != nil {
+		scopes := normalizeScopes(params.AllowedScopes)
+		if scopes == "" {
+			log.Debug().Msg("empty allowed_scopes rejected")
+			return nil, nil, fmt.Errorf("at least one allowed scope is required")
+		}
+		sa.AllowedScopes = scopes
+	}
+	if params.IsActive != nil {
+		sa.IsActive = *params.IsActive
+	}
+
+	updated, err := p.StorageProvider.UpdateServiceAccount(ctx, sa)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateServiceAccount")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditServiceAccountUpdatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeServiceAccount,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return updated.AsAPIServiceAccount(), nil, nil
+}
+
+// DeleteServiceAccount removes a service account. The storage layer cascades to
+// the account's TrustedIssuers. Requires super-admin auth.
+func (p *provider) DeleteServiceAccount(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteServiceAccount").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if params.ID == "" {
+		log.Debug().Msg("service account ID required")
+		return nil, nil, fmt.Errorf("service account ID required")
+	}
+
+	sa, err := p.StorageProvider.GetServiceAccountByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetServiceAccountByID")
+		return nil, nil, err
+	}
+
+	if err := p.StorageProvider.DeleteServiceAccount(ctx, sa); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteServiceAccount")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditServiceAccountDeletedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeServiceAccount,
+		ResourceID:   params.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.Response{
+		Message: "Service account deleted successfully",
+	}, nil, nil
+}
+
+// RotateServiceAccountSecret generates a fresh client secret, replaces the
+// stored bcrypt hash (cost 12), and returns the new plaintext exactly once.
+// The old secret stops validating immediately. Requires super-admin auth.
+func (p *provider) RotateServiceAccountSecret(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.CreateServiceAccountResponse, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "RotateServiceAccountSecret").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if params.ID == "" {
+		log.Debug().Msg("service account ID required")
+		return nil, nil, fmt.Errorf("service account ID required")
+	}
+
+	sa, err := p.StorageProvider.GetServiceAccountByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetServiceAccountByID")
+		return nil, nil, err
+	}
+
+	secret, err := generateServiceAccountSecret()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to generate client secret")
+		return nil, nil, err
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), serviceAccountSecretCost)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to hash client secret")
+		return nil, nil, err
+	}
+	sa.ClientSecret = string(hash)
+
+	updated, err := p.StorageProvider.UpdateServiceAccount(ctx, sa)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateServiceAccount")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditServiceAccountSecretRotatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeServiceAccount,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.CreateServiceAccountResponse{
+		ServiceAccount: updated.AsAPIServiceAccount(),
+		ClientSecret:   secret,
+	}, nil, nil
+}
+
+// ServiceAccount returns a single service account by id. The client secret is
+// never surfaced. Requires super-admin auth.
+func (p *provider) ServiceAccount(ctx context.Context, meta RequestMetadata, params *model.ServiceAccountRequest) (*model.ServiceAccount, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "ServiceAccount").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	sa, err := p.StorageProvider.GetServiceAccountByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetServiceAccountByID")
+		return nil, nil, err
+	}
+	return sa.AsAPIServiceAccount(), nil, nil
+}
+
+// ServiceAccounts returns a paginated list of service accounts. Client secrets
+// are never surfaced. Requires super-admin auth.
+func (p *provider) ServiceAccounts(ctx context.Context, meta RequestMetadata, params *model.ListServiceAccountsRequest) (*model.ServiceAccounts, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "ServiceAccounts").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	var paginatedReq *model.PaginatedRequest
+	if params != nil {
+		paginatedReq = params.Pagination
+	}
+	pagination := utils.GetPagination(paginatedReq)
+
+	sas, pagination, err := p.StorageProvider.ListServiceAccounts(ctx, pagination)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed ListServiceAccounts")
+		return nil, nil, err
+	}
+	res := make([]*model.ServiceAccount, len(sas))
+	for i, sa := range sas {
+		res[i] = sa.AsAPIServiceAccount()
+	}
+	return &model.ServiceAccounts{
+		Pagination:      pagination,
+		ServiceAccounts: res,
+	}, nil, nil
+}

--- a/internal/service/admin_trusted_issuers.go
+++ b/internal/service/admin_trusted_issuers.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// defaultSubjectClaim is the JWT claim used to identify the workload when the
+// admin does not specify one (spec §6 AddTrustedIssuerRequest comment).
+const defaultSubjectClaim = "sub"
+
+// AddTrustedIssuer registers an external JWT issuer for a service account.
+// subject_claim defaults to "sub" when omitted. Requires super-admin auth.
+func (p *provider) AddTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.AddTrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "AddTrustedIssuer").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if strings.TrimSpace(params.ServiceAccountID) == "" {
+		return nil, nil, fmt.Errorf("service_account_id is required")
+	}
+	if strings.TrimSpace(params.Name) == "" {
+		return nil, nil, fmt.Errorf("name is required")
+	}
+	if strings.TrimSpace(params.IssuerURL) == "" {
+		return nil, nil, fmt.Errorf("issuer_url is required")
+	}
+	if strings.TrimSpace(params.KeySourceType) == "" {
+		return nil, nil, fmt.Errorf("key_source_type is required")
+	}
+	if strings.TrimSpace(params.ExpectedAud) == "" {
+		return nil, nil, fmt.Errorf("expected_aud is required")
+	}
+	if strings.TrimSpace(params.IssuerType) == "" {
+		return nil, nil, fmt.Errorf("issuer_type is required")
+	}
+
+	// Reject issuers bound to a non-existent service account — otherwise a typo
+	// creates an orphan that can never be reached via the parent.
+	if _, err := p.StorageProvider.GetServiceAccountByID(ctx, params.ServiceAccountID); err != nil {
+		log.Debug().Err(err).Str("service_account_id", params.ServiceAccountID).Msg("service account not found")
+		return nil, nil, fmt.Errorf("service account not found: %s", params.ServiceAccountID)
+	}
+
+	subjectClaim := defaultSubjectClaim
+	if params.SubjectClaim != nil && strings.TrimSpace(*params.SubjectClaim) != "" {
+		subjectClaim = strings.TrimSpace(*params.SubjectClaim)
+	}
+
+	issuer, err := p.StorageProvider.AddTrustedIssuer(ctx, &schemas.TrustedIssuer{
+		ServiceAccountID: params.ServiceAccountID,
+		Name:             strings.TrimSpace(params.Name),
+		IssuerURL:        params.IssuerURL,
+		KeySourceType:    params.KeySourceType,
+		JWKSUrl:          params.JwksURL,
+		ExpectedAud:      params.ExpectedAud,
+		SubjectClaim:     subjectClaim,
+		IssuerType:       params.IssuerType,
+		// Set explicitly rather than relying on the GORM column default so NoSQL
+		// providers (no default support) persist the same values.
+		AuthMethod:               "jwt_assertion",
+		IsActive:                 true,
+		SpiffeRefreshHintSeconds: refs.Int64Value(params.SpiffeRefreshHintSeconds),
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed AddTrustedIssuer")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditTrustedIssuerCreatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeTrustedIssuer,
+		ResourceID:   issuer.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return issuer.AsAPITrustedIssuer(), nil, nil
+}
+
+// UpdateTrustedIssuer mutates only the fields present in params (load-then-
+// mutate, so the storage Save does not blank untouched columns). Requires
+// super-admin auth.
+func (p *provider) UpdateTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "UpdateTrustedIssuer").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
+		return nil, nil, err
+	}
+
+	if params.Name != nil {
+		issuer.Name = strings.TrimSpace(*params.Name)
+	}
+	if params.JwksURL != nil {
+		issuer.JWKSUrl = params.JwksURL
+	}
+	if params.ExpectedAud != nil {
+		issuer.ExpectedAud = *params.ExpectedAud
+	}
+	if params.IsActive != nil {
+		issuer.IsActive = *params.IsActive
+	}
+	if params.SpiffeRefreshHintSeconds != nil {
+		issuer.SpiffeRefreshHintSeconds = *params.SpiffeRefreshHintSeconds
+	}
+
+	updated, err := p.StorageProvider.UpdateTrustedIssuer(ctx, issuer)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateTrustedIssuer")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditTrustedIssuerUpdatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeTrustedIssuer,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return updated.AsAPITrustedIssuer(), nil, nil
+}
+
+// DeleteTrustedIssuer removes a trusted issuer by id. Requires super-admin auth.
+func (p *provider) DeleteTrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteTrustedIssuer").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if params.ID == "" {
+		log.Debug().Msg("trusted issuer ID required")
+		return nil, nil, fmt.Errorf("trusted issuer ID required")
+	}
+
+	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
+		return nil, nil, err
+	}
+
+	if err := p.StorageProvider.DeleteTrustedIssuer(ctx, issuer); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteTrustedIssuer")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditTrustedIssuerDeletedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeTrustedIssuer,
+		ResourceID:   params.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.Response{
+		Message: "Trusted issuer deleted successfully",
+	}, nil, nil
+}
+
+// TrustedIssuer returns a single trusted issuer by id. Requires super-admin auth.
+func (p *provider) TrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "TrustedIssuer").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
+		return nil, nil, err
+	}
+	return issuer.AsAPITrustedIssuer(), nil, nil
+}
+
+// TrustedIssuers returns a paginated list of trusted issuers, optionally
+// filtered by service_account_id. Requires super-admin auth.
+func (p *provider) TrustedIssuers(ctx context.Context, meta RequestMetadata, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "TrustedIssuers").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	var paginatedReq *model.PaginatedRequest
+	var serviceAccountID string
+	if params != nil {
+		paginatedReq = params.Pagination
+		serviceAccountID = refs.StringValue(params.ServiceAccountID)
+	}
+	pagination := utils.GetPagination(paginatedReq)
+
+	issuers, pagination, err := p.StorageProvider.ListTrustedIssuers(ctx, serviceAccountID, pagination)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed ListTrustedIssuers")
+		return nil, nil, err
+	}
+	res := make([]*model.TrustedIssuer, len(issuers))
+	for i, issuer := range issuers {
+		res[i] = issuer.AsAPITrustedIssuer()
+	}
+	return &model.TrustedIssuers{
+		Pagination:     pagination,
+		TrustedIssuers: res,
+	}, nil, nil
+}

--- a/internal/service/admin_trusted_issuers.go
+++ b/internal/service/admin_trusted_issuers.go
@@ -110,6 +110,10 @@ func (p *provider) UpdateTrustedIssuer(ctx context.Context, meta RequestMetadata
 		issuer.JWKSUrl = params.JwksURL
 	}
 	if params.ExpectedAud != nil {
+		if strings.TrimSpace(*params.ExpectedAud) == "" {
+			log.Debug().Msg("expected_aud cannot be empty")
+			return nil, nil, fmt.Errorf("expected_aud cannot be empty")
+		}
 		issuer.ExpectedAud = *params.ExpectedAud
 	}
 	if params.IsActive != nil {

--- a/internal/storage/schemas/service_account.go
+++ b/internal/storage/schemas/service_account.go
@@ -1,5 +1,12 @@
 package schemas
 
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
 // ServiceAccount is the machine/workload identity primitive used for the
 // OAuth2 client_credentials grant and workload identity federation.
 //
@@ -52,4 +59,30 @@ type ServiceAccount struct {
 
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPIServiceAccount converts the storage record into the GraphQL model.
+// It never exposes ClientSecret — there is no client_secret field on
+// model.ServiceAccount by design; the plaintext is surfaced only once via
+// CreateServiceAccountResponse at creation/rotation.
+func (s *ServiceAccount) AsAPIServiceAccount() *model.ServiceAccount {
+	id := s.ID
+	if strings.Contains(id, Collections.ServiceAccount+"/") {
+		id = strings.TrimPrefix(id, Collections.ServiceAccount+"/")
+	}
+	scopes := []string{}
+	for _, sc := range strings.Split(s.AllowedScopes, ",") {
+		if sc = strings.TrimSpace(sc); sc != "" {
+			scopes = append(scopes, sc)
+		}
+	}
+	return &model.ServiceAccount{
+		ID:            id,
+		Name:          s.Name,
+		Description:   s.Description,
+		AllowedScopes: scopes,
+		IsActive:      s.IsActive,
+		CreatedAt:     refs.NewInt64Ref(s.CreatedAt),
+		UpdatedAt:     refs.NewInt64Ref(s.UpdatedAt),
+	}
 }

--- a/internal/storage/schemas/trusted_issuer.go
+++ b/internal/storage/schemas/trusted_issuer.go
@@ -1,5 +1,12 @@
 package schemas
 
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
 // TrustedIssuer registers an external JWT issuer whose tokens are accepted as
 // client credentials for a ServiceAccount (RFC 7523 client_assertion flow).
 //
@@ -110,4 +117,29 @@ type TrustedIssuer struct {
 
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPITrustedIssuer converts the storage record into the GraphQL model. The
+// Phase 4/5/6 fields (EnableTokenReview, KubernetesAPIServerURL, SPIFFE/mTLS
+// proxy) are intentionally not surfaced in the Phase 1 admin API.
+func (t *TrustedIssuer) AsAPITrustedIssuer() *model.TrustedIssuer {
+	id := t.ID
+	if strings.Contains(id, Collections.TrustedIssuer+"/") {
+		id = strings.TrimPrefix(id, Collections.TrustedIssuer+"/")
+	}
+	return &model.TrustedIssuer{
+		ID:                       id,
+		ServiceAccountID:         t.ServiceAccountID,
+		Name:                     t.Name,
+		IssuerURL:                t.IssuerURL,
+		KeySourceType:            t.KeySourceType,
+		JwksURL:                  t.JWKSUrl,
+		ExpectedAud:              t.ExpectedAud,
+		SubjectClaim:             t.SubjectClaim,
+		IssuerType:               t.IssuerType,
+		IsActive:                 t.IsActive,
+		SpiffeRefreshHintSeconds: refs.NewInt64Ref(t.SpiffeRefreshHintSeconds),
+		CreatedAt:                refs.NewInt64Ref(t.CreatedAt),
+		UpdatedAt:                refs.NewInt64Ref(t.UpdatedAt),
+	}
 }


### PR DESCRIPTION
## Summary

Adds the transport-agnostic service layer and admin GraphQL API for `ServiceAccount` and `TrustedIssuer`, on top of the storage CRUD landed in #641/#642. Follows the repo's `admin_webhooks.go` / `add_webhook.go` idiom exactly — thin GraphQL resolvers delegating to `internal/service/`.

**Chains on:** #642 (merged into this integration branch)

## What's in this PR

**Service layer**
- `internal/service/admin_service_accounts.go` — Create/Update/Delete/Rotate/Get/List, plus `generateServiceAccountSecret`/`normalizeScopes` helpers
- `internal/service/admin_trusted_issuers.go` — Add/Update/Delete/Get/List

**GraphQL** (`internal/graph/schema.graphqls`, regenerated via `make generate-graphql`)
- Types: `ServiceAccount` (no client_secret field), `CreateServiceAccountResponse` (the only place client_secret appears — reused by rotate), `ServiceAccounts`, `TrustedIssuer`, `TrustedIssuers`
- Mutations: `_create_service_account`, `_update_service_account`, `_delete_service_account`, `_rotate_service_account_secret`, `_add_trusted_issuer`, `_update_trusted_issuer`, `_delete_trusted_issuer`
- Queries: `_service_account`, `_service_accounts`, `_trusted_issuer`, `_trusted_issuers`
- 11 thin resolver files in `internal/graphql/`

**Schema conversions:** `AsAPIServiceAccount()` / `AsAPITrustedIssuer()` on the storage schemas (deferred from #641/#642 since the GraphQL model types didn't exist yet).

## Security-critical invariants

- Client secret: 32 random bytes (`crypto/rand`) → base64url, hashed with `bcrypt` **cost 12** (not the package default of 10) before storage.
- One-time reveal: plaintext returned only from create and rotate; `model.ServiceAccount` has no client_secret field, so no read path can leak it.
- `IsActive` set explicitly `true` on create — does not rely on the GORM column default.
- Empty/whitespace-only `allowed_scopes` rejected on create and update (normalized: trimmed, deduped, empty segments dropped).
- Update is load-then-mutate (satisfies the storage layer's partial-struct guard).
- Delete cascades to trusted issuers (verified by test).
- `AddTrustedIssuer` defaults `subject_claim` to `"sub"` and rejects binding to a non-existent service account.

## PR chain

```
PR 1 — schema + interface + SQL + constants     merged → feat/workload-identity-phase1  ✅ #641
PR 2 — NoSQL provider implementations           merged → feat/workload-identity-phase1  ✅ #642
PR 3 — service layer + admin GraphQL API        🔄 this PR
PR 4 — gRPC admin RPCs
PR 5 — client_credentials grant + tests
```

## Test plan

- [x] `make generate-graphql`
- [x] `make fmt` (Go only — reverted an unrelated frontend reformat side effect)
- [x] `make lint` — lint-go: 0 issues (lint-ts fails on pre-existing frontend prettier drift unrelated to this PR)
- [x] New integration tests: `TestServiceAccountAdmin` (8 subtests), `TestTrustedIssuerAdmin` (7 subtests) — cover secret one-time-reveal, bcrypt cost 12, cascade delete, empty-scope rejection, non-admin rejection
- [x] Full `make test-sqlite` — pass