### PR TITLE
feat(m2m): client_credentials grant at /oauth/token [Phase 1 — PR 5/5]

### DIFF
--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -6,6 +6,9 @@ const (
 	AuditActorTypeUser = "user"
 	// AuditActorTypeAdmin identifies an admin as the audit actor.
 	AuditActorTypeAdmin = "admin"
+	// AuditActorTypeServiceAccount identifies a machine/workload service account
+	// as the audit actor (client_credentials grant, RFC 6749 §4.4).
+	AuditActorTypeServiceAccount = "service_account"
 )
 
 // Audit resource type constants identify the type of resource affected by an auditable action.

--- a/internal/constants/auth_methods.go
+++ b/internal/constants/auth_methods.go
@@ -30,4 +30,12 @@ const (
 	AuthRecipeMethodTwitch = "twitch"
 	// AuthRecipeMethodRoblox is the roblox auth method
 	AuthRecipeMethodRoblox = "roblox"
+
+	// AuthRecipeMethodServiceAccount is the login_method stamped on machine
+	// access tokens issued via the client_credentials grant (RFC 6749 §4.4).
+	// It is not a human login recipe — it namespaces the memory-store session
+	// key ("service_account:<id>") so ValidateAccessToken derives the same key
+	// the token endpoint registered the token under, keeping machine tokens on
+	// the existing stateful validation path with zero special-casing.
+	AuthRecipeMethodServiceAccount = "service_account"
 )

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -653,6 +653,9 @@ func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, clientID, c
 	// reconstructs this exact key from the token's login_method + sub claims.
 	sessionKey := constants.AuthRecipeMethodServiceAccount + ":" + sa.ID
 
+	// ponytail: aud is the global ClientID, same as human tokens. RFC 8707
+	// resource-bound audience binding (spec S8) is deliberately deferred to
+	// the Phase 2 token-exchange work, not silently forgotten.
 	authToken, err := h.TokenProvider.CreateMachineAuthToken(&token.AuthTokenConfig{
 		ServiceAccountID: sa.ID,
 		Scope:            grantedScopes,

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/authorizerdev/authorizer/internal/audit"
 	"github.com/authorizerdev/authorizer/internal/constants"
@@ -30,6 +32,38 @@ type RequestBody struct {
 	GrantType    string `form:"grant_type" json:"grant_type"`
 	RefreshToken string `form:"refresh_token" json:"refresh_token"`
 	RedirectURI  string `form:"redirect_uri" json:"redirect_uri"`
+	// Scope is the space-delimited OAuth2 scope parameter (RFC 6749 §3.3),
+	// used by the client_credentials grant to request a subset of the service
+	// account's allowed scopes.
+	Scope string `form:"scope" json:"scope"`
+}
+
+// serviceAccountBcryptCost is the bcrypt cost the client_credentials timing
+// mitigation must match. It has to equal the cost real service-account secrets
+// are hashed with (internal/service/admin_service_accounts.go
+// serviceAccountSecretCost == 12; also committed in the ServiceAccount schema
+// doc comment) so a dummy compare for an unknown client_id takes the same time
+// as a real compare — otherwise timing reveals whether the account exists.
+const serviceAccountBcryptCost = 12
+
+// clientCredentialsDummyHash is a precomputed bcrypt hash compared against when
+// a client_credentials client_id does not resolve to a service account, so the
+// unknown-client path does the same bcrypt work as a real credential check.
+// Mirrors loginDummyBcryptHash in internal/service/login.go, but at the
+// service-account cost (12) rather than bcrypt.DefaultCost.
+var (
+	clientCredentialsDummyHash []byte
+	clientCredentialsDummyOnce sync.Once
+)
+
+// performDummyServiceAccountCheck runs a constant-cost bcrypt comparison whose
+// result is discarded, equalising the timing of the unknown-client path with a
+// real client_secret verification.
+func performDummyServiceAccountCheck(clientSecret string) {
+	clientCredentialsDummyOnce.Do(func() {
+		clientCredentialsDummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), serviceAccountBcryptCost)
+	})
+	_ = bcrypt.CompareHashAndPassword(clientCredentialsDummyHash, []byte(clientSecret))
 }
 
 // TokenHandler to handle /oauth/token requests
@@ -57,6 +91,7 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 		grantType := strings.TrimSpace(reqBody.GrantType)
 		refreshToken := strings.TrimSpace(reqBody.RefreshToken)
 		clientSecret := strings.TrimSpace(reqBody.ClientSecret)
+		scopeParam := strings.TrimSpace(reqBody.Scope)
 
 		if grantType == "" {
 			grantType = "authorization_code"
@@ -64,8 +99,9 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 
 		isRefreshTokenGrant := grantType == "refresh_token"
 		isAuthorizationCodeGrant := grantType == "authorization_code"
+		isClientCredentialsGrant := grantType == constants.GrantTypeClientCredentials
 
-		if !isRefreshTokenGrant && !isAuthorizationCodeGrant {
+		if !isRefreshTokenGrant && !isAuthorizationCodeGrant && !isClientCredentialsGrant {
 			log.Debug().Str("grant_type", grantType).Msg("Invalid grant type")
 			gc.JSON(http.StatusBadRequest, gin.H{
 				"error":             "unsupported_grant_type",
@@ -86,6 +122,15 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 				"error":             "invalid_request",
 				"error_description": "The client_id parameter is required",
 			})
+			return
+		}
+
+		// RFC 6749 §4.4 client_credentials: machine identity. Fully self-
+		// contained — the client is a ServiceAccount (client_id ==
+		// ServiceAccount.ID), NOT the global confidential app client checked
+		// below. Handled and returned here.
+		if isClientCredentialsGrant {
+			h.handleClientCredentialsGrant(gc, clientID, clientSecret, scopeParam)
 			return
 		}
 
@@ -502,4 +547,162 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 		})
 		gc.JSON(http.StatusOK, res)
 	}
+}
+
+// handleClientCredentialsGrant implements the RFC 6749 §4.4 client_credentials
+// grant. The client authenticates as a ServiceAccount (client_id ==
+// ServiceAccount.ID, client_secret verified against the stored bcrypt hash) and
+// receives a stateful access token scoped to a subset of the account's allowed
+// scopes. No id_token and no refresh_token are issued — machines re-authenticate
+// on expiry (RFC 6749 §4.4.3).
+//
+// Timing: every authentication-failure path runs exactly one cost-12 bcrypt
+// compare (a dummy hash for an unknown client_id, the real stored hash for an
+// existing-but-inactive or wrong-secret account) and returns an identical
+// invalid_client response, so an attacker cannot learn from response timing or
+// body whether an account exists or is active.
+func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, clientID, clientSecret, scope string) {
+	log := h.Log.With().Str("func", "handleClientCredentialsGrant").Logger()
+
+	// respondInvalidClient emits the RFC 6749 §5.2 invalid_client error using
+	// the same convention as the confidential-client path above: 401 +
+	// WWW-Authenticate when the client authenticated via HTTP Basic, else 400.
+	respondInvalidClient := func() {
+		metrics.RecordSecurityEvent("invalid_client", "token_endpoint")
+		if _, _, hasBasicAuth := gc.Request.BasicAuth(); hasBasicAuth {
+			gc.Header("WWW-Authenticate", "Basic realm=\"authorizer\"")
+			gc.JSON(http.StatusUnauthorized, gin.H{
+				"error":             "invalid_client",
+				"error_description": "Client authentication failed",
+			})
+			return
+		}
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_client",
+			"error_description": "Client authentication failed",
+		})
+	}
+
+	sa, err := h.StorageProvider.GetServiceAccountByID(gc, clientID)
+	if err != nil || sa == nil {
+		// Unknown client_id — burn an equivalent bcrypt cost so timing does not
+		// distinguish this from a wrong-secret response, then reject.
+		log.Debug().Err(err).Msg("service account not found for client_credentials")
+		performDummyServiceAccountCheck(clientSecret)
+		respondInvalidClient()
+		return
+	}
+
+	// Always run the real compare (even for inactive accounts) BEFORE the
+	// active-state check, so inactive vs active-wrong-secret are timing-
+	// indistinguishable. bcrypt.CompareHashAndPassword is itself constant-time
+	// with respect to the secret.
+	secretErr := bcrypt.CompareHashAndPassword([]byte(sa.ClientSecret), []byte(clientSecret))
+	if !sa.IsActive || secretErr != nil {
+		log.Debug().Bool("is_active", sa.IsActive).Msg("client_credentials authentication failed")
+		respondInvalidClient()
+		return
+	}
+
+	// Scope handling (RFC 6749 §3.3 / §5.2). An empty AllowedScopes is DENY-ALL
+	// (schema § AllowedScopes comment) — reject rather than issue a scopeless
+	// token. The service layer already forbids creating such accounts; this is
+	// defense-in-depth.
+	allowedScopes := sa.ParsedAllowedScopes()
+	if len(allowedScopes) == 0 {
+		log.Debug().Msg("service account has no authorized scopes")
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_scope",
+			"error_description": "The service account has no authorized scopes",
+		})
+		return
+	}
+	allowedSet := make(map[string]struct{}, len(allowedScopes))
+	for _, s := range allowedScopes {
+		allowedSet[s] = struct{}{}
+	}
+
+	var grantedScopes []string
+	requestedScopes := strings.Fields(scope)
+	if len(requestedScopes) == 0 {
+		// No scope requested — grant the full authorized set. This repo's spec
+		// does not mandate a default; granting the full authorized set on an
+		// omitted scope param is the common client_credentials convention.
+		grantedScopes = allowedScopes
+	} else {
+		// Every requested scope MUST be authorized; reject the whole request
+		// otherwise (RFC 6749 §5.2 invalid_scope) rather than silently
+		// downgrading, which would hide a client misconfiguration.
+		for _, rs := range requestedScopes {
+			if _, ok := allowedSet[rs]; !ok {
+				log.Debug().Str("scope", rs).Msg("requested scope exceeds allowed scopes")
+				gc.JSON(http.StatusBadRequest, gin.H{
+					"error":             "invalid_scope",
+					"error_description": "The requested scope exceeds the scopes authorized for this service account",
+				})
+				return
+			}
+		}
+		grantedScopes = requestedScopes
+	}
+
+	hostname := parsers.GetHost(gc)
+	nonce := uuid.New().String()
+	// Namespace the session key so it can never collide with a human user's
+	// session key (a bare or login-method-prefixed UUID). ValidateAccessToken
+	// reconstructs this exact key from the token's login_method + sub claims.
+	sessionKey := constants.AuthRecipeMethodServiceAccount + ":" + sa.ID
+
+	authToken, err := h.TokenProvider.CreateMachineAuthToken(&token.AuthTokenConfig{
+		ServiceAccountID: sa.ID,
+		Scope:            grantedScopes,
+		Nonce:            nonce,
+		LoginMethod:      constants.AuthRecipeMethodServiceAccount,
+		HostName:         hostname,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to create machine access token")
+		gc.JSON(http.StatusInternalServerError, gin.H{
+			"error":             "server_error",
+			"error_description": "Could not complete token issuance",
+		})
+		return
+	}
+
+	// Access tokens in this codebase are stateful: register in the memory store
+	// or ValidateAccessToken (GraphQL context, gRPC interceptor, profile
+	// endpoints) rejects a cryptographically-valid-but-unregistered token.
+	if err := h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeAccessToken+"_"+nonce, authToken.Token, authToken.ExpiresAt); err != nil {
+		log.Debug().Err(err).Msg("failed to persist machine access token")
+		gc.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":             "temporarily_unavailable",
+			"error_description": "Could not complete token issuance",
+		})
+		return
+	}
+
+	expiresIn := authToken.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
+	metrics.RecordAuthEvent(metrics.EventTokenIssued, metrics.StatusSuccess)
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditTokenClientCredentialsEvent,
+		ActorID:      sa.ID,
+		ActorType:    constants.AuditActorTypeServiceAccount,
+		ResourceType: constants.AuditResourceTypeToken,
+		ResourceID:   sa.ID,
+		Metadata:     constants.GrantTypeClientCredentials,
+		IPAddress:    utils.GetIP(gc.Request),
+		UserAgent:    utils.GetUserAgent(gc.Request),
+	})
+
+	// RFC 6749 §5.1: no refresh_token and no id_token for client_credentials.
+	gc.JSON(http.StatusOK, gin.H{
+		"access_token": authToken.Token,
+		"token_type":   "Bearer",
+		"expires_in":   expiresIn,
+		"scope":        strings.Join(grantedScopes, " "),
+	})
 }

--- a/internal/integration_tests/oauth_standards_compliance_test.go
+++ b/internal/integration_tests/oauth_standards_compliance_test.go
@@ -188,7 +188,10 @@ func TestTokenEndpointCompliance(t *testing.T) {
 
 	t.Run("RFC6749_unsupported_grant_type", func(t *testing.T) {
 		form := url.Values{}
-		form.Set("grant_type", "client_credentials")
+		// "password" (RFC 6749 §4.3) is not implemented by this server; it is a
+		// stable example of a grant that must be rejected as unsupported.
+		// (client_credentials is now supported — see TestClientCredentialsGrant.)
+		form.Set("grant_type", "password")
 		form.Set("client_id", cfg.ClientID)
 
 		w := httptest.NewRecorder()

--- a/internal/integration_tests/token_client_credentials_test.go
+++ b/internal/integration_tests/token_client_credentials_test.go
@@ -1,0 +1,241 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// ccTestAuthorizerURL pins the issuer host for both token issuance and
+// validation so the round-trip iss check is deterministic (parsers.GetHost
+// honours X-Authorizer-URL). Real service-account secrets are hashed at bcrypt
+// cost 12 (see admin_service_accounts.go serviceAccountSecretCost).
+const (
+	ccTestAuthorizerURL   = "http://localhost:8080"
+	ccServiceAccountCost  = 12
+	ccServiceAccountScope = "read,write"
+)
+
+// createTestServiceAccount inserts a service account with a known plaintext
+// secret and returns (id, plaintextSecret). Accounts default to active; pass
+// active=false to persist an inactive one (via Save, since GORM's default:true
+// column default would otherwise flip a Create-time false back to true).
+func createTestServiceAccount(t *testing.T, ts *testSetup, allowedScopes string, active bool) (string, string) {
+	t.Helper()
+	secret := "cc-secret-" + uuid.New().String()
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), ccServiceAccountCost)
+	require.NoError(t, err)
+	sa, err := ts.StorageProvider.AddServiceAccount(context.Background(), &schemas.ServiceAccount{
+		Name:          "cc-sa-" + uuid.New().String(),
+		ClientSecret:  string(hash),
+		AllowedScopes: allowedScopes,
+		IsActive:      true,
+	})
+	require.NoError(t, err)
+	if !active {
+		sa.IsActive = false
+		_, err = ts.StorageProvider.UpdateServiceAccount(context.Background(), sa)
+		require.NoError(t, err)
+	}
+	return sa.ID, secret
+}
+
+// postClientCredentials POSTs a form to /oauth/token. If basicAuth is non-nil
+// ({clientID, clientSecret}) the credentials go in an HTTP Basic header instead
+// of the form body.
+func postClientCredentials(router http.Handler, form url.Values, basicAuth []string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Authorizer-URL", ccTestAuthorizerURL)
+	if basicAuth != nil {
+		req.SetBasicAuth(basicAuth[0], basicAuth[1])
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body
+}
+
+func TestClientCredentialsGrant(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	t.Run("happy_path_basic_auth", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, ccServiceAccountScope, true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+
+		w := postClientCredentials(router, form, []string{id, secret})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		body := decodeJSON(t, w)
+		assert.NotEmpty(t, body["access_token"], "must return an access_token")
+		assert.Equal(t, "Bearer", body["token_type"])
+		assert.EqualValues(t, "read write", body["scope"], "omitted scope grants full allowed set")
+		assert.NotZero(t, body["expires_in"])
+		// RFC 6749 §5.1: machine tokens carry no refresh_token / id_token.
+		assert.Nil(t, body["refresh_token"], "client_credentials MUST NOT return refresh_token")
+		assert.Nil(t, body["id_token"], "client_credentials MUST NOT return id_token")
+		assert.Nil(t, body["roles"], "machine tokens have no roles")
+	})
+
+	t.Run("happy_path_form_body_credentials", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, ccServiceAccountScope, true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("client_id", id)
+		form.Set("client_secret", secret)
+
+		w := postClientCredentials(router, form, nil)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		body := decodeJSON(t, w)
+		assert.NotEmpty(t, body["access_token"])
+		assert.Equal(t, "Bearer", body["token_type"])
+	})
+
+	t.Run("requested_scope_subset_is_granted", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, "read,write,admin", true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("scope", "read write")
+
+		w := postClientCredentials(router, form, []string{id, secret})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		body := decodeJSON(t, w)
+		assert.Equal(t, "read write", body["scope"], "granted scope echoes the requested subset")
+	})
+
+	t.Run("scope_exceeding_allowed_is_rejected", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, "read", true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("scope", "read write")
+
+		w := postClientCredentials(router, form, []string{id, secret})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSON(t, w)
+		assert.Equal(t, "invalid_scope", body["error"],
+			"RFC 6749 §5.2: unauthorized scope MUST return invalid_scope")
+	})
+
+	t.Run("wrong_secret_returns_invalid_client", func(t *testing.T) {
+		id, _ := createTestServiceAccount(t, ts, ccServiceAccountScope, true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("client_id", id)
+		form.Set("client_secret", "totally-wrong-secret")
+
+		w := postClientCredentials(router, form, nil)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSON(t, w)
+		assert.Equal(t, "invalid_client", body["error"])
+	})
+
+	t.Run("unknown_client_indistinguishable_from_wrong_secret", func(t *testing.T) {
+		// Wrong secret against a real account.
+		id, _ := createTestServiceAccount(t, ts, ccServiceAccountScope, true)
+		wrongSecretForm := url.Values{}
+		wrongSecretForm.Set("grant_type", constants.GrantTypeClientCredentials)
+		wrongSecretForm.Set("client_id", id)
+		wrongSecretForm.Set("client_secret", "totally-wrong-secret")
+		wrongSecretResp := postClientCredentials(router, wrongSecretForm, nil)
+
+		// Unknown client_id entirely.
+		unknownForm := url.Values{}
+		unknownForm.Set("grant_type", constants.GrantTypeClientCredentials)
+		unknownForm.Set("client_id", uuid.New().String())
+		unknownForm.Set("client_secret", "totally-wrong-secret")
+		unknownResp := postClientCredentials(router, unknownForm, nil)
+
+		assert.Equal(t, wrongSecretResp.Code, unknownResp.Code,
+			"unknown client and wrong secret MUST return the same status")
+		assert.JSONEq(t, wrongSecretResp.Body.String(), unknownResp.Body.String(),
+			"unknown client and wrong secret MUST return an identical error body")
+	})
+
+	t.Run("inactive_service_account_returns_invalid_client", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, ccServiceAccountScope, false)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("client_id", id)
+		form.Set("client_secret", secret)
+
+		w := postClientCredentials(router, form, nil)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSON(t, w)
+		assert.Equal(t, "invalid_client", body["error"],
+			"an inactive account (even with the correct secret) MUST return invalid_client")
+	})
+
+	t.Run("invalid_client_via_basic_auth_returns_401", func(t *testing.T) {
+		id, _ := createTestServiceAccount(t, ts, ccServiceAccountScope, true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+
+		w := postClientCredentials(router, form, []string{id, "wrong-secret"})
+		require.Equal(t, http.StatusUnauthorized, w.Code,
+			"RFC 6749 §5.2: client auth failure via Basic MUST return 401")
+		assert.NotEmpty(t, w.Header().Get("WWW-Authenticate"))
+	})
+
+	t.Run("issued_token_validates_and_round_trips", func(t *testing.T) {
+		id, secret := createTestServiceAccount(t, ts, "read,write", true)
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+		form.Set("scope", "read")
+
+		w := postClientCredentials(router, form, []string{id, secret})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		accessToken, _ := decodeJSON(t, w)["access_token"].(string)
+		require.NotEmpty(t, accessToken)
+
+		// Prove the memory-store registration is correct: a token that was never
+		// registered would be rejected here even with a valid signature.
+		validateReq, _ := http.NewRequest(http.MethodGet, "/", nil)
+		validateReq.Header.Set("X-Authorizer-URL", ccTestAuthorizerURL)
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Request = validateReq
+
+		claims, err := ts.TokenProvider.ValidateAccessToken(gctx, accessToken)
+		require.NoError(t, err, "issued machine token must validate downstream")
+		assert.Equal(t, id, claims["sub"], "sub must be the service account id")
+		assert.Equal(t, constants.TokenTypeAccessToken, claims["token_type"])
+		assert.Equal(t, constants.AuthRecipeMethodServiceAccount, claims["login_method"])
+		// Machines carry no roles/allowed_roles.
+		assert.Nil(t, claims["roles"])
+		assert.Nil(t, claims["allowed_roles"])
+	})
+
+	t.Run("missing_client_id_returns_invalid_request", func(t *testing.T) {
+		form := url.Values{}
+		form.Set("grant_type", constants.GrantTypeClientCredentials)
+
+		w := postClientCredentials(router, form, nil)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSON(t, w)
+		assert.Equal(t, "invalid_request", body["error"])
+	})
+}

--- a/internal/storage/schemas/service_account.go
+++ b/internal/storage/schemas/service_account.go
@@ -63,6 +63,22 @@ type ServiceAccount struct {
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
 }
 
+// ParsedAllowedScopes returns AllowedScopes as a slice: comma-separated,
+// whitespace trimmed, empty segments dropped. This is the single source of
+// truth for interpreting the stored scope string — the token endpoint uses it
+// to enforce that a client_credentials request stays within the authorized set.
+// An empty or whitespace-only AllowedScopes yields an empty slice, which the
+// token endpoint MUST treat as DENY-ALL (schema § AllowedScopes comment).
+func (s *ServiceAccount) ParsedAllowedScopes() []string {
+	scopes := []string{}
+	for _, sc := range strings.Split(s.AllowedScopes, ",") {
+		if sc = strings.TrimSpace(sc); sc != "" {
+			scopes = append(scopes, sc)
+		}
+	}
+	return scopes
+}
+
 // AsAPIServiceAccount converts the storage record into the GraphQL model.
 // It never exposes ClientSecret — there is no client_secret field on
 // model.ServiceAccount by design; the plaintext is surfaced only once via
@@ -72,17 +88,11 @@ func (s *ServiceAccount) AsAPIServiceAccount() *model.ServiceAccount {
 	if strings.Contains(id, Collections.ServiceAccount+"/") {
 		id = strings.TrimPrefix(id, Collections.ServiceAccount+"/")
 	}
-	scopes := []string{}
-	for _, sc := range strings.Split(s.AllowedScopes, ",") {
-		if sc = strings.TrimSpace(sc); sc != "" {
-			scopes = append(scopes, sc)
-		}
-	}
 	return &model.ServiceAccount{
 		ID:            id,
 		Name:          s.Name,
 		Description:   s.Description,
-		AllowedScopes: scopes,
+		AllowedScopes: s.ParsedAllowedScopes(),
 		IsActive:      s.IsActive,
 		CreatedAt:     refs.NewInt64Ref(s.CreatedAt),
 		UpdatedAt:     refs.NewInt64Ref(s.UpdatedAt),

--- a/internal/token/auth_token.go
+++ b/internal/token/auth_token.go
@@ -58,6 +58,14 @@ type AuthTokenConfig struct {
 	HostName   string
 	Roles      []string
 	Scope      []string
+	// ServiceAccountID is set — and User is nil — for machine access tokens
+	// issued via the client_credentials grant (RFC 6749 §4.4). When set,
+	// CreateAccessToken builds a machine token whose `sub` is this id, whose
+	// `scope` comes from Scope, and which carries NO roles/allowed_roles claim
+	// (machines have no roles). LoginMethod must be set to
+	// constants.AuthRecipeMethodServiceAccount so the token round-trips through
+	// ValidateAccessToken on the existing stateful path.
+	ServiceAccountID string
 	// AuthTime is the Unix timestamp (seconds) at which the user
 	// authenticated. OIDC Core §2 defines this as the `auth_time` ID
 	// token claim. If zero, CreateIDToken falls back to time.Now() so
@@ -224,6 +232,13 @@ func (p *provider) CreateRefreshToken(cfg *AuthTokenConfig) (string, int64, erro
 // CreateAccessToken util to create JWT token, based on
 // user information, roles config and CUSTOM_ACCESS_TOKEN_SCRIPT
 func (p *provider) CreateAccessToken(cfg *AuthTokenConfig) (string, int64, error) {
+	// Machine identity (client_credentials, RFC 6749 §4.4): there is no
+	// resource owner, so cfg.User is nil. Building the human token below would
+	// nil-deref on cfg.User.ID/Roles — route to the machine builder instead.
+	// The human path below is left completely unchanged.
+	if cfg.User == nil && cfg.ServiceAccountID != "" {
+		return p.createMachineAccessToken(cfg)
+	}
 	expiryBound, err := utils.ParseDurationInSeconds(cfg.ExpireTime)
 	if err != nil {
 		expiryBound = time.Minute * 30
@@ -256,6 +271,54 @@ func (p *provider) CreateAccessToken(cfg *AuthTokenConfig) (string, int64, error
 	}
 
 	return token, expiresAt, nil
+}
+
+// createMachineAccessToken builds the OAuth2 access token JWT for a service
+// account (client_credentials, RFC 6749 §4.4). It is the machine counterpart
+// to the human path in CreateAccessToken: identical iss/aud/exp/iat/
+// token_type/nonce shape, but `sub` is the service account id, `scope` carries
+// the granted scopes, and there are NO roles/allowed_roles claims — machines
+// have no roles. The CUSTOM_ACCESS_TOKEN_SCRIPT is intentionally not run: its
+// contract is customFunction(user, tokenPayload) and there is no user.
+// login_method is set (to constants.AuthRecipeMethodServiceAccount by the
+// caller) so ValidateAccessToken derives the same memory-store session key the
+// token endpoint registered this token under.
+func (p *provider) createMachineAccessToken(cfg *AuthTokenConfig) (string, int64, error) {
+	expiryBound, err := utils.ParseDurationInSeconds(cfg.ExpireTime)
+	if err != nil {
+		expiryBound = time.Minute * 30
+	}
+	expiresAt := time.Now().Add(expiryBound).Unix()
+	customClaims := jwt.MapClaims{
+		"iss":          cfg.HostName,
+		"aud":          p.config.ClientID,
+		"nonce":        cfg.Nonce,
+		"sub":          cfg.ServiceAccountID,
+		"exp":          expiresAt,
+		"iat":          time.Now().Unix(),
+		"token_type":   constants.TokenTypeAccessToken,
+		"scope":        cfg.Scope,
+		"login_method": cfg.LoginMethod,
+	}
+	token, err := p.SignJWTToken(customClaims)
+	if err != nil {
+		return "", 0, err
+	}
+	return token, expiresAt, nil
+}
+
+// CreateMachineAuthToken issues a stateful OAuth2 access token for a service
+// account (client_credentials, RFC 6749 §4.4). It returns ONLY an access token
+// — no id_token, no refresh_token, no browser/session token — because machines
+// have no OIDC identity and re-authenticate on expiry. The caller MUST register
+// the returned token in the memory store exactly as human access tokens are
+// (see the /oauth/token handler), or ValidateAccessToken will reject it.
+func (p *provider) CreateMachineAuthToken(cfg *AuthTokenConfig) (*JWTToken, error) {
+	accessToken, expiresAt, err := p.CreateAccessToken(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &JWTToken{Token: accessToken, ExpiresAt: expiresAt}, nil
 }
 
 // GetAccessToken returns the access token from the request (either from header or cookie)

--- a/internal/token/provider.go
+++ b/internal/token/provider.go
@@ -31,6 +31,8 @@ type Provider interface {
 	CreateAccessToken(cfg *AuthTokenConfig) (string, int64, error)
 	// CreateAuthToken creates all types of auth token
 	CreateAuthToken(gc *gin.Context, cfg *AuthTokenConfig) (*AuthToken, error)
+	// CreateMachineAuthToken creates a client_credentials access token (RFC 6749 §4.4)
+	CreateMachineAuthToken(cfg *AuthTokenConfig) (*JWTToken, error)
 	// CreateIDToken creates an id token
 	CreateIDToken(cfg *AuthTokenConfig) (string, int64, error)
 	// CreateRefreshToken creates a refresh token


### PR DESCRIPTION
## Summary

The final PR of Phase 1: the RFC 6749 §4.4 `client_credentials` OAuth2 grant at `/oauth/token`. Everything else (storage, service layer, GraphQL, gRPC) is already merged.

**Chains on:** #645 (merged into this integration branch)

## What's in this PR

- `internal/token/auth_token.go` — `AuthTokenConfig.ServiceAccountID`; `CreateAccessToken` branches to a new private `createMachineAccessToken` when `cfg.User == nil && cfg.ServiceAccountID != ""` (human path is byte-for-byte unchanged); new public `CreateMachineAuthToken` — access token only, no id_token, no refresh_token.
- `internal/http_handlers/token.go` — new `Scope` request field, `client_credentials` grant branch reusing the existing Basic/form client-auth extraction, bcrypt (cost 12) secret verification, scope-subset enforcement, memory-store registration, audit + metrics.
- `internal/storage/schemas/service_account.go` — `ParsedAllowedScopes()` helper.
- New constants: `AuthRecipeMethodServiceAccount`, `AuditActorTypeServiceAccount`.
- 10 new integration tests (`token_client_credentials_test.go`) plus a one-line fix to an existing compliance test that used `client_credentials` as its "unsupported grant type" example (now uses `password`, since client_credentials is supported).

## Key design decisions (flagging for review)

- **Stateful token validation preserved**: access tokens in this codebase are validated against `MemoryStoreProvider`, not just JWT signature. Machine tokens use `login_method: "service_account"` so the existing `ValidateAccessToken` key-derivation (`login_method + ":" + sub`) reconstructs the same session key the endpoint registers under — zero changes to the validator itself.
- **Default scope when omitted**: grants the full `AllowedScopes` set (common client_credentials convention, not spec-mandated). Requested scopes must be a strict subset — `invalid_scope` on any excess, no silent downgrade.
- **Timing**: every failure path (unknown client_id, inactive account, wrong secret) runs exactly one cost-12 bcrypt compare before returning an identical `invalid_client` body — inactive-vs-wrong-secret and unknown-vs-wrong-secret are indistinguishable by timing or response shape.
- **No refresh_token/id_token**: pure OAuth2, matches RFC 6749 §5.1 response shape exactly.
- **`IsActive=false` blocks new issuance, not already-issued tokens** (until natural expiry) — matches the schema's documented behavior and the existing human-token revocation model.

## PR chain

```
PR 1 — schema + interface + SQL + constants     merged → feat/workload-identity-phase1  ✅ #641
PR 2 — NoSQL provider implementations           merged → feat/workload-identity-phase1  ✅ #642
PR 3 — service layer + admin GraphQL API        merged → feat/workload-identity-phase1  ✅ #644
PR 4 — gRPC admin RPCs                          merged → feat/workload-identity-phase1  ✅ #645
PR 5 — client_credentials grant + tests         🔄 this PR (last one)
```

## Test plan

- [x] `go build ./...`, `go vet ./...`, `make lint-go` — 0 issues
- [x] 10 new client_credentials tests — pass
- [x] Existing token endpoint tests (authorization_code, refresh_token, RFC compliance) — pass, unaffected
- [x] Full `make test-sqlite` — pass