### PR TITLE
feat(oauth): shared client-auth resolver at /oauth/token (+ grant-matrix hardening)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -431,6 +431,12 @@ func runRoot(c *cobra.Command, args []string) {
 		}
 	}()
 
+	// Seed the reserved interactive client (Config.ClientID) into the client
+	// registry. Idempotent and non-fatal — must run after storage is up and
+	// before the Token/HTTP subsystems that will (in a later PR) resolve client
+	// auth from this row.
+	seedReservedClient(context.Background(), storageProvider, &rootArgs.config, &log)
+
 	// Authenticator provider
 	authenticatorProvider, err := authenticators.New(&rootArgs.config, &authenticators.Dependencies{
 		Log:             &log,

--- a/cmd/seed_client.go
+++ b/cmd/seed_client.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// reservedClientSecretCost is the bcrypt cost for the reserved client's secret.
+// It mirrors the cost the admin client API commits to (see
+// internal/service/admin_clients.go clientSecretCost) — MUST stay 12.
+const reservedClientSecretCost = 12
+
+// seedReservedClient idempotently upserts the deployment's reserved interactive
+// client into the client registry, keyed on ClientID == Config.ClientID (BC1).
+//
+// The row makes the deployment's global OAuth client a first-class registry
+// record so later PRs can resolve client authentication from storage. This PR
+// only makes the row EXIST; it does NOT rewire any handler — existing
+// Config.ClientID comparisons stay as-is.
+//
+// BC2: Config.ClientSecret remains the session-cookie AES key untouched. We only
+// ADD a bcrypt hash of it into the client row; cookie crypto is not changed.
+//
+// The seed is idempotent (skip-if-present, keyed on ClientID). On a read-only /
+// no-write-path storage instance the AddClient error is logged and skipped
+// rather than fatal, so a read replica can still boot.
+func seedReservedClient(ctx context.Context, storageProvider storage.Provider, cfg *config.Config, logger *zerolog.Logger) {
+	log := logger.With().Str("func", "seedReservedClient").Logger()
+
+	clientID := strings.TrimSpace(cfg.ClientID)
+	if clientID == "" {
+		log.Warn().Msg("Config.ClientID is empty; skipping reserved client seed")
+		return
+	}
+
+	if existing, err := storageProvider.GetClientByClientID(ctx, clientID); err == nil && existing != nil {
+		log.Debug().Msg("reserved client already present; seed is a no-op")
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.ClientSecret), reservedClientSecretCost)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to bcrypt Config.ClientSecret; skipping reserved client seed")
+		return
+	}
+
+	if _, err := storageProvider.AddClient(ctx, &schemas.Client{
+		ClientID:                clientID,
+		Kind:                    constants.ClientKindInteractive,
+		Name:                    "Reserved Interactive Client",
+		ClientSecret:            string(hash),
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		GrantTypes:              constants.GrantTypeAuthorizationCode + "," + constants.GrantTypeRefreshToken,
+		IsActive:                true,
+	}); err != nil {
+		// Read-only / no-write-path instance, or a concurrent seed that lost the
+		// unique-index race: log and skip rather than fatal.
+		log.Warn().Err(err).Msg("failed to seed reserved client (read-only instance or concurrent seed); continuing")
+		return
+	}
+
+	log.Info().Str("client_id", clientID).Msg("seeded reserved interactive client")
+}

--- a/cmd/seed_client_test.go
+++ b/cmd/seed_client_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage"
+)
+
+func newSeedTestProvider(t *testing.T) (storage.Provider, *config.Config) {
+	t.Helper()
+	cfg := &config.Config{
+		DatabaseType: constants.DbTypeSqlite,
+		DatabaseURL:  filepath.Join(t.TempDir(), "seed_client_test.db"),
+		DatabaseName: "authorizer_test",
+		ClientID:     "reserved-client-" + t.Name(),
+		ClientSecret: "super-secret-cookie-key",
+	}
+	logger := zerolog.Nop()
+	sp, err := storage.New(cfg, &storage.Dependencies{Log: &logger})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sp.Close() })
+	return sp, cfg
+}
+
+// TestSeedReservedClient_IsIdempotent verifies the boot seed inserts exactly one
+// reserved client, keyed on Config.ClientID, and is a no-op on repeat calls.
+func TestSeedReservedClient_IsIdempotent(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	// Exactly one row carries the reserved client_id.
+	clients, _, err := sp.ListClients(ctx, &model.Pagination{Limit: 100, Offset: 0})
+	require.NoError(t, err)
+	count := 0
+	for _, c := range clients {
+		if c.ClientID == cfg.ClientID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "seeding twice must yield exactly one reserved client row")
+}
+
+// TestSeedReservedClient_RowShape verifies the seeded row's identity, kind, and
+// that its stored secret is a bcrypt hash verifying against Config.ClientSecret
+// (BC1: client_id == Config.ClientID).
+func TestSeedReservedClient_RowShape(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	row, err := sp.GetClientByClientID(ctx, cfg.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+
+	assert.Equal(t, cfg.ClientID, row.ClientID, "BC1: seeded client_id must equal Config.ClientID")
+	assert.Equal(t, constants.ClientKindInteractive, row.Kind)
+	assert.Equal(t, constants.TokenEndpointAuthMethodClientSecretBasic, row.TokenEndpointAuthMethod)
+	assert.True(t, row.IsActive)
+	assert.Contains(t, row.GrantTypes, constants.GrantTypeAuthorizationCode)
+	assert.Contains(t, row.GrantTypes, constants.GrantTypeRefreshToken)
+
+	// The stored secret is a bcrypt hash of Config.ClientSecret, never plaintext.
+	assert.NotEqual(t, cfg.ClientSecret, row.ClientSecret, "stored secret must be hashed, not plaintext")
+	assert.NoError(t,
+		bcrypt.CompareHashAndPassword([]byte(row.ClientSecret), []byte(cfg.ClientSecret)),
+		"stored bcrypt hash must verify against Config.ClientSecret",
+	)
+}
+
+// TestSeedReservedClient_EmptyClientIDSkips verifies an empty Config.ClientID is
+// a safe no-op (no row, no panic).
+func TestSeedReservedClient_EmptyClientIDSkips(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	cfg.ClientID = ""
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	clients, _, err := sp.ListClients(ctx, &model.Pagination{Limit: 100, Offset: 0})
+	require.NoError(t, err)
+	assert.Empty(t, clients, "empty Config.ClientID must seed nothing")
+}

--- a/internal/constants/client_registry.go
+++ b/internal/constants/client_registry.go
@@ -1,0 +1,27 @@
+package constants
+
+// Client.Kind discriminator values. Immutable after creation.
+const (
+	// ClientKindInteractive is a human-facing login client (browser/app
+	// authorization_code + PKCE flows).
+	ClientKindInteractive = "interactive"
+
+	// ClientKindServiceAccount is a machine/workload client using the
+	// client_credentials grant or workload identity federation.
+	ClientKindServiceAccount = "service_account"
+)
+
+// Client.TokenEndpointAuthMethod values (RFC 7591 §2 / OIDC Core §9).
+const (
+	// TokenEndpointAuthMethodClientSecretBasic sends client_id/client_secret in
+	// the HTTP Authorization header (RFC 6749 §2.3.1).
+	TokenEndpointAuthMethodClientSecretBasic = "client_secret_basic"
+
+	// TokenEndpointAuthMethodClientSecretPost sends client_id/client_secret in
+	// the request body.
+	TokenEndpointAuthMethodClientSecretPost = "client_secret_post"
+
+	// TokenEndpointAuthMethodNone is a public client with no secret; it proves
+	// possession via PKCE.
+	TokenEndpointAuthMethodNone = "none"
+)

--- a/internal/http_handlers/provider.go
+++ b/internal/http_handlers/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/oauth"
 	"github.com/authorizerdev/authorizer/internal/rate_limit"
 	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/service/clientauth"
 	"github.com/authorizerdev/authorizer/internal/sms"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/token"
@@ -58,6 +59,13 @@ func New(cfg *config.Config, deps *Dependencies) (Provider, error) {
 	g := &httpProvider{
 		Config:       cfg,
 		Dependencies: *deps,
+		// Shared client-authentication resolver (RFC 6749 §2.3). Built from the
+		// same storage + config the handlers already hold, so no extra wiring is
+		// needed at construction sites.
+		clientAuthProvider: clientauth.New(cfg, &clientauth.Dependencies{
+			Log:             deps.Log,
+			StorageProvider: deps.StorageProvider,
+		}),
 	}
 	return g, nil
 }
@@ -66,6 +74,9 @@ func New(cfg *config.Config, deps *Dependencies) (Provider, error) {
 type httpProvider struct {
 	*config.Config
 	Dependencies
+	// clientAuthProvider resolves and authenticates the OAuth client presented at
+	// the token endpoint.
+	clientAuthProvider clientauth.Provider
 }
 
 // Ensure interface is implemented

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -104,6 +104,10 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			// only — preserving the pre-registry behavior of each grant.
 			RequireSecret:         isClientCredentialsGrant,
 			VerifyPresentedSecret: isAuthorizationCodeGrant,
+			// client_credentials is machine-only (design §4.1): the resolver rejects a
+			// non-service_account client before verifying the secret, so an interactive
+			// client_id cannot confirm a guessed secret on this grant.
+			RequireServiceAccountKind: isClientCredentialsGrant,
 		})
 		if authErr != nil {
 			h.respondClientAuthError(gc, authErr, resolvedClient, isClientCredentialsGrant)
@@ -525,6 +529,15 @@ func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolv
 		gc.JSON(http.StatusBadRequest, gin.H{
 			"error":             "invalid_request",
 			"error_description": "The client_id parameter is required",
+		})
+		return
+	case errors.Is(err, clientauth.ErrUnauthorizedClient):
+		// Client is authenticated-or-not but simply not allowed to use this grant
+		// (an interactive client on client_credentials). Returned before secret
+		// verification, so this response is identical for any secret — no oracle.
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "unauthorized_client",
+			"error_description": "This client is not authorized to use this grant type",
 		})
 		return
 	}

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -4,15 +4,14 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/authorizerdev/authorizer/internal/audit"
 	"github.com/authorizerdev/authorizer/internal/constants"
@@ -20,6 +19,8 @@ import (
 	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/parsers"
 	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/service/clientauth"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 	"github.com/authorizerdev/authorizer/internal/token"
 	"github.com/authorizerdev/authorizer/internal/utils"
 )
@@ -36,34 +37,6 @@ type RequestBody struct {
 	// used by the client_credentials grant to request a subset of the service
 	// account's allowed scopes.
 	Scope string `form:"scope" json:"scope"`
-}
-
-// clientCredentialsBcryptCost is the bcrypt cost the client_credentials timing
-// mitigation must match. It has to equal the cost real service-account secrets
-// are hashed with (internal/service/admin_service_accounts.go
-// serviceAccountSecretCost == 12; also committed in the Client schema
-// doc comment) so a dummy compare for an unknown client_id takes the same time
-// as a real compare — otherwise timing reveals whether the account exists.
-const clientCredentialsBcryptCost = 12
-
-// clientCredentialsDummyHash is a precomputed bcrypt hash compared against when
-// a client_credentials client_id does not resolve to a service account, so the
-// unknown-client path does the same bcrypt work as a real credential check.
-// Mirrors loginDummyBcryptHash in internal/service/login.go, but at the
-// service-account cost (12) rather than bcrypt.DefaultCost.
-var (
-	clientCredentialsDummyHash []byte
-	clientCredentialsDummyOnce sync.Once
-)
-
-// performDummyClientCheck runs a constant-cost bcrypt comparison whose
-// result is discarded, equalising the timing of the unknown-client path with a
-// real client_secret verification.
-func performDummyClientCheck(clientSecret string) {
-	clientCredentialsDummyOnce.Do(func() {
-		clientCredentialsDummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), clientCredentialsBcryptCost)
-	})
-	_ = bcrypt.CompareHashAndPassword(clientCredentialsDummyHash, []byte(clientSecret))
 }
 
 // TokenHandler to handle /oauth/token requests
@@ -87,10 +60,9 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 
 		codeVerifier := strings.TrimSpace(reqBody.CodeVerifier)
 		code := strings.TrimSpace(reqBody.Code)
-		clientID := strings.TrimSpace(reqBody.ClientID)
 		grantType := strings.TrimSpace(reqBody.GrantType)
 		refreshToken := strings.TrimSpace(reqBody.RefreshToken)
-		clientSecret := strings.TrimSpace(reqBody.ClientSecret)
+		bodyClientSecret := strings.TrimSpace(reqBody.ClientSecret)
 		scopeParam := strings.TrimSpace(reqBody.Scope)
 
 		if grantType == "" {
@@ -110,46 +82,38 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			return
 		}
 
-		// check if clientID & clientSecret are present as part of
-		// authorization header with basic auth
-		if clientID == "" && clientSecret == "" {
-			clientID, clientSecret, _ = gc.Request.BasicAuth()
-		}
-
-		if clientID == "" {
-			log.Debug().Msg("Client ID is missing")
-			gc.JSON(http.StatusBadRequest, gin.H{
-				"error":             "invalid_request",
-				"error_description": "The client_id parameter is required",
-			})
+		// Authenticate the client through the shared resolver (RFC 6749 §2.3):
+		// it extracts the credential from client_secret_basic (Authorization
+		// header) or client_secret_post (body), rejects presenting more than one
+		// method, looks the client up by its public client_id, and verifies the
+		// secret. client_credentials always requires a secret; authorization_code
+		// / refresh_token treat a missing secret as "no secret presented" and let
+		// the PKCE checks below gate the request. secretPresented drives the
+		// no-PKCE "secret required" rule further down.
+		basicClientID, basicClientSecret, hasBasicAuth := gc.Request.BasicAuth()
+		secretPresented := bodyClientSecret != "" || (hasBasicAuth && basicClientSecret != "")
+		resolvedClient, authErr := h.clientAuthProvider.ResolveClient(gc, clientauth.ResolveParams{
+			BodyClientID:  strings.TrimSpace(reqBody.ClientID),
+			BodySecret:    bodyClientSecret,
+			BasicClientID: basicClientID,
+			BasicSecret:   basicClientSecret,
+			HasBasicAuth:  hasBasicAuth,
+			// client_credentials always requires a secret; authorization_code
+			// verifies a presented secret (PKCE gates a secret-less request);
+			// refresh_token ignores the secret and authenticates the client_id
+			// only — preserving the pre-registry behavior of each grant.
+			RequireSecret:         isClientCredentialsGrant,
+			VerifyPresentedSecret: isAuthorizationCodeGrant,
+		})
+		if authErr != nil {
+			h.respondClientAuthError(gc, authErr, resolvedClient, isClientCredentialsGrant)
 			return
 		}
 
-		// RFC 6749 §4.4 client_credentials: machine identity. Fully self-
-		// contained — the client is a Client (client_id ==
-		// Client.ID), NOT the global confidential app client checked
-		// below. Handled and returned here.
+		// RFC 6749 §4.4 client_credentials: machine identity. The resolver has
+		// already authenticated the service_account; issue its scoped token here.
 		if isClientCredentialsGrant {
-			h.handleClientCredentialsGrant(gc, clientID, clientSecret, scopeParam)
-			return
-		}
-
-		if h.Config.ClientID != clientID {
-			log.Debug().Msg("Client ID is invalid")
-			metrics.RecordSecurityEvent("invalid_client", "token_endpoint")
-			// RFC 6749 §5.2: If client auth fails via HTTP Basic, return 401
-			if _, _, hasBasicAuth := gc.Request.BasicAuth(); hasBasicAuth {
-				gc.Header("WWW-Authenticate", "Basic realm=\"authorizer\"")
-				gc.JSON(http.StatusUnauthorized, gin.H{
-					"error":             "invalid_client",
-					"error_description": "Client authentication failed",
-				})
-			} else {
-				gc.JSON(http.StatusBadRequest, gin.H{
-					"error":             "invalid_client",
-					"error_description": "The client_id is invalid",
-				})
-			}
+			h.handleClientCredentialsGrant(gc, resolvedClient, scopeParam)
 			return
 		}
 
@@ -279,23 +243,14 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			// of whether PKCE was used. PKCE protects against authorization code
 			// interception; client authentication is a separate concern.
 			// When no PKCE was used, client_secret is the sole proof of identity.
+			// The secret itself was already verified by the client-auth resolver
+			// above; here we only enforce that one was presented.
 			if storedChallenge == "" && codeVerifier == "" {
-				// No PKCE — client_secret is required
-				if clientSecret == "" {
+				// No PKCE — a client secret is required.
+				if !secretPresented {
 					gc.JSON(http.StatusBadRequest, gin.H{
 						"error":             "invalid_request",
 						"error_description": "Either code_verifier or client_secret is required",
-					})
-					return
-				}
-			}
-			// Always validate client_secret when provided (confidential client).
-			if clientSecret != "" {
-				if subtle.ConstantTimeCompare([]byte(clientSecret), []byte(h.Config.ClientSecret)) != 1 {
-					log.Debug().Msg("Client secret is invalid")
-					gc.JSON(http.StatusUnauthorized, gin.H{
-						"error":             "invalid_client",
-						"error_description": "Client authentication failed",
 					})
 					return
 				}
@@ -549,74 +504,80 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 	}
 }
 
-// handleClientCredentialsGrant implements the RFC 6749 §4.4 client_credentials
-// grant. The client authenticates as a Client (client_id ==
-// Client.ID, client_secret verified against the stored bcrypt hash) and
-// receives a stateful access token scoped to a subset of the account's allowed
-// scopes. No id_token and no refresh_token are issued — machines re-authenticate
-// on expiry (RFC 6749 §4.4.3).
-//
-// Timing: every authentication-failure path runs exactly one cost-12 bcrypt
-// compare (a dummy hash for an unknown client_id, the real stored hash for an
-// existing-but-inactive or wrong-secret account) and returns an identical
-// invalid_client response, so an attacker cannot learn from response timing or
-// body whether an account exists or is active.
-func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, clientID, clientSecret, scope string) {
-	log := h.Log.With().Str("func", "handleClientCredentialsGrant").Logger()
+// respondClientAuthError maps a clientauth resolver error to the RFC 6749 §5.2
+// token-endpoint error response. Dual-method and missing-client_id map to
+// invalid_request (400); everything else is invalid_client (401 when the client
+// authenticated via HTTP Basic per §5.2, else 400). For a failed
+// client_credentials attempt against a *resolved* client it also writes the
+// token.client_credentials_failed audit event — mirroring the historical
+// behavior, which audited only known-client failures (not unknown client_ids).
+func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolved *schemas.Client, isClientCredentials bool) {
+	log := h.Log.With().Str("func", "respondClientAuthError").Logger()
 
-	// respondInvalidClient emits the RFC 6749 §5.2 invalid_client error using
-	// the same convention as the confidential-client path above: 401 +
-	// WWW-Authenticate when the client authenticated via HTTP Basic, else 400.
-	respondInvalidClient := func() {
-		metrics.RecordSecurityEvent("invalid_client", "token_endpoint")
-		if _, _, hasBasicAuth := gc.Request.BasicAuth(); hasBasicAuth {
-			gc.Header("WWW-Authenticate", "Basic realm=\"authorizer\"")
-			gc.JSON(http.StatusUnauthorized, gin.H{
-				"error":             "invalid_client",
-				"error_description": "Client authentication failed",
-			})
-			return
-		}
+	switch {
+	case errors.Is(err, clientauth.ErrMultipleAuthMethods):
 		gc.JSON(http.StatusBadRequest, gin.H{
-			"error":             "invalid_client",
-			"error_description": "Client authentication failed",
+			"error":             "invalid_request",
+			"error_description": "Only one client authentication method may be used per request",
 		})
-	}
-
-	sa, err := h.StorageProvider.GetClientByID(gc, clientID)
-	if err != nil || sa == nil {
-		// Unknown client_id — burn an equivalent bcrypt cost so timing does not
-		// distinguish this from a wrong-secret response, then reject.
-		log.Debug().Err(err).Msg("service account not found for client_credentials")
-		performDummyClientCheck(clientSecret)
-		respondInvalidClient()
+		return
+	case errors.Is(err, clientauth.ErrMissingClientID):
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_request",
+			"error_description": "The client_id parameter is required",
+		})
 		return
 	}
 
-	// Always run the real compare (even for inactive accounts) BEFORE the
-	// active-state check, so inactive vs active-wrong-secret are timing-
-	// indistinguishable. bcrypt.CompareHashAndPassword is itself constant-time
-	// with respect to the secret.
-	secretErr := bcrypt.CompareHashAndPassword([]byte(sa.ClientSecret), []byte(clientSecret))
-	if !sa.IsActive || secretErr != nil {
-		log.Debug().Bool("is_active", sa.IsActive).Msg("client_credentials authentication failed")
-		// Audited here (not on the unknown-client_id path above) because we
-		// have a resolved Client to attribute the attempt to — mirrors
-		// login.go's bad_password/account_revoked branches, which likewise
-		// don't audit the user-not-found case.
+	// invalid_client (clientauth.ErrInvalidClient, or any unexpected error).
+	metrics.RecordSecurityEvent("invalid_client", "token_endpoint")
+
+	// Audit only a known-client failure on the client_credentials path — mirrors
+	// the historical behavior (login.go audits bad_password but not user-not-
+	// found). resolved.ID == "" is the synthesized reserved-client fallback,
+	// which is not a service_account and must not be audited as one.
+	if isClientCredentials && resolved != nil && resolved.ID != "" {
 		h.AuditProvider.LogEvent(audit.Event{
 			Action:       constants.AuditTokenClientCredentialsFailedEvent,
-			ActorID:      sa.ID,
+			ActorID:      resolved.ID,
 			ActorType:    constants.AuditActorTypeServiceAccount,
 			ResourceType: constants.AuditResourceTypeToken,
-			ResourceID:   sa.ID,
+			ResourceID:   resolved.ID,
 			Metadata:     constants.GrantTypeClientCredentials,
 			IPAddress:    utils.GetIP(gc.Request),
 			UserAgent:    utils.GetUserAgent(gc.Request),
 		})
-		respondInvalidClient()
-		return
 	}
+
+	log.Debug().Err(err).Msg("client authentication failed")
+	// Status selection reproduces the pre-registry behavior exactly:
+	//   - HTTP Basic auth failure → 401 + WWW-Authenticate (RFC 6749 §5.2).
+	//   - authorization_code with a wrong secret on a resolved (known) client →
+	//     401 without WWW-Authenticate (the old confidential-client path).
+	//   - everything else (unknown client_id via body, client_credentials
+	//     non-Basic) → 400.
+	_, _, hasBasicAuth := gc.Request.BasicAuth()
+	status := http.StatusBadRequest
+	if hasBasicAuth {
+		gc.Header("WWW-Authenticate", "Basic realm=\"authorizer\"")
+		status = http.StatusUnauthorized
+	} else if !isClientCredentials && resolved != nil {
+		status = http.StatusUnauthorized
+	}
+	gc.JSON(status, gin.H{
+		"error":             "invalid_client",
+		"error_description": "Client authentication failed",
+	})
+}
+
+// handleClientCredentialsGrant implements the RFC 6749 §4.4 client_credentials
+// grant. The client (a service_account) is already authenticated by the
+// clientauth resolver; sa is that resolved, active client. This issues a
+// stateful access token scoped to a subset of the account's allowed scopes. No
+// id_token and no refresh_token are issued — machines re-authenticate on expiry
+// (RFC 6749 §4.4.3).
+func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, sa *schemas.Client, scope string) {
+	log := h.Log.With().Str("func", "handleClientCredentialsGrant").Logger()
 
 	// Scope handling (RFC 6749 §3.3 / §5.2). An empty AllowedScopes is DENY-ALL
 	// (schema § AllowedScopes comment) — reject rather than issue a scopeless

--- a/internal/integration_tests/token_client_auth_bc_test.go
+++ b/internal/integration_tests/token_client_auth_bc_test.go
@@ -1,0 +1,192 @@
+package integration_tests
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+)
+
+// runReservedLogin performs the interactive reserved-client login up to the
+// authorization code: signup -> browser session -> /authorize (PKCE, S256). It
+// returns a router with /oauth/token wired, the single-use code, and the PKCE
+// code_verifier so each test can drive the token exchange under different client
+// authentication conditions. This is the exact flow the reserved client uses in
+// production, so a green exchange proves the client-auth resolver preserves BC1.
+func runReservedLogin(t *testing.T, ts *testSetup, clientID string, defaultRoles []string) (http.Handler, string, string) {
+	t.Helper()
+	_, ctx := createContext(ts)
+
+	email := "reserved_bc_" + uuid.New().String() + "@authorizer.dev"
+	password := "Password@123"
+	_, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email:           &email,
+		Password:        password,
+		ConfirmPassword: password,
+	})
+	require.NoError(t, err)
+
+	user, err := ts.StorageProvider.GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	nonce := uuid.New().String()
+	sessionData, sessionToken, sessionExpiresAt, err := ts.TokenProvider.CreateSessionToken(&token.AuthTokenConfig{
+		User:        user,
+		Nonce:       nonce,
+		Roles:       defaultRoles,
+		Scope:       []string{"openid", "profile", "email"},
+		LoginMethod: constants.AuthRecipeMethodBasicAuth,
+	})
+	require.NoError(t, err)
+
+	sessionKey := constants.AuthRecipeMethodBasicAuth + ":" + user.ID
+	require.NoError(t, ts.MemoryStoreProvider.SetUserSession(
+		sessionKey, constants.TokenTypeSessionToken+"_"+sessionData.Nonce, sessionToken, sessionExpiresAt))
+
+	codeVerifier := uuid.New().String() + uuid.New().String()
+	sum := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	router := gin.New()
+	router.GET("/authorize", ts.HttpProvider.AuthorizeHandler())
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	qs := url.Values{}
+	qs.Set("client_id", clientID)
+	qs.Set("response_type", "code")
+	qs.Set("redirect_uri", "http://localhost:3000/callback")
+	qs.Set("code_challenge", codeChallenge)
+	qs.Set("code_challenge_method", "S256")
+	qs.Set("state", uuid.New().String())
+	qs.Set("response_mode", "query")
+	qs.Set("scope", "openid profile email")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/authorize?"+qs.Encode(), nil)
+	req.AddCookie(&http.Cookie{Name: constants.AppCookieName + "_session", Value: sessionToken})
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code, "authorize should redirect: %s", w.Body.String())
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	code := loc.Query().Get("code")
+	require.NotEmpty(t, code, "authorization code must be present")
+
+	return router, code, codeVerifier
+}
+
+func exchangeCode(router http.Handler, form url.Values, basicAuth []string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if basicAuth != nil {
+		req.SetBasicAuth(basicAuth[0], basicAuth[1])
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// BC1 (fallback): with NO reserved-client row seeded (the read-only-replica
+// case), the reserved client still authenticates the authorization_code+PKCE
+// exchange against Config.ClientID / Config.ClientSecret. This is the default
+// state of a fresh test DB, so it also guards every other login test.
+func TestReservedClientLogin_ConfigFallback_SeedAbsent(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	// Guard: no reserved-client row exists — we are genuinely on the fallback path.
+	existing, err := ts.StorageProvider.GetClientByClientID(t.Context(), cfg.ClientID)
+	require.True(t, err != nil || existing == nil, "test must run with the reserved row absent")
+
+	router, code, codeVerifier := runReservedLogin(t, ts, cfg.ClientID, cfg.DefaultRoles)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", cfg.ClientID)
+	form.Set("code", code)
+	form.Set("code_verifier", codeVerifier)
+	form.Set("redirect_uri", "http://localhost:3000/callback")
+
+	w := exchangeCode(router, form, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.NotEmpty(t, body["access_token"])
+}
+
+// BC1 (registry): with the reserved-client row seeded (bcrypt(Config.ClientSecret),
+// client_id == Config.ClientID), the same login exchanges successfully through
+// the resolver's registry path — proving the row-backed path is byte-for-byte
+// equivalent to the fallback for the reserved client.
+func TestReservedClientLogin_SeededRow(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.ClientSecret), 12)
+	require.NoError(t, err)
+	_, err = ts.StorageProvider.AddClient(t.Context(), &schemas.Client{
+		ClientID:                cfg.ClientID,
+		Kind:                    constants.ClientKindInteractive,
+		Name:                    "Reserved Interactive Client",
+		ClientSecret:            string(hash),
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		IsActive:                true,
+	})
+	require.NoError(t, err)
+
+	router, code, codeVerifier := runReservedLogin(t, ts, cfg.ClientID, cfg.DefaultRoles)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", cfg.ClientID)
+	form.Set("code", code)
+	form.Set("code_verifier", codeVerifier)
+	form.Set("redirect_uri", "http://localhost:3000/callback")
+
+	w := exchangeCode(router, form, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.NotEmpty(t, body["access_token"])
+}
+
+// RFC 6749 §2.3: presenting more than one client-authentication method (HTTP
+// Basic AND a body client_secret) must be rejected with invalid_request, before
+// any grant processing. New behavior enforced by the resolver.
+func TestTokenClientAuth_DualMethodRejected(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", cfg.ClientID)
+	form.Set("client_secret", cfg.ClientSecret) // client_secret_post
+	form.Set("code", "any-code")
+	form.Set("code_verifier", "any-verifier")
+
+	// ...and ALSO HTTP Basic (client_secret_basic) in the same request.
+	w := exchangeCode(router, form, []string{cfg.ClientID, cfg.ClientSecret})
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "invalid_request", body["error"],
+		"RFC 6749 §2.3: more than one auth method MUST be rejected as invalid_request")
+}

--- a/internal/integration_tests/token_client_credentials_test.go
+++ b/internal/integration_tests/token_client_credentials_test.go
@@ -41,6 +41,7 @@ func createTestClient(t *testing.T, ts *testSetup, allowedScopes string, active 
 	require.NoError(t, err)
 	sa, err := ts.StorageProvider.AddClient(context.Background(), &schemas.Client{
 		Name:          "cc-sa-" + uuid.New().String(),
+		Kind:          constants.ClientKindServiceAccount,
 		ClientSecret:  string(hash),
 		AllowedScopes: allowedScopes,
 		IsActive:      true,

--- a/internal/service/clientauth/clientauth.go
+++ b/internal/service/clientauth/clientauth.go
@@ -37,6 +37,14 @@ var (
 	// returned *schemas.Client is non-nil so the caller can attribute an audit
 	// event to it; on an unknown client it is nil.
 	ErrInvalidClient = errors.New("clientauth: client authentication failed")
+
+	// ErrUnauthorizedClient is returned when a resolved client is not permitted to
+	// use the requested grant — e.g. an interactive client attempting
+	// client_credentials (design §4.1: client_credentials is machine-only). It is
+	// returned BEFORE the secret is verified, so a correct and an incorrect secret
+	// produce the identical response — no secret-confirmation oracle. Map to
+	// unauthorized_client (RFC 6749 §5.2).
+	ErrUnauthorizedClient = errors.New("clientauth: client not authorized for this grant")
 )
 
 // dummySecretCost mirrors the bcrypt cost real client secrets are hashed with
@@ -86,6 +94,14 @@ type ResolveParams struct {
 	// (refresh_token) the secret is ignored entirely, only the client_id is
 	// authenticated — reproducing the pre-registry refresh_token behavior.
 	VerifyPresentedSecret bool
+
+	// RequireServiceAccountKind rejects a resolved client whose Kind is not
+	// service_account with ErrUnauthorizedClient, BEFORE the secret is verified.
+	// Set for client_credentials (a machine-only grant, design §4.1). Rejecting
+	// pre-verification is what keeps the response identical for a correct and an
+	// incorrect secret, so the interactive reserved client_id cannot be used as a
+	// secret-confirmation oracle on this grant.
+	RequireServiceAccountKind bool
 }
 
 // Dependencies for the clientauth provider.
@@ -152,6 +168,13 @@ func (p *provider) ResolveClient(ctx context.Context, params ResolveParams) (*sc
 		// bootstrap Config credential so login is never locked out. This path
 		// reproduces the pre-registry constant-time comparison verbatim.
 		if p.Config != nil && clientID == strings.TrimSpace(p.Config.ClientID) {
+			// The reserved client is interactive; client_credentials is machine-only.
+			// Reject before touching the secret so the response is identical for any
+			// secret (no confirmation oracle) — matches the found-client branch below.
+			if params.RequireServiceAccountKind {
+				log.Debug().Msg("reserved interactive client not authorized for client_credentials grant")
+				return nil, ErrUnauthorizedClient
+			}
 			return p.resolveViaConfig(clientID, secret, doVerify)
 		}
 		// Unknown client: burn an equivalent bcrypt cost so timing does not
@@ -159,6 +182,15 @@ func (p *provider) ResolveClient(ctx context.Context, params ResolveParams) (*sc
 		log.Debug().Err(err).Msg("client not found")
 		performDummyCompare(secret)
 		return nil, ErrInvalidClient
+	}
+
+	// Grant matrix (design §4.1): only a service_account client may use
+	// client_credentials. Reject any other kind BEFORE verifying the secret, so a
+	// correct and an incorrect secret return the identical unauthorized_client — the
+	// interactive reserved client_id cannot confirm a guessed secret on this grant.
+	if params.RequireServiceAccountKind && client.Kind != constants.ClientKindServiceAccount {
+		log.Debug().Str("kind", client.Kind).Msg("client not authorized for client_credentials grant")
+		return client, ErrUnauthorizedClient
 	}
 
 	// bcrypt.CompareHashAndPassword is itself constant-time with respect to the

--- a/internal/service/clientauth/clientauth.go
+++ b/internal/service/clientauth/clientauth.go
@@ -1,0 +1,204 @@
+// Package clientauth resolves and authenticates the OAuth client presented at
+// the token endpoint (RFC 6749 §2.3). It is the single source of truth for
+// client-secret verification so every transport (token, and — in later PRs —
+// introspect/revoke) authenticates clients identically.
+package clientauth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// Sentinel errors callers map to the RFC 6749 §5.2 token-endpoint responses.
+var (
+	// ErrMultipleAuthMethods is returned when a request presents more than one
+	// client-authentication method (RFC 6749 §2.3: "The client MUST NOT use more
+	// than one authentication method in each request."). Map to invalid_request.
+	ErrMultipleAuthMethods = errors.New("clientauth: multiple authentication methods presented")
+
+	// ErrMissingClientID is returned when no client_id can be extracted from the
+	// request. Map to invalid_request.
+	ErrMissingClientID = errors.New("clientauth: client_id is required")
+
+	// ErrInvalidClient is returned when the client is unknown, inactive, or the
+	// presented secret does not match. Map to invalid_client. When the client was
+	// resolved (a known client with a wrong secret or an inactive account) the
+	// returned *schemas.Client is non-nil so the caller can attribute an audit
+	// event to it; on an unknown client it is nil.
+	ErrInvalidClient = errors.New("clientauth: client authentication failed")
+)
+
+// dummySecretCost mirrors the bcrypt cost real client secrets are hashed with
+// (admin_clients.go clientSecretCost == 12, and the reserved-client seed). A
+// dummy compare for an unknown client MUST take the same time as a real compare
+// or timing reveals whether the client exists.
+const dummySecretCost = 12
+
+var (
+	dummyHash []byte
+	dummyOnce sync.Once
+)
+
+// performDummyCompare runs a constant-cost bcrypt comparison whose result is
+// discarded, equalising the unknown-client path with a real secret verification.
+func performDummyCompare(secret string) {
+	dummyOnce.Do(func() {
+		dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), dummySecretCost)
+	})
+	_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(secret))
+}
+
+// ResolveParams carries the client credentials extracted from a token request.
+// The transport layer owns extraction (it has the *http.Request); this keeps the
+// resolver transport-agnostic and unit-testable.
+type ResolveParams struct {
+	// BodyClientID / BodySecret are client_id and client_secret from the request
+	// body (client_secret_post, or a public client sending only client_id).
+	BodyClientID string
+	BodySecret   string
+
+	// BasicClientID / BasicSecret / HasBasicAuth carry the HTTP Basic
+	// (client_secret_basic) credential. HasBasicAuth is true when a well-formed
+	// Authorization: Basic header was present.
+	BasicClientID string
+	BasicSecret   string
+	HasBasicAuth  bool
+
+	// RequireSecret verifies the presented secret even when it is empty
+	// (client_credentials — a machine identity always authenticates with a
+	// secret). Implies VerifyPresentedSecret.
+	RequireSecret bool
+
+	// VerifyPresentedSecret verifies the secret only when one is presented, and
+	// treats a missing secret as "no secret" (authorization_code — the caller's
+	// PKCE checks gate a secret-less request). When both flags are false
+	// (refresh_token) the secret is ignored entirely, only the client_id is
+	// authenticated — reproducing the pre-registry refresh_token behavior.
+	VerifyPresentedSecret bool
+}
+
+// Dependencies for the clientauth provider.
+type Dependencies struct {
+	Log             *zerolog.Logger
+	StorageProvider storage.Provider
+}
+
+// Provider resolves and authenticates the OAuth client for a token request.
+type Provider interface {
+	// ResolveClient extracts the client credential from params, enforces the
+	// single-auth-method rule (RFC 6749 §2.3), looks the client up by its public
+	// client_id, and verifies the secret. See the sentinel errors for the caller
+	// contract.
+	ResolveClient(ctx context.Context, params ResolveParams) (*schemas.Client, error)
+}
+
+type provider struct {
+	*config.Config
+	Dependencies
+}
+
+var _ Provider = &provider{}
+
+// New constructs a clientauth provider. cfg supplies the bootstrap
+// ClientID/ClientSecret fallback that keeps a deployment from being locked out
+// when the reserved-client row is absent (read-only replica).
+func New(cfg *config.Config, deps *Dependencies) Provider {
+	return &provider{Config: cfg, Dependencies: *deps}
+}
+
+func (p *provider) ResolveClient(ctx context.Context, params ResolveParams) (*schemas.Client, error) {
+	log := p.Log.With().Str("func", "ResolveClient").Logger()
+
+	// RFC 6749 §2.3: reject a request that carries both an HTTP Basic credential
+	// and a body client_secret (more than one authentication method).
+	if params.HasBasicAuth && params.BodySecret != "" {
+		log.Debug().Msg("multiple client authentication methods presented")
+		return nil, ErrMultipleAuthMethods
+	}
+
+	// Select the effective credential. Basic wins when present; otherwise the
+	// body carries the client_secret_post / public-client parameters.
+	clientID := strings.TrimSpace(params.BodyClientID)
+	secret := params.BodySecret
+	if params.HasBasicAuth {
+		clientID = strings.TrimSpace(params.BasicClientID)
+		secret = params.BasicSecret
+	}
+	if clientID == "" {
+		log.Debug().Msg("client_id missing")
+		return nil, ErrMissingClientID
+	}
+	secretPresented := secret != ""
+	// doVerify decides whether the secret is checked at all: always for
+	// client_credentials (RequireSecret), only-when-present for authorization_code
+	// (VerifyPresentedSecret), never for refresh_token (both false).
+	doVerify := params.RequireSecret || (params.VerifyPresentedSecret && secretPresented)
+
+	client, err := p.StorageProvider.GetClientByClientID(ctx, clientID)
+	if err != nil || client == nil {
+		// Availability fallback (BC): the reserved client's row may be absent on a
+		// read-only replica where the boot seed was skipped. Fall back to the
+		// bootstrap Config credential so login is never locked out. This path
+		// reproduces the pre-registry constant-time comparison verbatim.
+		if p.Config != nil && clientID == strings.TrimSpace(p.Config.ClientID) {
+			return p.resolveViaConfig(clientID, secret, doVerify)
+		}
+		// Unknown client: burn an equivalent bcrypt cost so timing does not
+		// distinguish an unknown client from a wrong secret, then reject.
+		log.Debug().Err(err).Msg("client not found")
+		performDummyCompare(secret)
+		return nil, ErrInvalidClient
+	}
+
+	// bcrypt.CompareHashAndPassword is itself constant-time with respect to the
+	// secret; running it before the IsActive check keeps a wrong-secret and an
+	// inactive-account rejection timing-indistinguishable.
+	if doVerify {
+		if bcrypt.CompareHashAndPassword([]byte(client.ClientSecret), []byte(secret)) != nil {
+			log.Debug().Msg("client secret mismatch")
+			// Return the resolved client so the caller can attribute an audit event.
+			return client, ErrInvalidClient
+		}
+	}
+
+	if !client.IsActive {
+		log.Debug().Msg("client is inactive")
+		return client, ErrInvalidClient
+	}
+
+	return client, nil
+}
+
+// resolveViaConfig authenticates the reserved interactive client against the
+// bootstrap Config credential when its registry row is absent. The secret is
+// compared constant-time against the plaintext Config.ClientSecret — never a
+// stored hash — exactly reproducing the pre-registry token-endpoint behavior.
+// On mismatch it still returns the synthesized client alongside ErrInvalidClient
+// so the caller can tell "known client_id, bad secret" from an unknown client.
+func (p *provider) resolveViaConfig(clientID, secret string, doVerify bool) (*schemas.Client, error) {
+	// Synthesize the reserved client. ClientSecret (the bcrypt hash) is left empty
+	// on purpose — the secret is verified against Config.ClientSecret, not a hash.
+	client := &schemas.Client{
+		ClientID:                clientID,
+		Kind:                    constants.ClientKindInteractive,
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		IsActive:                true,
+	}
+	if doVerify {
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(p.Config.ClientSecret)) != 1 {
+			return client, ErrInvalidClient
+		}
+	}
+	return client, nil
+}

--- a/internal/service/clientauth/clientauth_test.go
+++ b/internal/service/clientauth/clientauth_test.go
@@ -1,0 +1,242 @@
+package clientauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// fakeStore implements only GetClientByClientID; every other storage.Provider
+// method is promoted from the embedded nil interface and would panic if called.
+// The resolver only ever calls GetClientByClientID, so this stays valid.
+type fakeStore struct {
+	storage.Provider
+	clients map[string]*schemas.Client
+}
+
+func (f *fakeStore) GetClientByClientID(_ context.Context, clientID string) (*schemas.Client, error) {
+	c, ok := f.clients[clientID]
+	if !ok {
+		return nil, errors.New("client not found")
+	}
+	return c, nil
+}
+
+const (
+	testClientID     = "worker-1"
+	testClientSecret = "s3cr3t-plaintext"
+	testConfigID     = "reserved-client"
+	testConfigSecret = "config-plaintext-secret"
+)
+
+func newResolver(t *testing.T, clients map[string]*schemas.Client) Provider {
+	t.Helper()
+	logger := zerolog.Nop()
+	return New(
+		&config.Config{ClientID: testConfigID, ClientSecret: testConfigSecret},
+		&Dependencies{Log: &logger, StorageProvider: &fakeStore{clients: clients}},
+	)
+}
+
+func hashSecret(t *testing.T, secret string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(secret), dummySecretCost)
+	require.NoError(t, err)
+	return string(h)
+}
+
+func confidentialClient(t *testing.T) *schemas.Client {
+	return &schemas.Client{
+		ID:                      "id-worker-1",
+		ClientID:                testClientID,
+		Kind:                    constants.ClientKindServiceAccount,
+		ClientSecret:            hashSecret(t, testClientSecret),
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		IsActive:                true,
+	}
+}
+
+func TestResolveClient_ClientSecretBasic(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BasicClientID: testClientID,
+		BasicSecret:   testClientSecret,
+		HasBasicAuth:  true,
+		RequireSecret: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testClientID, got.ClientID)
+}
+
+func TestResolveClient_ClientSecretPost(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		BodySecret:    testClientSecret,
+		RequireSecret: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testClientID, got.ClientID)
+}
+
+func TestResolveClient_DualAuthMethodsRejected(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	// A Basic credential AND a body client_secret in one request (RFC 6749 §2.3).
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		BodySecret:    testClientSecret,
+		BasicClientID: testClientID,
+		BasicSecret:   testClientSecret,
+		HasBasicAuth:  true,
+		RequireSecret: true,
+	})
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, ErrMultipleAuthMethods)
+}
+
+func TestResolveClient_WrongSecret(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		BodySecret:    "wrong-secret",
+		RequireSecret: true,
+	})
+	assert.ErrorIs(t, err, ErrInvalidClient)
+	// The resolved client is returned so the caller can attribute an audit event.
+	require.NotNil(t, got)
+	assert.Equal(t, "id-worker-1", got.ID)
+}
+
+func TestResolveClient_UnknownClient(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  "does-not-exist",
+		BodySecret:    "whatever",
+		RequireSecret: true,
+	})
+	assert.ErrorIs(t, err, ErrInvalidClient)
+	// Unknown client returns a nil client (nothing to attribute an audit to); the
+	// dummy bcrypt compare inside keeps timing indistinguishable from wrong-secret.
+	assert.Nil(t, got)
+}
+
+func TestResolveClient_MissingClientID(t *testing.T) {
+	r := newResolver(t, map[string]*schemas.Client{})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{BodySecret: "x"})
+	assert.ErrorIs(t, err, ErrMissingClientID)
+	assert.Nil(t, got)
+}
+
+func TestResolveClient_InactiveClient(t *testing.T) {
+	c := confidentialClient(t)
+	c.IsActive = false
+	r := newResolver(t, map[string]*schemas.Client{testClientID: c})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		BodySecret:    testClientSecret, // correct secret, but account is inactive
+		RequireSecret: true,
+	})
+	assert.ErrorIs(t, err, ErrInvalidClient)
+	require.NotNil(t, got)
+}
+
+func TestResolveClient_PublicClientNoSecret(t *testing.T) {
+	// A public client (token_endpoint_auth_method == "none") presents no secret;
+	// authorization_code sets VerifyPresentedSecret=true but with no secret there
+	// is nothing to verify — PKCE (enforced by the caller) is the proof.
+	public := &schemas.Client{
+		ID:                      "id-public",
+		ClientID:                "public-app",
+		Kind:                    constants.ClientKindInteractive,
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodNone,
+		IsActive:                true,
+	}
+	r := newResolver(t, map[string]*schemas.Client{"public-app": public})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:          "public-app",
+		VerifyPresentedSecret: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "public-app", got.ClientID)
+}
+
+func TestResolveClient_RefreshTokenIgnoresSecret(t *testing.T) {
+	// refresh_token authenticates the client_id only: a presented (wrong) secret
+	// is ignored, reproducing the pre-registry behavior.
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: testClientID,
+		BodySecret:   "wrong-secret-but-ignored",
+		// Both RequireSecret and VerifyPresentedSecret are false (refresh_token).
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testClientID, got.ClientID)
+}
+
+func TestResolveClient_ConfigFallbackWhenRowAbsent(t *testing.T) {
+	// The reserved client's row is absent (read-only replica); the resolver must
+	// fall back to Config.ClientID / Config.ClientSecret so login is never locked
+	// out (BC availability fallback).
+	r := newResolver(t, map[string]*schemas.Client{})
+
+	t.Run("correct_secret_authenticates", func(t *testing.T) {
+		got, err := r.ResolveClient(context.Background(), ResolveParams{
+			BodyClientID:          testConfigID,
+			BodySecret:            testConfigSecret,
+			VerifyPresentedSecret: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, testConfigID, got.ClientID)
+		assert.Equal(t, constants.ClientKindInteractive, got.Kind)
+	})
+
+	t.Run("no_secret_authenticates_pkce_path", func(t *testing.T) {
+		got, err := r.ResolveClient(context.Background(), ResolveParams{
+			BodyClientID:          testConfigID,
+			VerifyPresentedSecret: true, // authorization_code, but no secret presented
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, testConfigID, got.ClientID)
+	})
+
+	t.Run("wrong_secret_returns_client_and_error", func(t *testing.T) {
+		got, err := r.ResolveClient(context.Background(), ResolveParams{
+			BodyClientID:          testConfigID,
+			BodySecret:            "wrong",
+			VerifyPresentedSecret: true,
+		})
+		assert.ErrorIs(t, err, ErrInvalidClient)
+		// Non-nil so the caller can distinguish a known client_id from an unknown
+		// one (drives the 401-vs-400 status choice at the token endpoint).
+		require.NotNil(t, got)
+		assert.Empty(t, got.ID, "the synthesized fallback client has no surrogate ID")
+	})
+}
+
+func TestResolveClient_ClientCredentialsEmptySecretRejected(t *testing.T) {
+	// client_credentials always requires a secret; an empty one must be rejected
+	// (RequireSecret forces the compare, which fails on the empty secret).
+	r := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		RequireSecret: true,
+	})
+	assert.ErrorIs(t, err, ErrInvalidClient)
+	require.NotNil(t, got)
+}

--- a/internal/service/clientauth/clientauth_test.go
+++ b/internal/service/clientauth/clientauth_test.go
@@ -240,3 +240,52 @@ func TestResolveClient_ClientCredentialsEmptySecretRejected(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidClient)
 	require.NotNil(t, got)
 }
+
+func TestResolveClient_InteractiveRejectedForClientCredentials_NoOracle(t *testing.T) {
+	// An interactive client on client_credentials (RequireServiceAccountKind) must
+	// be rejected as ErrUnauthorizedClient BEFORE the secret is verified — so a
+	// correct and a wrong secret return the identical error and cannot be used to
+	// confirm a guessed secret (design §4.1 grant matrix / no confirmation oracle).
+	interactive := &schemas.Client{
+		ID:           "id-web-app",
+		ClientID:     "web-app",
+		Kind:         constants.ClientKindInteractive,
+		ClientSecret: hashSecret(t, "the-right-secret"),
+		IsActive:     true,
+	}
+	r := newResolver(t, map[string]*schemas.Client{"web-app": interactive})
+	_, errRight := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: "web-app", BodySecret: "the-right-secret",
+		RequireSecret: true, RequireServiceAccountKind: true,
+	})
+	_, errWrong := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: "web-app", BodySecret: "WRONG-secret",
+		RequireSecret: true, RequireServiceAccountKind: true,
+	})
+	require.ErrorIs(t, errRight, ErrUnauthorizedClient, "correct secret must be unauthorized_client")
+	require.ErrorIs(t, errWrong, ErrUnauthorizedClient, "wrong secret must be unauthorized_client")
+	assert.Equal(t, errRight, errWrong, "correct vs wrong secret must be indistinguishable (no oracle)")
+
+	// Config-fallback reserved client (interactive, registry row absent): same property.
+	rf := newResolver(t, map[string]*schemas.Client{})
+	_, fbRight := rf.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: testConfigID, BodySecret: testConfigSecret,
+		RequireSecret: true, RequireServiceAccountKind: true,
+	})
+	_, fbWrong := rf.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: testConfigID, BodySecret: "WRONG-secret",
+		RequireSecret: true, RequireServiceAccountKind: true,
+	})
+	require.ErrorIs(t, fbRight, ErrUnauthorizedClient)
+	require.ErrorIs(t, fbWrong, ErrUnauthorizedClient)
+	assert.Equal(t, fbRight, fbWrong, "fallback path must not distinguish secrets either")
+
+	// The kind gate must NOT affect a real service_account: correct secret authenticates.
+	rsa := newResolver(t, map[string]*schemas.Client{testClientID: confidentialClient(t)})
+	got2, err2 := rsa.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID: testClientID, BodySecret: testClientSecret,
+		RequireSecret: true, RequireServiceAccountKind: true,
+	})
+	require.NoError(t, err2)
+	assert.Equal(t, testClientID, got2.ClientID)
+}

--- a/internal/storage/db/arangodb/client.go
+++ b/internal/storage/db/arangodb/client.go
@@ -18,6 +18,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -102,6 +105,34 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 		if !cursor.HasMore() {
 			if sa == nil {
 				return nil, fmt.Errorf("service account not found")
+			}
+			break
+		}
+		s := &schemas.Client{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		sa = s
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa *schemas.Client
+	query := fmt.Sprintf("FOR d in %s FILTER d.client_id == @client_id LIMIT 1 RETURN d", schemas.Collections.Client)
+	bindVars := map[string]interface{}{
+		"client_id": clientID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if sa == nil {
+				return nil, fmt.Errorf("client not found")
 			}
 			break
 		}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -359,6 +359,17 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 			return nil, err
 		}
 	}
+	clientCollection, err := arangodb.Collection(ctx, schemas.Collections.Client)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = clientCollection.EnsureHashIndex(ctx, []string{"client_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Unique: true,
+		Sparse: true,
+	})
+	_, _, _ = clientCollection.EnsureHashIndex(ctx, []string{"org_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Sparse: true,
+	})
 
 	// TrustedIssuer collection and indexes
 	trustedIssuerCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.TrustedIssuer)

--- a/internal/storage/db/cassandradb/client.go
+++ b/internal/storage/db/cassandradb/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const clientColumns = "id, kind, name, description, client_secret, allowed_scopes, is_active, created_at, updated_at"
+const clientColumns = "id, client_id, kind, name, description, client_secret, allowed_scopes, redirect_uris, grant_types, token_endpoint_auth_method, is_active, org_id, created_at, updated_at"
 
 // AddClient creates a new service account record.
 func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.Client, error) {
@@ -21,11 +21,25 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// Cassandra has no cross-attribute unique constraint, so guard client_id
+	// uniqueness with a check-then-insert mirroring AddTrustedIssuer's issuer_url
+	// pre-check.
+	// ponytail: inherent TOCTOU race — two concurrent inserts of the same
+	// client_id can both pass this check. Cassandra offers no atomic IF NOT
+	// EXISTS on a non-partition-key column; this closes the common case
+	// (sequential admin/boot-seed) only. A fully race-free guard would need an
+	// LWT on a dedicated client_id-keyed table.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
-	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.Client, clientColumns)
-	err := p.db.Query(insertQuery, sa.ID, sa.Kind, sa.Name, sa.Description, sa.ClientSecret, sa.AllowedScopes, sa.IsActive, sa.CreatedAt, sa.UpdatedAt).Exec()
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.Client, clientColumns)
+	err := p.db.Query(insertQuery, sa.ID, sa.ClientID, sa.Kind, sa.Name, sa.Description, sa.ClientSecret, sa.AllowedScopes, sa.RedirectURIs, sa.GrantTypes, sa.TokenEndpointAuthMethod, sa.IsActive, sa.OrgID, sa.CreatedAt, sa.UpdatedAt).Exec()
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +124,19 @@ func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
 func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Client, error) {
 	var sa schemas.Client
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", clientColumns, KeySpace+"."+schemas.Collections.Client)
-	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&sa.ID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.IsActive, &sa.CreatedAt, &sa.UpdatedAt)
+	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+// Served by the client_id secondary index.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa schemas.Client
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE client_id = ? LIMIT 1 ALLOW FILTERING", clientColumns, KeySpace+"."+schemas.Collections.Client)
+	err := p.db.Query(query, clientID).Consistency(gocql.One).Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +161,7 @@ func (p *provider) ListClients(ctx context.Context, pagination *model.Pagination
 	for scanner.Next() {
 		if counter >= pagination.Offset {
 			var sa schemas.Client
-			err := scanner.Scan(&sa.ID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.IsActive, &sa.CreatedAt, &sa.UpdatedAt)
+			err := scanner.Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -372,11 +372,25 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	waitForCassandraIndexes(session, KeySpace, schemas.Collections.AuditLog, 30*time.Second)
 
 	// Client table
-	clientCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, kind text, name text, description text, client_secret text, allowed_scopes text, is_active boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.Client)
+	clientCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, kind text, name text, description text, client_secret text, allowed_scopes text, redirect_uris text, grant_types text, token_endpoint_auth_method text, is_active boolean, org_id text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.Client)
 	err = session.Query(clientCollectionQuery).Exec()
 	if err != nil {
 		return nil, err
 	}
+	clientClientIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_client_client_id ON %s.%s (client_id)", KeySpace, schemas.Collections.Client)
+	err = session.Query(clientClientIDIndex).Exec()
+	if err != nil {
+		return nil, err
+	}
+	clientOrgIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_client_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.Client)
+	err = session.Query(clientOrgIDIndex).Exec()
+	if err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for the client_id
+	// index (used by GetClientByClientID and the boot-time reserved-client seed)
+	// to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Client, "client_id", 30*time.Second)
 
 	// TrustedIssuer table and indexes
 	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
@@ -396,7 +410,7 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	}
 	// ScyllaDB builds secondary indexes asynchronously; wait for the issuer_url
 	// index (hot path for client_assertion validation) to become queryable.
-	waitForCassandraTrustedIssuerIndexes(session, KeySpace, schemas.Collections.TrustedIssuer, 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.TrustedIssuer, "issuer_url", 30*time.Second)
 
 	return &provider{
 		config:       cfg,
@@ -426,12 +440,13 @@ func waitForCassandraIndexes(session *cansandraDriver.Session, keyspace, table s
 	}
 }
 
-// waitForCassandraTrustedIssuerIndexes polls a probe query that requires the
-// issuer_url secondary index until it succeeds or the timeout is reached.
-// ScyllaDB builds secondary indexes asynchronously; the issuer_url lookup is a
-// hot path (client_assertion validation) so we wait for it to become queryable.
-func waitForCassandraTrustedIssuerIndexes(session *cansandraDriver.Session, keyspace, table string, timeout time.Duration) {
-	probe := fmt.Sprintf("SELECT id FROM %s.%s WHERE issuer_url='' LIMIT 1 ALLOW FILTERING", keyspace, table)
+// waitForCassandraSecondaryIndex polls a probe query that requires the given
+// column's secondary index until it succeeds or the timeout is reached.
+// ScyllaDB builds secondary indexes asynchronously; hot-path lookups (e.g.
+// issuer_url for client_assertion validation, client_id for client resolution)
+// must wait for the index to become queryable.
+func waitForCassandraSecondaryIndex(session *cansandraDriver.Session, keyspace, table, column string, timeout time.Duration) {
+	probe := fmt.Sprintf("SELECT id FROM %s.%s WHERE %s='' LIMIT 1 ALLOW FILTERING", keyspace, table, column)
 	deadline := time.Now().Add(timeout)
 	delay := 500 * time.Millisecond
 	for {

--- a/internal/storage/db/couchbase/client.go
+++ b/internal/storage/db/couchbase/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const clientColumns = "_id, kind, name, description, client_secret, allowed_scopes, is_active, created_at, updated_at"
+const clientColumns = "_id, client_id, kind, name, description, client_secret, allowed_scopes, redirect_uris, grant_types, token_endpoint_auth_method, is_active, org_id, created_at, updated_at"
 
 // AddClient creates a new service account record.
 func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.Client, error) {
@@ -21,6 +21,16 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// Couchbase enforces uniqueness only on the document key (_id), so guard
+	// client_id uniqueness with a check-then-insert.
+	// ponytail: inherent TOCTOU race — sequential admin/boot-seed only; a
+	// concurrent double-insert of the same client_id is not fully prevented.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -93,6 +103,30 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	params := make(map[string]interface{}, 1)
 	params["_id"] = id
 	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, clientColumns, p.scopeName, schemas.Collections.Client)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	sa := &schemas.Client{}
+	if err := decodeDocument(raw, sa); err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	params := make(map[string]interface{}, 1)
+	params["client_id"] = clientID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE client_id=$client_id LIMIT 1`, clientColumns, p.scopeName, schemas.Collections.Client)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		Context:         ctx,
 		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -291,5 +291,10 @@ func getIndex(scopeName string) map[string][]string {
 	trustedIssuerIndex2 := fmt.Sprintf("CREATE INDEX TrustedIssuerClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.TrustedIssuer)
 	indices[schemas.Collections.TrustedIssuer] = []string{trustedIssuerIndex1, trustedIssuerIndex2}
 
+	// Client indexes
+	clientIndex1 := fmt.Sprintf("CREATE INDEX ClientClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.Client)
+	clientIndex2 := fmt.Sprintf("CREATE INDEX ClientOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.Client)
+	indices[schemas.Collections.Client] = []string{clientIndex1, clientIndex2}
+
 	return indices
 }

--- a/internal/storage/db/dynamodb/client.go
+++ b/internal/storage/db/dynamodb/client.go
@@ -19,6 +19,17 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// DynamoDB has no unique constraint on a GSI, so guard client_id uniqueness
+	// with a check-then-insert.
+	// ponytail: inherent TOCTOU race — two concurrent inserts of the same
+	// client_id can both pass this check; DynamoDB offers no cross-item
+	// uniqueness. This closes the common case (sequential admin/boot-seed) only.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -80,6 +91,23 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	}
 	if sa.ID == "" {
 		return nil, errors.New("no document found")
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+// Served by the client_id GSI.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	items, err := p.queryEqLimit(ctx, schemas.Collections.Client, "client_id", "client_id", clientID, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var sa schemas.Client
+	if err := unmarshalItem(items[0], &sa); err != nil {
+		return nil, err
 	}
 	return &sa, nil
 }

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -178,7 +178,9 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			hash: "id",
 			attr: []types.AttributeDefinition{
 				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("client_id"), AttributeType: types.ScalarAttributeTypeS},
 			},
+			gsi: []types.GlobalSecondaryIndex{gsi("client_id", "client_id")},
 		},
 		{
 			name: schemas.Collections.TrustedIssuer,

--- a/internal/storage/db/mongodb/client.go
+++ b/internal/storage/db/mongodb/client.go
@@ -19,6 +19,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -68,6 +71,17 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	var sa *schemas.Client
 	saCollection := p.db.Collection(schemas.Collections.Client, options.Collection())
 	err := saCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&sa)
+	if err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa *schemas.Client
+	saCollection := p.db.Collection(schemas.Collections.Client, options.Collection())
+	err := saCollection.FindOne(ctx, bson.M{"client_id": clientID}).Decode(&sa)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -204,6 +204,17 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 
 	// Client collection and indexes
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.Client, options.CreateCollection())
+	clientCollection := mongodb.Collection(schemas.Collections.Client, options.Collection())
+	_, _ = clientCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.M{"client_id": 1},
+			Options: options.Index().SetUnique(true).SetSparse(true),
+		},
+		{
+			Keys:    bson.M{"org_id": 1},
+			Options: options.Index().SetSparse(true),
+		},
+	}, options.CreateIndexes())
 
 	// TrustedIssuer collection and indexes
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.TrustedIssuer, options.CreateCollection())

--- a/internal/storage/db/sql/client.go
+++ b/internal/storage/db/sql/client.go
@@ -17,6 +17,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -56,6 +59,16 @@ func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
 func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Client, error) {
 	var sa schemas.Client
 	res := p.db.Where("id = ?", id).First(&sa)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa schemas.Client
+	res := p.db.Where("client_id = ?", clientID).First(&sa)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -190,8 +190,12 @@ type Provider interface {
 	// DeleteClient removes a service account. Callers must delete
 	// associated TrustedIssuers before or within the same logical operation.
 	DeleteClient(ctx context.Context, sa *schemas.Client) error
-	// GetClientByID fetches a service account by its primary key (= client_id).
+	// GetClientByID fetches a client by its surrogate primary key.
 	GetClientByID(ctx context.Context, id string) (*schemas.Client, error)
+	// GetClientByClientID fetches a client by its public, unique client_id
+	// (distinct from the surrogate ID). This is the lookup the token/authorize
+	// endpoints and the boot-time reserved-client seed use.
+	GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error)
 	// ListClients returns a paginated list of all service accounts.
 	ListClients(ctx context.Context, pagination *model.Pagination) ([]*schemas.Client, *model.Pagination, error)
 

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -1213,12 +1213,19 @@ func testOAuthStateOperations(t *testing.T, ctx context.Context, provider Provid
 // caller — client_credentials authentication would be completely broken.
 func testClientOperations(t *testing.T, ctx context.Context, provider Provider) {
 	const initialSecretHash = "bcrypt-hash-placeholder-initial"
+	explicitClientID := "client-" + uuid.New().String()
+	orgID := "org-" + uuid.New().String()
 	sa := &schemas.Client{
-		Name:          "test_service_account_" + uuid.New().String(),
-		Kind:          "service_account",
-		ClientSecret:  initialSecretHash,
-		AllowedScopes: "read,write",
-		IsActive:      true,
+		Name:                    "test_service_account_" + uuid.New().String(),
+		Kind:                    "interactive",
+		ClientID:                explicitClientID,
+		ClientSecret:            initialSecretHash,
+		AllowedScopes:           "read,write",
+		RedirectURIs:            "https://app.example.com/callback,https://app.example.com/callback2",
+		GrantTypes:              "authorization_code,refresh_token",
+		TokenEndpointAuthMethod: "client_secret_basic",
+		OrgID:                   &orgID,
+		IsActive:                true,
 	}
 
 	created, err := provider.AddClient(ctx, sa)
@@ -1234,9 +1241,34 @@ func testClientOperations(t *testing.T, ctx context.Context, provider Provider) 
 	fetched, err := provider.GetClientByID(ctx, clientID)
 	require.NoError(t, err, "GetClientByID must resolve the API-facing client_id")
 	assert.Equal(t, sa.Name, fetched.Name)
-	assert.Equal(t, "service_account", fetched.Kind, "Kind must round-trip through storage")
+	assert.Equal(t, "interactive", fetched.Kind, "Kind must round-trip through storage")
 	assert.True(t, fetched.IsActive)
 	assert.Equal(t, []string{"read", "write"}, fetched.ParsedAllowedScopes())
+
+	// Interactive-kind registry columns must round-trip through storage.
+	assert.Equal(t, explicitClientID, fetched.ClientID, "ClientID must round-trip through storage")
+	assert.Equal(t, "https://app.example.com/callback,https://app.example.com/callback2", fetched.RedirectURIs, "RedirectURIs must round-trip")
+	assert.Equal(t, "authorization_code,refresh_token", fetched.GrantTypes, "GrantTypes must round-trip")
+	assert.Equal(t, "client_secret_basic", fetched.TokenEndpointAuthMethod, "TokenEndpointAuthMethod must round-trip")
+	require.NotNil(t, fetched.OrgID, "OrgID must round-trip as a non-nil pointer")
+	assert.Equal(t, orgID, *fetched.OrgID, "OrgID value must round-trip")
+
+	// GetClientByClientID resolves by the public client_id (distinct from the
+	// surrogate id) — the lookup the token endpoint and boot-time seed use.
+	byClientID, err := provider.GetClientByClientID(ctx, explicitClientID)
+	require.NoError(t, err, "GetClientByClientID must resolve the public client_id")
+	assert.Equal(t, clientID, byClientID.AsAPIClient().ID, "GetClientByClientID must return the same client")
+	assert.Equal(t, explicitClientID, byClientID.ClientID)
+
+	// A second client with the same client_id must be rejected (unique client_id).
+	_, dupErr := provider.AddClient(ctx, &schemas.Client{
+		Name:         "dup_" + uuid.New().String(),
+		Kind:         "interactive",
+		ClientID:     explicitClientID,
+		ClientSecret: initialSecretHash,
+		IsActive:     true,
+	})
+	assert.Error(t, dupErr, "duplicate client_id must be rejected")
 	// ClientSecret has json:"-" (kept out of API responses/logs) — a storage
 	// provider that (de)serializes via encoding/json for persistence (e.g.
 	// Couchbase) can silently drop it on write or read unless it routes

--- a/internal/storage/schemas/client.go
+++ b/internal/storage/schemas/client.go
@@ -32,6 +32,21 @@ type Client struct {
 
 	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
 
+	// ClientID is the public OAuth client_id presented at the authorize/token
+	// endpoints. It is distinct from the surrogate primary key ID: ID is an
+	// internal UUID, ClientID is the externally-referenced identifier and is
+	// UNIQUE across the registry. ClientID is IMMUTABLE after creation.
+	//
+	// For the reserved interactive client seeded at boot, ClientID equals the
+	// deployment's Config.ClientID verbatim (BC1) — every token aud, JWKS kid,
+	// and introspection client_id continues to key on that exact string.
+	//
+	// When left empty on create, every provider defaults ClientID to ID so the
+	// unique index always holds and lookups keep working for admin-created
+	// clients that do not (yet) supply an explicit client_id — ID has
+	// historically doubled as the client_id.
+	ClientID string `gorm:"uniqueIndex" json:"client_id" bson:"client_id" cql:"client_id" dynamo:"client_id" index:"client_id,hash"`
+
 	// Kind distinguishes the client type. Values: "interactive" (human-facing
 	// login clients) | "service_account" (machine/workload clients). It is
 	// immutable after creation. This rename step defaults existing and newly
@@ -61,6 +76,22 @@ type Client struct {
 	// endpoint — an unparseable or empty AllowedScopes must reject the request.
 	AllowedScopes string `json:"allowed_scopes" bson:"allowed_scopes" cql:"allowed_scopes" dynamo:"allowed_scopes"`
 
+	// RedirectURIs is a comma-separated allow-list of exact redirect URIs for
+	// interactive clients. Empty for service_account clients. The service layer
+	// MUST exact-match a presented redirect_uri against a parsed segment of this
+	// list — never a prefix or substring match.
+	RedirectURIs string `json:"redirect_uris" bson:"redirect_uris" cql:"redirect_uris" dynamo:"redirect_uris"`
+
+	// GrantTypes is a comma-separated list of OAuth2 grant types this client is
+	// allowed to use (e.g. "authorization_code,refresh_token" for interactive
+	// clients, "client_credentials" for service accounts).
+	GrantTypes string `json:"grant_types" bson:"grant_types" cql:"grant_types" dynamo:"grant_types"`
+
+	// TokenEndpointAuthMethod is how the client authenticates at the token
+	// endpoint: "client_secret_basic" | "client_secret_post" | "none" (public
+	// client authenticating via PKCE only).
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method" bson:"token_endpoint_auth_method" cql:"token_endpoint_auth_method" dynamo:"token_endpoint_auth_method"`
+
 	// IsActive controls whether this service account may authenticate.
 	// Flipping to false blocks new token issuance immediately; existing
 	// tokens remain valid until their exp.
@@ -70,6 +101,17 @@ type Client struct {
 	// layer must always set IsActive explicitly and use Save (not Create-only)
 	// when creating a disabled account.
 	IsActive bool `json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active" gorm:"default:true"`
+
+	// OrgID optionally scopes this client to an organization. A nil value means
+	// the client is global (not org-scoped). This is a plain nullable column,
+	// NOT a cross-table foreign key — five of the six storage providers are
+	// NoSQL and cannot enforce an FK constraint, so referential integrity is the
+	// service layer's responsibility.
+	//
+	// No `omitempty` on the json/bson tags: a nil pointer must serialize to
+	// null so an update clears a previously-set org (see
+	// docs/storage-optional-null-fields.md).
+	OrgID *string `json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" gorm:"index"`
 
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`


### PR DESCRIPTION
## Summary

Extracts a shared **client-authentication resolver** (`internal/service/clientauth`) and routes `/oauth/token` client authentication (`authorization_code` + `client_credentials`) through it, replacing the inline `Config.ClientID`/`ClientSecret` comparison and inline service-account lookup. Behavior for the existing reserved client is byte-identical.

Stacked on #649 (base `feat/mai-client-registry-columns`).

## Why this matters for backward compatibility

The reserved client's `client_id` is whatever `--client_id` was set to — **often not a UUID**. The resolver looks clients up by the `client_id` column (`GetClientByClientID`), never the surrogate UUID `id`, so a non-UUID `client_id` (e.g. `test-client-id`) authenticates exactly as before. A config fallback keeps a read-only replica (where the boot seed was skipped) from being locked out.

## Security hardening (found in review, fixed here — not deferred)

A security review found a **secret-confirmation oracle**: because `client_credentials` now resolves the reserved `client_id` (main never did — it looked up by the UUID `id`), a correct secret returned `invalid_scope` while a wrong one returned `invalid_client` — distinguishable. Fixed by enforcing the **§4.1 grant matrix at resolution, before secret verification**: a non-service-account client on `client_credentials` is rejected with `unauthorized_client` regardless of the secret, so correct and wrong secrets return the identical response. Covers the seeded-row and config-fallback paths; regression test `TestResolveClient_InteractiveRejectedForClientCredentials_NoOracle` asserts the responses are indistinguishable.

## Preserved legacy quirks (matched byte-for-byte, documented)

- `authorization_code` returns 401 for a wrong secret presented via POST body (not just Basic).
- `refresh_token` authenticates the `client_id` only, never the secret (refresh tokens are unbound bearer tokens keyed by `login_method:userID`, so this is no weaker than main).

## Testing

- 12 resolver unit tests (each auth method, dual-method rejection → `invalid_request`, unknown-client dummy-hash timing, config fallback, the no-oracle test).
- BC regression (`TestReservedClientLogin_SeededRow` + `_ConfigFallback_SeedAbsent`): full signup → session → `/authorize` → `/oauth/token` with a **non-UUID** `client_id`, asserting unchanged behavior (BC1); cookie AES key untouched (BC2); `aud` stays `Config.ClientID` (BC3).
- `go build`/`vet`/`gofmt`/`make lint-go` clean; no codegen drift.
- **Full integration suite green across 4 consecutive runs** (ruling out the suite's known shared-state flakiness).

Security review verdict: **ship** — BC preserved for a non-UUID reserved client; timing, dual-auth, and fallback-bypass protections intact; the one MEDIUM finding (oracle) is fixed in this PR.

## Deferred to the follow-up (introspect/revoke/discovery rewire)

`introspect.go`, `revoke_refresh_token.go`, `client_check.go`, `app.go`, `authorize.go`, discovery metadata, refresh rotation — and canonicalizing `Config.ClientID` at config load (they compare the raw value; the seed+resolver already agree on the trimmed value).
