### PR TITLE
feat(client): interactive-kind registry columns + reserved-client seed

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -431,6 +431,12 @@ func runRoot(c *cobra.Command, args []string) {
 		}
 	}()
 
+	// Seed the reserved interactive client (Config.ClientID) into the client
+	// registry. Idempotent and non-fatal — must run after storage is up and
+	// before the Token/HTTP subsystems that will (in a later PR) resolve client
+	// auth from this row.
+	seedReservedClient(context.Background(), storageProvider, &rootArgs.config, &log)
+
 	// Authenticator provider
 	authenticatorProvider, err := authenticators.New(&rootArgs.config, &authenticators.Dependencies{
 		Log:             &log,

--- a/cmd/seed_client.go
+++ b/cmd/seed_client.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// reservedClientSecretCost is the bcrypt cost for the reserved client's secret.
+// It mirrors the cost the admin client API commits to (see
+// internal/service/admin_clients.go clientSecretCost) — MUST stay 12.
+const reservedClientSecretCost = 12
+
+// seedReservedClient idempotently upserts the deployment's reserved interactive
+// client into the client registry, keyed on ClientID == Config.ClientID (BC1).
+//
+// The row makes the deployment's global OAuth client a first-class registry
+// record so later PRs can resolve client authentication from storage. This PR
+// only makes the row EXIST; it does NOT rewire any handler — existing
+// Config.ClientID comparisons stay as-is.
+//
+// BC2: Config.ClientSecret remains the session-cookie AES key untouched. We only
+// ADD a bcrypt hash of it into the client row; cookie crypto is not changed.
+//
+// The seed is idempotent (skip-if-present, keyed on ClientID). On a read-only /
+// no-write-path storage instance the AddClient error is logged and skipped
+// rather than fatal, so a read replica can still boot.
+func seedReservedClient(ctx context.Context, storageProvider storage.Provider, cfg *config.Config, logger *zerolog.Logger) {
+	log := logger.With().Str("func", "seedReservedClient").Logger()
+
+	clientID := strings.TrimSpace(cfg.ClientID)
+	if clientID == "" {
+		log.Warn().Msg("Config.ClientID is empty; skipping reserved client seed")
+		return
+	}
+
+	if existing, err := storageProvider.GetClientByClientID(ctx, clientID); err == nil && existing != nil {
+		log.Debug().Msg("reserved client already present; seed is a no-op")
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.ClientSecret), reservedClientSecretCost)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to bcrypt Config.ClientSecret; skipping reserved client seed")
+		return
+	}
+
+	if _, err := storageProvider.AddClient(ctx, &schemas.Client{
+		ClientID:                clientID,
+		Kind:                    constants.ClientKindInteractive,
+		Name:                    "Reserved Interactive Client",
+		ClientSecret:            string(hash),
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		GrantTypes:              constants.GrantTypeAuthorizationCode + "," + constants.GrantTypeRefreshToken,
+		IsActive:                true,
+	}); err != nil {
+		// Read-only / no-write-path instance, or a concurrent seed that lost the
+		// unique-index race: log and skip rather than fatal.
+		log.Warn().Err(err).Msg("failed to seed reserved client (read-only instance or concurrent seed); continuing")
+		return
+	}
+
+	log.Info().Str("client_id", clientID).Msg("seeded reserved interactive client")
+}

--- a/cmd/seed_client_test.go
+++ b/cmd/seed_client_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage"
+)
+
+func newSeedTestProvider(t *testing.T) (storage.Provider, *config.Config) {
+	t.Helper()
+	cfg := &config.Config{
+		DatabaseType: constants.DbTypeSqlite,
+		DatabaseURL:  filepath.Join(t.TempDir(), "seed_client_test.db"),
+		DatabaseName: "authorizer_test",
+		ClientID:     "reserved-client-" + t.Name(),
+		ClientSecret: "super-secret-cookie-key",
+	}
+	logger := zerolog.Nop()
+	sp, err := storage.New(cfg, &storage.Dependencies{Log: &logger})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sp.Close() })
+	return sp, cfg
+}
+
+// TestSeedReservedClient_IsIdempotent verifies the boot seed inserts exactly one
+// reserved client, keyed on Config.ClientID, and is a no-op on repeat calls.
+func TestSeedReservedClient_IsIdempotent(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	// Exactly one row carries the reserved client_id.
+	clients, _, err := sp.ListClients(ctx, &model.Pagination{Limit: 100, Offset: 0})
+	require.NoError(t, err)
+	count := 0
+	for _, c := range clients {
+		if c.ClientID == cfg.ClientID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "seeding twice must yield exactly one reserved client row")
+}
+
+// TestSeedReservedClient_RowShape verifies the seeded row's identity, kind, and
+// that its stored secret is a bcrypt hash verifying against Config.ClientSecret
+// (BC1: client_id == Config.ClientID).
+func TestSeedReservedClient_RowShape(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	row, err := sp.GetClientByClientID(ctx, cfg.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+
+	assert.Equal(t, cfg.ClientID, row.ClientID, "BC1: seeded client_id must equal Config.ClientID")
+	assert.Equal(t, constants.ClientKindInteractive, row.Kind)
+	assert.Equal(t, constants.TokenEndpointAuthMethodClientSecretBasic, row.TokenEndpointAuthMethod)
+	assert.True(t, row.IsActive)
+	assert.Contains(t, row.GrantTypes, constants.GrantTypeAuthorizationCode)
+	assert.Contains(t, row.GrantTypes, constants.GrantTypeRefreshToken)
+
+	// The stored secret is a bcrypt hash of Config.ClientSecret, never plaintext.
+	assert.NotEqual(t, cfg.ClientSecret, row.ClientSecret, "stored secret must be hashed, not plaintext")
+	assert.NoError(t,
+		bcrypt.CompareHashAndPassword([]byte(row.ClientSecret), []byte(cfg.ClientSecret)),
+		"stored bcrypt hash must verify against Config.ClientSecret",
+	)
+}
+
+// TestSeedReservedClient_EmptyClientIDSkips verifies an empty Config.ClientID is
+// a safe no-op (no row, no panic).
+func TestSeedReservedClient_EmptyClientIDSkips(t *testing.T) {
+	sp, cfg := newSeedTestProvider(t)
+	cfg.ClientID = ""
+	logger := zerolog.Nop()
+	ctx := context.Background()
+
+	seedReservedClient(ctx, sp, cfg, &logger)
+
+	clients, _, err := sp.ListClients(ctx, &model.Pagination{Limit: 100, Offset: 0})
+	require.NoError(t, err)
+	assert.Empty(t, clients, "empty Config.ClientID must seed nothing")
+}

--- a/internal/constants/client_registry.go
+++ b/internal/constants/client_registry.go
@@ -1,0 +1,27 @@
+package constants
+
+// Client.Kind discriminator values. Immutable after creation.
+const (
+	// ClientKindInteractive is a human-facing login client (browser/app
+	// authorization_code + PKCE flows).
+	ClientKindInteractive = "interactive"
+
+	// ClientKindServiceAccount is a machine/workload client using the
+	// client_credentials grant or workload identity federation.
+	ClientKindServiceAccount = "service_account"
+)
+
+// Client.TokenEndpointAuthMethod values (RFC 7591 §2 / OIDC Core §9).
+const (
+	// TokenEndpointAuthMethodClientSecretBasic sends client_id/client_secret in
+	// the HTTP Authorization header (RFC 6749 §2.3.1).
+	TokenEndpointAuthMethodClientSecretBasic = "client_secret_basic"
+
+	// TokenEndpointAuthMethodClientSecretPost sends client_id/client_secret in
+	// the request body.
+	TokenEndpointAuthMethodClientSecretPost = "client_secret_post"
+
+	// TokenEndpointAuthMethodNone is a public client with no secret; it proves
+	// possession via PKCE.
+	TokenEndpointAuthMethodNone = "none"
+)

--- a/internal/storage/db/arangodb/client.go
+++ b/internal/storage/db/arangodb/client.go
@@ -18,6 +18,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -102,6 +105,34 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 		if !cursor.HasMore() {
 			if sa == nil {
 				return nil, fmt.Errorf("service account not found")
+			}
+			break
+		}
+		s := &schemas.Client{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		sa = s
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa *schemas.Client
+	query := fmt.Sprintf("FOR d in %s FILTER d.client_id == @client_id LIMIT 1 RETURN d", schemas.Collections.Client)
+	bindVars := map[string]interface{}{
+		"client_id": clientID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if sa == nil {
+				return nil, fmt.Errorf("client not found")
 			}
 			break
 		}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -359,6 +359,17 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 			return nil, err
 		}
 	}
+	clientCollection, err := arangodb.Collection(ctx, schemas.Collections.Client)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = clientCollection.EnsureHashIndex(ctx, []string{"client_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Unique: true,
+		Sparse: true,
+	})
+	_, _, _ = clientCollection.EnsureHashIndex(ctx, []string{"org_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Sparse: true,
+	})
 
 	// TrustedIssuer collection and indexes
 	trustedIssuerCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.TrustedIssuer)

--- a/internal/storage/db/cassandradb/client.go
+++ b/internal/storage/db/cassandradb/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const clientColumns = "id, kind, name, description, client_secret, allowed_scopes, is_active, created_at, updated_at"
+const clientColumns = "id, client_id, kind, name, description, client_secret, allowed_scopes, redirect_uris, grant_types, token_endpoint_auth_method, is_active, org_id, created_at, updated_at"
 
 // AddClient creates a new service account record.
 func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.Client, error) {
@@ -21,11 +21,25 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// Cassandra has no cross-attribute unique constraint, so guard client_id
+	// uniqueness with a check-then-insert mirroring AddTrustedIssuer's issuer_url
+	// pre-check.
+	// ponytail: inherent TOCTOU race — two concurrent inserts of the same
+	// client_id can both pass this check. Cassandra offers no atomic IF NOT
+	// EXISTS on a non-partition-key column; this closes the common case
+	// (sequential admin/boot-seed) only. A fully race-free guard would need an
+	// LWT on a dedicated client_id-keyed table.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
-	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.Client, clientColumns)
-	err := p.db.Query(insertQuery, sa.ID, sa.Kind, sa.Name, sa.Description, sa.ClientSecret, sa.AllowedScopes, sa.IsActive, sa.CreatedAt, sa.UpdatedAt).Exec()
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.Client, clientColumns)
+	err := p.db.Query(insertQuery, sa.ID, sa.ClientID, sa.Kind, sa.Name, sa.Description, sa.ClientSecret, sa.AllowedScopes, sa.RedirectURIs, sa.GrantTypes, sa.TokenEndpointAuthMethod, sa.IsActive, sa.OrgID, sa.CreatedAt, sa.UpdatedAt).Exec()
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +124,19 @@ func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
 func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Client, error) {
 	var sa schemas.Client
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", clientColumns, KeySpace+"."+schemas.Collections.Client)
-	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&sa.ID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.IsActive, &sa.CreatedAt, &sa.UpdatedAt)
+	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+// Served by the client_id secondary index.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa schemas.Client
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE client_id = ? LIMIT 1 ALLOW FILTERING", clientColumns, KeySpace+"."+schemas.Collections.Client)
+	err := p.db.Query(query, clientID).Consistency(gocql.One).Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +161,7 @@ func (p *provider) ListClients(ctx context.Context, pagination *model.Pagination
 	for scanner.Next() {
 		if counter >= pagination.Offset {
 			var sa schemas.Client
-			err := scanner.Scan(&sa.ID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.IsActive, &sa.CreatedAt, &sa.UpdatedAt)
+			err := scanner.Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -372,11 +372,25 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	waitForCassandraIndexes(session, KeySpace, schemas.Collections.AuditLog, 30*time.Second)
 
 	// Client table
-	clientCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, kind text, name text, description text, client_secret text, allowed_scopes text, is_active boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.Client)
+	clientCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, kind text, name text, description text, client_secret text, allowed_scopes text, redirect_uris text, grant_types text, token_endpoint_auth_method text, is_active boolean, org_id text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.Client)
 	err = session.Query(clientCollectionQuery).Exec()
 	if err != nil {
 		return nil, err
 	}
+	clientClientIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_client_client_id ON %s.%s (client_id)", KeySpace, schemas.Collections.Client)
+	err = session.Query(clientClientIDIndex).Exec()
+	if err != nil {
+		return nil, err
+	}
+	clientOrgIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_client_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.Client)
+	err = session.Query(clientOrgIDIndex).Exec()
+	if err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for the client_id
+	// index (used by GetClientByClientID and the boot-time reserved-client seed)
+	// to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Client, "client_id", 30*time.Second)
 
 	// TrustedIssuer table and indexes
 	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
@@ -396,7 +410,7 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	}
 	// ScyllaDB builds secondary indexes asynchronously; wait for the issuer_url
 	// index (hot path for client_assertion validation) to become queryable.
-	waitForCassandraTrustedIssuerIndexes(session, KeySpace, schemas.Collections.TrustedIssuer, 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.TrustedIssuer, "issuer_url", 30*time.Second)
 
 	return &provider{
 		config:       cfg,
@@ -426,12 +440,13 @@ func waitForCassandraIndexes(session *cansandraDriver.Session, keyspace, table s
 	}
 }
 
-// waitForCassandraTrustedIssuerIndexes polls a probe query that requires the
-// issuer_url secondary index until it succeeds or the timeout is reached.
-// ScyllaDB builds secondary indexes asynchronously; the issuer_url lookup is a
-// hot path (client_assertion validation) so we wait for it to become queryable.
-func waitForCassandraTrustedIssuerIndexes(session *cansandraDriver.Session, keyspace, table string, timeout time.Duration) {
-	probe := fmt.Sprintf("SELECT id FROM %s.%s WHERE issuer_url='' LIMIT 1 ALLOW FILTERING", keyspace, table)
+// waitForCassandraSecondaryIndex polls a probe query that requires the given
+// column's secondary index until it succeeds or the timeout is reached.
+// ScyllaDB builds secondary indexes asynchronously; hot-path lookups (e.g.
+// issuer_url for client_assertion validation, client_id for client resolution)
+// must wait for the index to become queryable.
+func waitForCassandraSecondaryIndex(session *cansandraDriver.Session, keyspace, table, column string, timeout time.Duration) {
+	probe := fmt.Sprintf("SELECT id FROM %s.%s WHERE %s='' LIMIT 1 ALLOW FILTERING", keyspace, table, column)
 	deadline := time.Now().Add(timeout)
 	delay := 500 * time.Millisecond
 	for {

--- a/internal/storage/db/couchbase/client.go
+++ b/internal/storage/db/couchbase/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const clientColumns = "_id, kind, name, description, client_secret, allowed_scopes, is_active, created_at, updated_at"
+const clientColumns = "_id, client_id, kind, name, description, client_secret, allowed_scopes, redirect_uris, grant_types, token_endpoint_auth_method, is_active, org_id, created_at, updated_at"
 
 // AddClient creates a new service account record.
 func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.Client, error) {
@@ -21,6 +21,16 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// Couchbase enforces uniqueness only on the document key (_id), so guard
+	// client_id uniqueness with a check-then-insert.
+	// ponytail: inherent TOCTOU race — sequential admin/boot-seed only; a
+	// concurrent double-insert of the same client_id is not fully prevented.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -93,6 +103,30 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	params := make(map[string]interface{}, 1)
 	params["_id"] = id
 	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, clientColumns, p.scopeName, schemas.Collections.Client)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	sa := &schemas.Client{}
+	if err := decodeDocument(raw, sa); err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	params := make(map[string]interface{}, 1)
+	params["client_id"] = clientID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE client_id=$client_id LIMIT 1`, clientColumns, p.scopeName, schemas.Collections.Client)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		Context:         ctx,
 		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -291,5 +291,10 @@ func getIndex(scopeName string) map[string][]string {
 	trustedIssuerIndex2 := fmt.Sprintf("CREATE INDEX TrustedIssuerClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.TrustedIssuer)
 	indices[schemas.Collections.TrustedIssuer] = []string{trustedIssuerIndex1, trustedIssuerIndex2}
 
+	// Client indexes
+	clientIndex1 := fmt.Sprintf("CREATE INDEX ClientClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.Client)
+	clientIndex2 := fmt.Sprintf("CREATE INDEX ClientOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.Client)
+	indices[schemas.Collections.Client] = []string{clientIndex1, clientIndex2}
+
 	return indices
 }

--- a/internal/storage/db/dynamodb/client.go
+++ b/internal/storage/db/dynamodb/client.go
@@ -19,6 +19,17 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
+	// DynamoDB has no unique constraint on a GSI, so guard client_id uniqueness
+	// with a check-then-insert.
+	// ponytail: inherent TOCTOU race — two concurrent inserts of the same
+	// client_id can both pass this check; DynamoDB offers no cross-item
+	// uniqueness. This closes the common case (sequential admin/boot-seed) only.
+	if existing, _ := p.GetClientByClientID(ctx, sa.ClientID); existing != nil {
+		return nil, fmt.Errorf("client with client_id %s already exists", sa.ClientID)
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -80,6 +91,23 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	}
 	if sa.ID == "" {
 		return nil, errors.New("no document found")
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+// Served by the client_id GSI.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	items, err := p.queryEqLimit(ctx, schemas.Collections.Client, "client_id", "client_id", clientID, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var sa schemas.Client
+	if err := unmarshalItem(items[0], &sa); err != nil {
+		return nil, err
 	}
 	return &sa, nil
 }

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -178,7 +178,9 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			hash: "id",
 			attr: []types.AttributeDefinition{
 				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("client_id"), AttributeType: types.ScalarAttributeTypeS},
 			},
+			gsi: []types.GlobalSecondaryIndex{gsi("client_id", "client_id")},
 		},
 		{
 			name: schemas.Collections.TrustedIssuer,

--- a/internal/storage/db/mongodb/client.go
+++ b/internal/storage/db/mongodb/client.go
@@ -19,6 +19,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -68,6 +71,17 @@ func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Clien
 	var sa *schemas.Client
 	saCollection := p.db.Collection(schemas.Collections.Client, options.Collection())
 	err := saCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&sa)
+	if err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa *schemas.Client
+	saCollection := p.db.Collection(schemas.Collections.Client, options.Collection())
+	err := saCollection.FindOne(ctx, bson.M{"client_id": clientID}).Decode(&sa)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -204,6 +204,17 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 
 	// Client collection and indexes
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.Client, options.CreateCollection())
+	clientCollection := mongodb.Collection(schemas.Collections.Client, options.Collection())
+	_, _ = clientCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.M{"client_id": 1},
+			Options: options.Index().SetUnique(true).SetSparse(true),
+		},
+		{
+			Keys:    bson.M{"org_id": 1},
+			Options: options.Index().SetSparse(true),
+		},
+	}, options.CreateIndexes())
 
 	// TrustedIssuer collection and indexes
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.TrustedIssuer, options.CreateCollection())

--- a/internal/storage/db/sql/client.go
+++ b/internal/storage/db/sql/client.go
@@ -17,6 +17,9 @@ func (p *provider) AddClient(ctx context.Context, sa *schemas.Client) (*schemas.
 		sa.ID = uuid.New().String()
 	}
 	sa.Key = sa.ID
+	if sa.ClientID == "" {
+		sa.ClientID = sa.ID
+	}
 	now := time.Now().Unix()
 	sa.CreatedAt = now
 	sa.UpdatedAt = now
@@ -56,6 +59,16 @@ func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
 func (p *provider) GetClientByID(ctx context.Context, id string) (*schemas.Client, error) {
 	var sa schemas.Client
 	res := p.db.Where("id = ?", id).First(&sa)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &sa, nil
+}
+
+// GetClientByClientID fetches a client by its unique public client_id.
+func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error) {
+	var sa schemas.Client
+	res := p.db.Where("client_id = ?", clientID).First(&sa)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -190,8 +190,12 @@ type Provider interface {
 	// DeleteClient removes a service account. Callers must delete
 	// associated TrustedIssuers before or within the same logical operation.
 	DeleteClient(ctx context.Context, sa *schemas.Client) error
-	// GetClientByID fetches a service account by its primary key (= client_id).
+	// GetClientByID fetches a client by its surrogate primary key.
 	GetClientByID(ctx context.Context, id string) (*schemas.Client, error)
+	// GetClientByClientID fetches a client by its public, unique client_id
+	// (distinct from the surrogate ID). This is the lookup the token/authorize
+	// endpoints and the boot-time reserved-client seed use.
+	GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error)
 	// ListClients returns a paginated list of all service accounts.
 	ListClients(ctx context.Context, pagination *model.Pagination) ([]*schemas.Client, *model.Pagination, error)
 

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -1213,12 +1213,19 @@ func testOAuthStateOperations(t *testing.T, ctx context.Context, provider Provid
 // caller — client_credentials authentication would be completely broken.
 func testClientOperations(t *testing.T, ctx context.Context, provider Provider) {
 	const initialSecretHash = "bcrypt-hash-placeholder-initial"
+	explicitClientID := "client-" + uuid.New().String()
+	orgID := "org-" + uuid.New().String()
 	sa := &schemas.Client{
-		Name:          "test_service_account_" + uuid.New().String(),
-		Kind:          "service_account",
-		ClientSecret:  initialSecretHash,
-		AllowedScopes: "read,write",
-		IsActive:      true,
+		Name:                    "test_service_account_" + uuid.New().String(),
+		Kind:                    "interactive",
+		ClientID:                explicitClientID,
+		ClientSecret:            initialSecretHash,
+		AllowedScopes:           "read,write",
+		RedirectURIs:            "https://app.example.com/callback,https://app.example.com/callback2",
+		GrantTypes:              "authorization_code,refresh_token",
+		TokenEndpointAuthMethod: "client_secret_basic",
+		OrgID:                   &orgID,
+		IsActive:                true,
 	}
 
 	created, err := provider.AddClient(ctx, sa)
@@ -1234,9 +1241,34 @@ func testClientOperations(t *testing.T, ctx context.Context, provider Provider) 
 	fetched, err := provider.GetClientByID(ctx, clientID)
 	require.NoError(t, err, "GetClientByID must resolve the API-facing client_id")
 	assert.Equal(t, sa.Name, fetched.Name)
-	assert.Equal(t, "service_account", fetched.Kind, "Kind must round-trip through storage")
+	assert.Equal(t, "interactive", fetched.Kind, "Kind must round-trip through storage")
 	assert.True(t, fetched.IsActive)
 	assert.Equal(t, []string{"read", "write"}, fetched.ParsedAllowedScopes())
+
+	// Interactive-kind registry columns must round-trip through storage.
+	assert.Equal(t, explicitClientID, fetched.ClientID, "ClientID must round-trip through storage")
+	assert.Equal(t, "https://app.example.com/callback,https://app.example.com/callback2", fetched.RedirectURIs, "RedirectURIs must round-trip")
+	assert.Equal(t, "authorization_code,refresh_token", fetched.GrantTypes, "GrantTypes must round-trip")
+	assert.Equal(t, "client_secret_basic", fetched.TokenEndpointAuthMethod, "TokenEndpointAuthMethod must round-trip")
+	require.NotNil(t, fetched.OrgID, "OrgID must round-trip as a non-nil pointer")
+	assert.Equal(t, orgID, *fetched.OrgID, "OrgID value must round-trip")
+
+	// GetClientByClientID resolves by the public client_id (distinct from the
+	// surrogate id) — the lookup the token endpoint and boot-time seed use.
+	byClientID, err := provider.GetClientByClientID(ctx, explicitClientID)
+	require.NoError(t, err, "GetClientByClientID must resolve the public client_id")
+	assert.Equal(t, clientID, byClientID.AsAPIClient().ID, "GetClientByClientID must return the same client")
+	assert.Equal(t, explicitClientID, byClientID.ClientID)
+
+	// A second client with the same client_id must be rejected (unique client_id).
+	_, dupErr := provider.AddClient(ctx, &schemas.Client{
+		Name:         "dup_" + uuid.New().String(),
+		Kind:         "interactive",
+		ClientID:     explicitClientID,
+		ClientSecret: initialSecretHash,
+		IsActive:     true,
+	})
+	assert.Error(t, dupErr, "duplicate client_id must be rejected")
 	// ClientSecret has json:"-" (kept out of API responses/logs) — a storage
 	// provider that (de)serializes via encoding/json for persistence (e.g.
 	// Couchbase) can silently drop it on write or read unless it routes

--- a/internal/storage/schemas/client.go
+++ b/internal/storage/schemas/client.go
@@ -32,6 +32,21 @@ type Client struct {
 
 	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
 
+	// ClientID is the public OAuth client_id presented at the authorize/token
+	// endpoints. It is distinct from the surrogate primary key ID: ID is an
+	// internal UUID, ClientID is the externally-referenced identifier and is
+	// UNIQUE across the registry. ClientID is IMMUTABLE after creation.
+	//
+	// For the reserved interactive client seeded at boot, ClientID equals the
+	// deployment's Config.ClientID verbatim (BC1) — every token aud, JWKS kid,
+	// and introspection client_id continues to key on that exact string.
+	//
+	// When left empty on create, every provider defaults ClientID to ID so the
+	// unique index always holds and lookups keep working for admin-created
+	// clients that do not (yet) supply an explicit client_id — ID has
+	// historically doubled as the client_id.
+	ClientID string `gorm:"uniqueIndex" json:"client_id" bson:"client_id" cql:"client_id" dynamo:"client_id" index:"client_id,hash"`
+
 	// Kind distinguishes the client type. Values: "interactive" (human-facing
 	// login clients) | "service_account" (machine/workload clients). It is
 	// immutable after creation. This rename step defaults existing and newly
@@ -61,6 +76,22 @@ type Client struct {
 	// endpoint — an unparseable or empty AllowedScopes must reject the request.
 	AllowedScopes string `json:"allowed_scopes" bson:"allowed_scopes" cql:"allowed_scopes" dynamo:"allowed_scopes"`
 
+	// RedirectURIs is a comma-separated allow-list of exact redirect URIs for
+	// interactive clients. Empty for service_account clients. The service layer
+	// MUST exact-match a presented redirect_uri against a parsed segment of this
+	// list — never a prefix or substring match.
+	RedirectURIs string `json:"redirect_uris" bson:"redirect_uris" cql:"redirect_uris" dynamo:"redirect_uris"`
+
+	// GrantTypes is a comma-separated list of OAuth2 grant types this client is
+	// allowed to use (e.g. "authorization_code,refresh_token" for interactive
+	// clients, "client_credentials" for service accounts).
+	GrantTypes string `json:"grant_types" bson:"grant_types" cql:"grant_types" dynamo:"grant_types"`
+
+	// TokenEndpointAuthMethod is how the client authenticates at the token
+	// endpoint: "client_secret_basic" | "client_secret_post" | "none" (public
+	// client authenticating via PKCE only).
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method" bson:"token_endpoint_auth_method" cql:"token_endpoint_auth_method" dynamo:"token_endpoint_auth_method"`
+
 	// IsActive controls whether this service account may authenticate.
 	// Flipping to false blocks new token issuance immediately; existing
 	// tokens remain valid until their exp.
@@ -70,6 +101,17 @@ type Client struct {
 	// layer must always set IsActive explicitly and use Save (not Create-only)
 	// when creating a disabled account.
 	IsActive bool `json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active" gorm:"default:true"`
+
+	// OrgID optionally scopes this client to an organization. A nil value means
+	// the client is global (not org-scoped). This is a plain nullable column,
+	// NOT a cross-table foreign key — five of the six storage providers are
+	// NoSQL and cannot enforce an FK constraint, so referential integrity is the
+	// service layer's responsibility.
+	//
+	// No `omitempty` on the json/bson tags: a nil pointer must serialize to
+	// null so an update clears a previously-set org (see
+	// docs/storage-optional-null-fields.md).
+	OrgID *string `json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" gorm:"index"`
 
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`


### PR DESCRIPTION
Registry columns + reserved-client seed (BC1/BC2). Foundation #648 is now merged; this is the same content as the CI-green, security-reviewed #649 (reopened against main after a stacked-merge base-branch deletion closed it). See #649 for full description and the review verdict (SHIP).