### PR TITLE
feat(organizations): Organization + user-org membership entities

### DIFF
--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -33,6 +33,10 @@ const (
 	AuditResourceTypeServiceAccount = "service_account"
 	// AuditResourceTypeTrustedIssuer represents a trusted external JWT issuer.
 	AuditResourceTypeTrustedIssuer = "trusted_issuer"
+	// AuditResourceTypeOrganization represents an organization entity.
+	AuditResourceTypeOrganization = "organization"
+	// AuditResourceTypeOrgMembership represents an org membership entity.
+	AuditResourceTypeOrgMembership = "org_membership"
 )
 
 // Audit event type constants used for structured audit logging.
@@ -159,6 +163,27 @@ const (
 	// Downgrading from online (true) to offline (false) is a security-posture change and
 	// must be queryable independently of generic trusted_issuer_updated events.
 	AuditTrustedIssuerTokenReviewChangedEvent = "admin.trusted_issuer_token_review_changed"
+
+	// AuditOrganizationCreatedEvent is logged when an admin creates an organization.
+	AuditOrganizationCreatedEvent = "admin.organization_created"
+	// AuditOrganizationCreateFailedEvent is logged when organization creation fails.
+	AuditOrganizationCreateFailedEvent = "admin.organization_create_failed"
+	// AuditOrganizationUpdatedEvent is logged when an admin updates an organization.
+	AuditOrganizationUpdatedEvent = "admin.organization_updated"
+	// AuditOrganizationUpdateFailedEvent is logged when an organization update fails.
+	AuditOrganizationUpdateFailedEvent = "admin.organization_update_failed"
+	// AuditOrganizationDeletedEvent is logged when an admin deletes an organization.
+	AuditOrganizationDeletedEvent = "admin.organization_deleted"
+	// AuditOrganizationDeleteFailedEvent is logged when an organization delete fails.
+	AuditOrganizationDeleteFailedEvent = "admin.organization_delete_failed"
+	// AuditOrgMemberAddedEvent is logged when an admin adds a user to an organization.
+	AuditOrgMemberAddedEvent = "admin.org_member_added"
+	// AuditOrgMemberAddFailedEvent is logged when adding an org member fails.
+	AuditOrgMemberAddFailedEvent = "admin.org_member_add_failed"
+	// AuditOrgMemberRemovedEvent is logged when an admin removes a user from an organization.
+	AuditOrgMemberRemovedEvent = "admin.org_member_removed"
+	// AuditOrgMemberRemoveFailedEvent is logged when removing an org member fails.
+	AuditOrgMemberRemoveFailedEvent = "admin.org_member_remove_failed"
 
 	// AuditTokenClientCredentialsEvent is logged when a service account obtains a token
 	// via the client_credentials grant (RFC 6749 §4.4).

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -275,15 +275,18 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		AddEmailTemplate    func(childComplexity int, params model.AddEmailTemplateRequest) int
+		AddOrgMember        func(childComplexity int, params model.AddOrgMemberRequest) int
 		AddTrustedIssuer    func(childComplexity int, params model.AddTrustedIssuerRequest) int
 		AddWebhook          func(childComplexity int, params model.AddWebhookRequest) int
 		AdminLogin          func(childComplexity int, params model.AdminLoginRequest) int
 		AdminLogout         func(childComplexity int) int
 		AdminSignup         func(childComplexity int, params model.AdminSignupRequest) int
 		CreateClient        func(childComplexity int, params model.CreateClientRequest) int
+		CreateOrganization  func(childComplexity int, params model.CreateOrganizationRequest) int
 		DeactivateAccount   func(childComplexity int) int
 		DeleteClient        func(childComplexity int, params model.ClientRequest) int
 		DeleteEmailTemplate func(childComplexity int, params model.DeleteEmailTemplateRequest) int
+		DeleteOrganization  func(childComplexity int, params model.OrganizationRequest) int
 		DeleteTrustedIssuer func(childComplexity int, params model.TrustedIssuerRequest) int
 		DeleteUser          func(childComplexity int, params model.DeleteUserRequest) int
 		DeleteWebhook       func(childComplexity int, params model.WebhookRequest) int
@@ -300,6 +303,7 @@ type ComplexityRoot struct {
 		MagicLinkLogin      func(childComplexity int, params model.MagicLinkLoginRequest) int
 		MobileLogin         func(childComplexity int, params model.MobileLoginRequest) int
 		MobileSignup        func(childComplexity int, params *model.MobileSignUpRequest) int
+		RemoveOrgMember     func(childComplexity int, params model.RemoveOrgMemberRequest) int
 		ResendOtp           func(childComplexity int, params model.ResendOTPRequest) int
 		ResendVerifyEmail   func(childComplexity int, params model.ResendVerifyEmailRequest) int
 		ResetPassword       func(childComplexity int, params model.ResetPasswordRequest) int
@@ -311,12 +315,41 @@ type ComplexityRoot struct {
 		UpdateClient        func(childComplexity int, params model.UpdateClientRequest) int
 		UpdateEmailTemplate func(childComplexity int, params model.UpdateEmailTemplateRequest) int
 		UpdateEnv           func(childComplexity int, params model.UpdateEnvRequest) int
+		UpdateOrganization  func(childComplexity int, params model.UpdateOrganizationRequest) int
 		UpdateProfile       func(childComplexity int, params model.UpdateProfileRequest) int
 		UpdateTrustedIssuer func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
 		UpdateUser          func(childComplexity int, params model.UpdateUserRequest) int
 		UpdateWebhook       func(childComplexity int, params model.UpdateWebhookRequest) int
 		VerifyEmail         func(childComplexity int, params model.VerifyEmailRequest) int
 		VerifyOtp           func(childComplexity int, params model.VerifyOTPRequest) int
+	}
+
+	OrgMember struct {
+		CreatedAt func(childComplexity int) int
+		ID        func(childComplexity int) int
+		OrgID     func(childComplexity int) int
+		Roles     func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+		UserID    func(childComplexity int) int
+	}
+
+	OrgMembers struct {
+		OrgMembers func(childComplexity int) int
+		Pagination func(childComplexity int) int
+	}
+
+	Organization struct {
+		CreatedAt   func(childComplexity int) int
+		DisplayName func(childComplexity int) int
+		Enabled     func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
+	}
+
+	Organizations struct {
+		Organizations func(childComplexity int) int
+		Pagination    func(childComplexity int) int
 	}
 
 	Pagination struct {
@@ -352,6 +385,9 @@ type ComplexityRoot struct {
 		FgaReadTuples        func(childComplexity int, params model.FgaReadTuplesInput) int
 		ListPermissions      func(childComplexity int, params model.ListPermissionsInput) int
 		Meta                 func(childComplexity int) int
+		OrgMembers           func(childComplexity int, params model.ListOrgMembersRequest) int
+		Organization         func(childComplexity int, params model.OrganizationRequest) int
+		Organizations        func(childComplexity int, params *model.ListOrganizationsRequest) int
 		Profile              func(childComplexity int) int
 		Session              func(childComplexity int, params *model.SessionQueryRequest) int
 		TrustedIssuer        func(childComplexity int, params model.TrustedIssuerRequest) int
@@ -519,6 +555,11 @@ type MutationResolver interface {
 	AddTrustedIssuer(ctx context.Context, params model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error)
 	UpdateTrustedIssuer(ctx context.Context, params model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error)
 	DeleteTrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.Response, error)
+	CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error)
+	UpdateOrganization(ctx context.Context, params model.UpdateOrganizationRequest) (*model.Organization, error)
+	DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error)
+	AddOrgMember(ctx context.Context, params model.AddOrgMemberRequest) (*model.OrgMember, error)
+	RemoveOrgMember(ctx context.Context, params model.RemoveOrgMemberRequest) (*model.Response, error)
 	TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error)
 	AddEmailTemplate(ctx context.Context, params model.AddEmailTemplateRequest) (*model.Response, error)
 	UpdateEmailTemplate(ctx context.Context, params model.UpdateEmailTemplateRequest) (*model.Response, error)
@@ -547,6 +588,9 @@ type QueryResolver interface {
 	Clients(ctx context.Context, params *model.ListClientsRequest) (*model.Clients, error)
 	TrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.TrustedIssuer, error)
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
+	Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error)
+	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
+	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
 	EmailTemplates(ctx context.Context, params *model.PaginatedRequest) (*model.EmailTemplates, error)
 	AuditLogs(ctx context.Context, params *model.ListAuditLogRequest) (*model.AuditLogs, error)
 	FgaGetModel(ctx context.Context) (*model.FgaModel, error)
@@ -1715,6 +1759,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.AddEmailTemplate(childComplexity, args["params"].(model.AddEmailTemplateRequest)), true
 
+	case "Mutation._add_org_member":
+		if e.complexity.Mutation.AddOrgMember == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__add_org_member_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddOrgMember(childComplexity, args["params"].(model.AddOrgMemberRequest)), true
+
 	case "Mutation._add_trusted_issuer":
 		if e.complexity.Mutation.AddTrustedIssuer == nil {
 			break
@@ -1782,6 +1838,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateClient(childComplexity, args["params"].(model.CreateClientRequest)), true
 
+	case "Mutation._create_organization":
+		if e.complexity.Mutation.CreateOrganization == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_organization_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateOrganization(childComplexity, args["params"].(model.CreateOrganizationRequest)), true
+
 	case "Mutation.deactivate_account":
 		if e.complexity.Mutation.DeactivateAccount == nil {
 			break
@@ -1812,6 +1880,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteEmailTemplate(childComplexity, args["params"].(model.DeleteEmailTemplateRequest)), true
+
+	case "Mutation._delete_organization":
+		if e.complexity.Mutation.DeleteOrganization == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_organization_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteOrganization(childComplexity, args["params"].(model.OrganizationRequest)), true
 
 	case "Mutation._delete_trusted_issuer":
 		if e.complexity.Mutation.DeleteTrustedIssuer == nil {
@@ -1995,6 +2075,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.MobileSignup(childComplexity, args["params"].(*model.MobileSignUpRequest)), true
 
+	case "Mutation._remove_org_member":
+		if e.complexity.Mutation.RemoveOrgMember == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__remove_org_member_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveOrgMember(childComplexity, args["params"].(model.RemoveOrgMemberRequest)), true
+
 	case "Mutation.resend_otp":
 		if e.complexity.Mutation.ResendOtp == nil {
 			break
@@ -2127,6 +2219,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateEnv(childComplexity, args["params"].(model.UpdateEnvRequest)), true
 
+	case "Mutation._update_organization":
+		if e.complexity.Mutation.UpdateOrganization == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_organization_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateOrganization(childComplexity, args["params"].(model.UpdateOrganizationRequest)), true
+
 	case "Mutation.update_profile":
 		if e.complexity.Mutation.UpdateProfile == nil {
 			break
@@ -2198,6 +2302,118 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.VerifyOtp(childComplexity, args["params"].(model.VerifyOTPRequest)), true
+
+	case "OrgMember.created_at":
+		if e.complexity.OrgMember.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.CreatedAt(childComplexity), true
+
+	case "OrgMember.id":
+		if e.complexity.OrgMember.ID == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.ID(childComplexity), true
+
+	case "OrgMember.org_id":
+		if e.complexity.OrgMember.OrgID == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.OrgID(childComplexity), true
+
+	case "OrgMember.roles":
+		if e.complexity.OrgMember.Roles == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.Roles(childComplexity), true
+
+	case "OrgMember.updated_at":
+		if e.complexity.OrgMember.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.UpdatedAt(childComplexity), true
+
+	case "OrgMember.user_id":
+		if e.complexity.OrgMember.UserID == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.UserID(childComplexity), true
+
+	case "OrgMembers.org_members":
+		if e.complexity.OrgMembers.OrgMembers == nil {
+			break
+		}
+
+		return e.complexity.OrgMembers.OrgMembers(childComplexity), true
+
+	case "OrgMembers.pagination":
+		if e.complexity.OrgMembers.Pagination == nil {
+			break
+		}
+
+		return e.complexity.OrgMembers.Pagination(childComplexity), true
+
+	case "Organization.created_at":
+		if e.complexity.Organization.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Organization.CreatedAt(childComplexity), true
+
+	case "Organization.display_name":
+		if e.complexity.Organization.DisplayName == nil {
+			break
+		}
+
+		return e.complexity.Organization.DisplayName(childComplexity), true
+
+	case "Organization.enabled":
+		if e.complexity.Organization.Enabled == nil {
+			break
+		}
+
+		return e.complexity.Organization.Enabled(childComplexity), true
+
+	case "Organization.id":
+		if e.complexity.Organization.ID == nil {
+			break
+		}
+
+		return e.complexity.Organization.ID(childComplexity), true
+
+	case "Organization.name":
+		if e.complexity.Organization.Name == nil {
+			break
+		}
+
+		return e.complexity.Organization.Name(childComplexity), true
+
+	case "Organization.updated_at":
+		if e.complexity.Organization.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Organization.UpdatedAt(childComplexity), true
+
+	case "Organizations.organizations":
+		if e.complexity.Organizations.Organizations == nil {
+			break
+		}
+
+		return e.complexity.Organizations.Organizations(childComplexity), true
+
+	case "Organizations.pagination":
+		if e.complexity.Organizations.Pagination == nil {
+			break
+		}
+
+		return e.complexity.Organizations.Pagination(childComplexity), true
 
 	case "Pagination.limit":
 		if e.complexity.Pagination.Limit == nil {
@@ -2404,6 +2620,42 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Meta(childComplexity), true
+
+	case "Query._org_members":
+		if e.complexity.Query.OrgMembers == nil {
+			break
+		}
+
+		args, err := ec.field_Query__org_members_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OrgMembers(childComplexity, args["params"].(model.ListOrgMembersRequest)), true
+
+	case "Query._organization":
+		if e.complexity.Query.Organization == nil {
+			break
+		}
+
+		args, err := ec.field_Query__organization_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Organization(childComplexity, args["params"].(model.OrganizationRequest)), true
+
+	case "Query._organizations":
+		if e.complexity.Query.Organizations == nil {
+			break
+		}
+
+		args, err := ec.field_Query__organizations_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Organizations(childComplexity, args["params"].(*model.ListOrganizationsRequest)), true
 
 	case "Query.profile":
 		if e.complexity.Query.Profile == nil {
@@ -3071,6 +3323,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAddEmailTemplateRequest,
+		ec.unmarshalInputAddOrgMemberRequest,
 		ec.unmarshalInputAddTrustedIssuerRequest,
 		ec.unmarshalInputAddWebhookRequest,
 		ec.unmarshalInputAdminLoginRequest,
@@ -3078,6 +3331,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCheckPermissionsInput,
 		ec.unmarshalInputClientRequest,
 		ec.unmarshalInputCreateClientRequest,
+		ec.unmarshalInputCreateOrganizationRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
 		ec.unmarshalInputDeleteUserRequest,
 		ec.unmarshalInputFgaExpandInput,
@@ -3093,6 +3347,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInviteMemberRequest,
 		ec.unmarshalInputListAuditLogRequest,
 		ec.unmarshalInputListClientsRequest,
+		ec.unmarshalInputListOrgMembersRequest,
+		ec.unmarshalInputListOrganizationsRequest,
 		ec.unmarshalInputListPermissionsInput,
 		ec.unmarshalInputListTrustedIssuersRequest,
 		ec.unmarshalInputListWebhookLogRequest,
@@ -3101,9 +3357,11 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMobileLoginRequest,
 		ec.unmarshalInputMobileSignUpRequest,
 		ec.unmarshalInputOAuthRevokeRequest,
+		ec.unmarshalInputOrganizationRequest,
 		ec.unmarshalInputPaginatedRequest,
 		ec.unmarshalInputPaginationRequest,
 		ec.unmarshalInputPermissionCheckInput,
+		ec.unmarshalInputRemoveOrgMemberRequest,
 		ec.unmarshalInputResendOTPRequest,
 		ec.unmarshalInputResendVerifyEmailRequest,
 		ec.unmarshalInputResetPasswordRequest,
@@ -3115,6 +3373,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateClientRequest,
 		ec.unmarshalInputUpdateEmailTemplateRequest,
 		ec.unmarshalInputUpdateEnvRequest,
+		ec.unmarshalInputUpdateOrganizationRequest,
 		ec.unmarshalInputUpdateProfileRequest,
 		ec.unmarshalInputUpdateTrustedIssuerRequest,
 		ec.unmarshalInputUpdateUserRequest,
@@ -3568,6 +3827,36 @@ type TrustedIssuers {
   trusted_issuers: [TrustedIssuer!]!
 }
 
+type Organization {
+  id: ID!
+  # name is a unique, URL-safe slug identifying the organization.
+  name: String!
+  display_name: String
+  enabled: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type Organizations {
+  pagination: Pagination!
+  organizations: [Organization!]!
+}
+
+type OrgMember {
+  id: ID!
+  org_id: String!
+  user_id: String!
+  # roles is the set of per-organization roles granted to this member.
+  roles: [String!]!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type OrgMembers {
+  pagination: Pagination!
+  org_members: [OrgMember!]!
+}
+
 type WebhookLog {
   id: ID!
   http_status: Int64
@@ -3993,6 +4282,44 @@ input ListTrustedIssuersRequest {
   pagination: PaginatedRequest
 }
 
+input CreateOrganizationRequest {
+  # name must be a unique, URL-safe slug.
+  name: String!
+  display_name: String
+}
+
+input UpdateOrganizationRequest {
+  id: ID!
+  name: String
+  display_name: String
+  enabled: Boolean
+}
+
+input OrganizationRequest {
+  id: ID!
+}
+
+input ListOrganizationsRequest {
+  pagination: PaginatedRequest
+}
+
+input AddOrgMemberRequest {
+  org_id: String!
+  user_id: String!
+  # roles defaults to an empty set when omitted.
+  roles: [String!]
+}
+
+input RemoveOrgMemberRequest {
+  org_id: String!
+  user_id: String!
+}
+
+input ListOrgMembersRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
 input TestEndpointRequest {
   endpoint: String!
   event_name: String!
@@ -4177,6 +4504,12 @@ type Mutation {
   _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
   _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
   _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
+  # Organizations and per-org membership
+  _create_organization(params: CreateOrganizationRequest!): Organization!
+  _update_organization(params: UpdateOrganizationRequest!): Organization!
+  _delete_organization(params: OrganizationRequest!): Response!
+  _add_org_member(params: AddOrgMemberRequest!): OrgMember!
+  _remove_org_member(params: RemoveOrgMemberRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -4213,6 +4546,10 @@ type Query {
   # Trusted issuers
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
+  # Organizations and per-org membership
+  _organization(params: OrganizationRequest!): Organization!
+  _organizations(params: ListOrganizationsRequest): Organizations!
+  _org_members(params: ListOrgMembersRequest!): OrgMembers!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)
@@ -4257,6 +4594,34 @@ func (ec *executionContext) field_Mutation__add_email_template_argsParams(
 	}
 
 	var zeroVal model.AddEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__add_org_member_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__add_org_member_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__add_org_member_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.AddOrgMemberRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.AddOrgMemberRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNAddOrgMemberRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddOrgMemberRequest(ctx, tmp)
+	}
+
+	var zeroVal model.AddOrgMemberRequest
 	return zeroVal, nil
 }
 
@@ -4400,6 +4765,34 @@ func (ec *executionContext) field_Mutation__create_client_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_organization_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_organization_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateOrganizationRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateOrganizationRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrganizationRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateOrganizationRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__delete_client_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -4453,6 +4846,34 @@ func (ec *executionContext) field_Mutation__delete_email_template_argsParams(
 	}
 
 	var zeroVal model.DeleteEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_organization_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_organization_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrganizationRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrganizationRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizationRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrganizationRequest
 	return zeroVal, nil
 }
 
@@ -4708,6 +5129,34 @@ func (ec *executionContext) field_Mutation__invite_members_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__remove_org_member_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__remove_org_member_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__remove_org_member_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.RemoveOrgMemberRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.RemoveOrgMemberRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNRemoveOrgMemberRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRemoveOrgMemberRequest(ctx, tmp)
+	}
+
+	var zeroVal model.RemoveOrgMemberRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__revoke_access_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -4873,6 +5322,34 @@ func (ec *executionContext) field_Mutation__update_env_argsParams(
 	}
 
 	var zeroVal model.UpdateEnvRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_organization_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_organization_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateOrganizationRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateOrganizationRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrganizationRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateOrganizationRequest
 	return zeroVal, nil
 }
 
@@ -5545,6 +6022,90 @@ func (ec *executionContext) field_Query__fga_read_tuples_argsParams(
 	}
 
 	var zeroVal model.FgaReadTuplesInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__org_members_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__org_members_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__org_members_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ListOrgMembersRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ListOrgMembersRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNListOrgMembersRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrgMembersRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ListOrgMembersRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__organization_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__organization_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrganizationRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrganizationRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizationRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrganizationRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__organizations_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__organizations_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__organizations_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*model.ListOrganizationsRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal *model.ListOrganizationsRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalOListOrganizationsRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrganizationsRequest(ctx, tmp)
+	}
+
+	var zeroVal *model.ListOrganizationsRequest
 	return zeroVal, nil
 }
 
@@ -15343,6 +15904,331 @@ func (ec *executionContext) fieldContext_Mutation__delete_trusted_issuer(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrganization(rctx, fc.Args["params"].(model.CreateOrganizationRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_organization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "display_name":
+				return ec.fieldContext_Organization_display_name(ctx, field)
+			case "enabled":
+				return ec.fieldContext_Organization_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Organization_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Organization_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_organization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateOrganization(rctx, fc.Args["params"].(model.UpdateOrganizationRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_organization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "display_name":
+				return ec.fieldContext_Organization_display_name(ctx, field)
+			case "enabled":
+				return ec.fieldContext_Organization_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Organization_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Organization_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_organization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteOrganization(rctx, fc.Args["params"].(model.OrganizationRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_organization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_organization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__add_org_member(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__add_org_member(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddOrgMember(rctx, fc.Args["params"].(model.AddOrgMemberRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgMember)
+	fc.Result = res
+	return ec.marshalNOrgMember2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMember(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__add_org_member(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgMember_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgMember_org_id(ctx, field)
+			case "user_id":
+				return ec.fieldContext_OrgMember_user_id(ctx, field)
+			case "roles":
+				return ec.fieldContext_OrgMember_roles(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgMember_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgMember_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgMember", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__add_org_member_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__remove_org_member(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__remove_org_member(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveOrgMember(rctx, fc.Args["params"].(model.RemoveOrgMemberRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__remove_org_member(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__remove_org_member_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__test_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__test_endpoint(ctx, field)
 	if err != nil {
@@ -15803,6 +16689,743 @@ func (ec *executionContext) fieldContext_Mutation__fga_reset(_ context.Context, 
 				return ec.fieldContext_Response_message(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_org_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_user_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_user_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_user_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_roles(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_roles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Roles, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_roles(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_created_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMembers_pagination(ctx context.Context, field graphql.CollectedField, obj *model.OrgMembers) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMembers_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMembers_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMembers",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMembers_org_members(ctx context.Context, field graphql.CollectedField, obj *model.OrgMembers) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMembers_org_members(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgMembers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.OrgMember)
+	fc.Result = res
+	return ec.marshalNOrgMember2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMemberᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMembers_org_members(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMembers",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgMember_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgMember_org_id(ctx, field)
+			case "user_id":
+				return ec.fieldContext_OrgMember_user_id(ctx, field)
+			case "roles":
+				return ec.fieldContext_OrgMember_roles(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgMember_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgMember_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgMember", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_name(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_display_name(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_display_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_display_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_enabled(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_created_at(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organizations_pagination(ctx context.Context, field graphql.CollectedField, obj *model.Organizations) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organizations_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organizations_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organizations",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organizations_organizations(ctx context.Context, field graphql.CollectedField, obj *model.Organizations) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organizations_organizations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Organizations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organizations_organizations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organizations",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "display_name":
+				return ec.fieldContext_Organization_display_name(ctx, field)
+			case "enabled":
+				return ec.fieldContext_Organization_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Organization_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Organization_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
 		},
 	}
 	return fc, nil
@@ -17551,6 +19174,197 @@ func (ec *executionContext) fieldContext_Query__trusted_issuers(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query__trusted_issuers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Organization(rctx, fc.Args["params"].(model.OrganizationRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__organization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "display_name":
+				return ec.fieldContext_Organization_display_name(ctx, field)
+			case "enabled":
+				return ec.fieldContext_Organization_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Organization_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Organization_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__organization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__organizations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__organizations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Organizations(rctx, fc.Args["params"].(*model.ListOrganizationsRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Organizations)
+	fc.Result = res
+	return ec.marshalNOrganizations2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizations(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__organizations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_Organizations_pagination(ctx, field)
+			case "organizations":
+				return ec.fieldContext_Organizations_organizations(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organizations", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__organizations_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__org_members(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__org_members(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().OrgMembers(rctx, fc.Args["params"].(model.ListOrgMembersRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgMembers)
+	fc.Result = res
+	return ec.marshalNOrgMembers2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMembers(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__org_members(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_OrgMembers_pagination(ctx, field)
+			case "org_members":
+				return ec.fieldContext_OrgMembers_org_members(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgMembers", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__org_members_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -23503,6 +25317,47 @@ func (ec *executionContext) unmarshalInputAddEmailTemplateRequest(ctx context.Co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputAddOrgMemberRequest(ctx context.Context, obj any) (model.AddOrgMemberRequest, error) {
+	var it model.AddOrgMemberRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "user_id", "roles"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "user_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("user_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "roles":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roles"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Roles = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputAddTrustedIssuerRequest(ctx context.Context, obj any) (model.AddTrustedIssuerRequest, error) {
 	var it model.AddTrustedIssuerRequest
 	asMap := map[string]any{}
@@ -23791,6 +25646,40 @@ func (ec *executionContext) unmarshalInputCreateClientRequest(ctx context.Contex
 				return it, err
 			}
 			it.AllowedScopes = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCreateOrganizationRequest(ctx context.Context, obj any) (model.CreateOrganizationRequest, error) {
+	var it model.CreateOrganizationRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "display_name"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "display_name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("display_name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DisplayName = data
 		}
 	}
 
@@ -24349,6 +26238,67 @@ func (ec *executionContext) unmarshalInputListClientsRequest(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputListOrgMembersRequest(ctx context.Context, obj any) (model.ListOrgMembersRequest, error) {
+	var it model.ListOrgMembersRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListOrganizationsRequest(ctx context.Context, obj any) (model.ListOrganizationsRequest, error) {
+	var it model.ListOrganizationsRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputListPermissionsInput(ctx context.Context, obj any) (model.ListPermissionsInput, error) {
 	var it model.ListPermissionsInput
 	asMap := map[string]any{}
@@ -24796,6 +26746,33 @@ func (ec *executionContext) unmarshalInputOAuthRevokeRequest(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputOrganizationRequest(ctx context.Context, obj any) (model.OrganizationRequest, error) {
+	var it model.OrganizationRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputPaginatedRequest(ctx context.Context, obj any) (model.PaginatedRequest, error) {
 	var it model.PaginatedRequest
 	asMap := map[string]any{}
@@ -24892,6 +26869,40 @@ func (ec *executionContext) unmarshalInputPermissionCheckInput(ctx context.Conte
 				return it, err
 			}
 			it.ContextualTuples = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRemoveOrgMemberRequest(ctx context.Context, obj any) (model.RemoveOrgMemberRequest, error) {
+	var it model.RemoveOrgMemberRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "user_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "user_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("user_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
 		}
 	}
 
@@ -25882,6 +27893,54 @@ func (ec *executionContext) unmarshalInputUpdateEnvRequest(ctx context.Context, 
 				return it, err
 			}
 			it.DisableTotpLogin = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateOrganizationRequest(ctx context.Context, obj any) (model.UpdateOrganizationRequest, error) {
+	var it model.UpdateOrganizationRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "display_name", "enabled"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "display_name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("display_name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DisplayName = data
+		case "enabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Enabled = data
 		}
 	}
 
@@ -28030,6 +30089,41 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_organization":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_organization(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_organization":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_organization(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_organization":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_organization(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_add_org_member":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__add_org_member(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_remove_org_member":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__remove_org_member(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_test_endpoint":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__test_endpoint(ctx, field)
@@ -28083,6 +30177,207 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__fga_reset(ctx, field)
 			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgMemberImplementors = []string{"OrgMember"}
+
+func (ec *executionContext) _OrgMember(ctx context.Context, sel ast.SelectionSet, obj *model.OrgMember) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgMemberImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgMember")
+		case "id":
+			out.Values[i] = ec._OrgMember_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._OrgMember_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "user_id":
+			out.Values[i] = ec._OrgMember_user_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "roles":
+			out.Values[i] = ec._OrgMember_roles(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._OrgMember_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._OrgMember_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgMembersImplementors = []string{"OrgMembers"}
+
+func (ec *executionContext) _OrgMembers(ctx context.Context, sel ast.SelectionSet, obj *model.OrgMembers) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgMembersImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgMembers")
+		case "pagination":
+			out.Values[i] = ec._OrgMembers_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_members":
+			out.Values[i] = ec._OrgMembers_org_members(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var organizationImplementors = []string{"Organization"}
+
+func (ec *executionContext) _Organization(ctx context.Context, sel ast.SelectionSet, obj *model.Organization) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, organizationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Organization")
+		case "id":
+			out.Values[i] = ec._Organization_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._Organization_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "display_name":
+			out.Values[i] = ec._Organization_display_name(ctx, field, obj)
+		case "enabled":
+			out.Values[i] = ec._Organization_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._Organization_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._Organization_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var organizationsImplementors = []string{"Organizations"}
+
+func (ec *executionContext) _Organizations(ctx context.Context, sel ast.SelectionSet, obj *model.Organizations) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, organizationsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Organizations")
+		case "pagination":
+			out.Values[i] = ec._Organizations_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "organizations":
+			out.Values[i] = ec._Organizations_organizations(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -28659,6 +30954,72 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query__trusted_issuers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__organization(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_organizations":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__organizations(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_org_members":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__org_members(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -29935,6 +32296,11 @@ func (ec *executionContext) unmarshalNAddEmailTemplateRequest2githubᚗcomᚋaut
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNAddOrgMemberRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddOrgMemberRequest(ctx context.Context, v any) (model.AddOrgMemberRequest, error) {
+	res, err := ec.unmarshalInputAddOrgMemberRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNAddTrustedIssuerRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddTrustedIssuerRequest(ctx context.Context, v any) (model.AddTrustedIssuerRequest, error) {
 	res, err := ec.unmarshalInputAddTrustedIssuerRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -30180,6 +32546,11 @@ func (ec *executionContext) marshalNCreateClientResponse2ᚖgithubᚗcomᚋautho
 		return graphql.Null
 	}
 	return ec._CreateClientResponse(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrganizationRequest(ctx context.Context, v any) (model.CreateOrganizationRequest, error) {
+	res, err := ec.unmarshalInputCreateOrganizationRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNDeleteEmailTemplateRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteEmailTemplateRequest(ctx context.Context, v any) (model.DeleteEmailTemplateRequest, error) {
@@ -30528,6 +32899,11 @@ func (ec *executionContext) marshalNInviteMembersResponse2ᚖgithubᚗcomᚋauth
 	return ec._InviteMembersResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNListOrgMembersRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrgMembersRequest(ctx context.Context, v any) (model.ListOrgMembersRequest, error) {
+	res, err := ec.unmarshalInputListOrgMembersRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNListPermissionsInput2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListPermissionsInput(ctx context.Context, v any) (model.ListPermissionsInput, error) {
 	res, err := ec.unmarshalInputListPermissionsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -30579,6 +32955,155 @@ func (ec *executionContext) unmarshalNMobileLoginRequest2githubᚗcomᚋauthoriz
 func (ec *executionContext) unmarshalNOAuthRevokeRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOAuthRevokeRequest(ctx context.Context, v any) (model.OAuthRevokeRequest, error) {
 	res, err := ec.unmarshalInputOAuthRevokeRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOrgMember2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMember(ctx context.Context, sel ast.SelectionSet, v model.OrgMember) graphql.Marshaler {
+	return ec._OrgMember(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgMember2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMemberᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.OrgMember) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNOrgMember2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMember(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNOrgMember2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMember(ctx context.Context, sel ast.SelectionSet, v *model.OrgMember) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgMember(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNOrgMembers2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMembers(ctx context.Context, sel ast.SelectionSet, v model.OrgMembers) graphql.Marshaler {
+	return ec._OrgMembers(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgMembers2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMembers(ctx context.Context, sel ast.SelectionSet, v *model.OrgMembers) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgMembers(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNOrganization2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx context.Context, sel ast.SelectionSet, v model.Organization) graphql.Marshaler {
+	return ec._Organization(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrganization2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Organization) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNOrganization2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNOrganization2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx context.Context, sel ast.SelectionSet, v *model.Organization) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Organization(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizationRequest(ctx context.Context, v any) (model.OrganizationRequest, error) {
+	res, err := ec.unmarshalInputOrganizationRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOrganizations2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizations(ctx context.Context, sel ast.SelectionSet, v model.Organizations) graphql.Marshaler {
+	return ec._Organizations(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrganizations2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganizations(ctx context.Context, sel ast.SelectionSet, v *model.Organizations) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Organizations(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx context.Context, sel ast.SelectionSet, v *model.Pagination) graphql.Marshaler {
@@ -30717,6 +33242,11 @@ func (ec *executionContext) marshalNPermissionCheckResult2ᚖgithubᚗcomᚋauth
 		return graphql.Null
 	}
 	return ec._PermissionCheckResult(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNRemoveOrgMemberRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRemoveOrgMemberRequest(ctx context.Context, v any) (model.RemoveOrgMemberRequest, error) {
+	res, err := ec.unmarshalInputRemoveOrgMemberRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNResendOTPRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResendOTPRequest(ctx context.Context, v any) (model.ResendOTPRequest, error) {
@@ -30912,6 +33442,11 @@ func (ec *executionContext) unmarshalNUpdateEmailTemplateRequest2githubᚗcomᚋ
 
 func (ec *executionContext) unmarshalNUpdateEnvRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateEnvRequest(ctx context.Context, v any) (model.UpdateEnvRequest, error) {
 	res, err := ec.unmarshalInputUpdateEnvRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrganizationRequest(ctx context.Context, v any) (model.UpdateOrganizationRequest, error) {
+	res, err := ec.unmarshalInputUpdateOrganizationRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -31631,6 +34166,14 @@ func (ec *executionContext) unmarshalOListClientsRequest2ᚖgithubᚗcomᚋautho
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputListClientsRequest(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOListOrganizationsRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrganizationsRequest(ctx context.Context, v any) (*model.ListOrganizationsRequest, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputListOrganizationsRequest(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -9,6 +9,12 @@ type AddEmailTemplateRequest struct {
 	Design    *string `json:"design,omitempty"`
 }
 
+type AddOrgMemberRequest struct {
+	OrgID  string   `json:"org_id"`
+	UserID string   `json:"user_id"`
+	Roles  []string `json:"roles,omitempty"`
+}
+
 type AddTrustedIssuerRequest struct {
 	ServiceAccountID         string  `json:"service_account_id"`
 	Name                     string  `json:"name"`
@@ -114,6 +120,11 @@ type CreateClientRequest struct {
 type CreateClientResponse struct {
 	Client       *Client `json:"client"`
 	ClientSecret string  `json:"client_secret"`
+}
+
+type CreateOrganizationRequest struct {
+	Name        string  `json:"name"`
+	DisplayName *string `json:"display_name,omitempty"`
 }
 
 type DeleteEmailTemplateRequest struct {
@@ -331,6 +342,15 @@ type ListClientsRequest struct {
 	Pagination *PaginatedRequest `json:"pagination,omitempty"`
 }
 
+type ListOrgMembersRequest struct {
+	OrgID      string            `json:"org_id"`
+	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+}
+
+type ListOrganizationsRequest struct {
+	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+}
+
 type ListPermissionsInput struct {
 	Relation   *string `json:"relation,omitempty"`
 	ObjectType *string `json:"object_type,omitempty"`
@@ -428,6 +448,38 @@ type OAuthRevokeRequest struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
+type OrgMember struct {
+	ID        string   `json:"id"`
+	OrgID     string   `json:"org_id"`
+	UserID    string   `json:"user_id"`
+	Roles     []string `json:"roles"`
+	CreatedAt *int64   `json:"created_at,omitempty"`
+	UpdatedAt *int64   `json:"updated_at,omitempty"`
+}
+
+type OrgMembers struct {
+	Pagination *Pagination  `json:"pagination"`
+	OrgMembers []*OrgMember `json:"org_members"`
+}
+
+type Organization struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	DisplayName *string `json:"display_name,omitempty"`
+	Enabled     bool    `json:"enabled"`
+	CreatedAt   *int64  `json:"created_at,omitempty"`
+	UpdatedAt   *int64  `json:"updated_at,omitempty"`
+}
+
+type OrganizationRequest struct {
+	ID string `json:"id"`
+}
+
+type Organizations struct {
+	Pagination    *Pagination     `json:"pagination"`
+	Organizations []*Organization `json:"organizations"`
+}
+
 type PaginatedRequest struct {
 	Pagination *PaginationRequest `json:"pagination,omitempty"`
 }
@@ -462,6 +514,11 @@ type PermissionCheckResult struct {
 }
 
 type Query struct {
+}
+
+type RemoveOrgMemberRequest struct {
+	OrgID  string `json:"org_id"`
+	UserID string `json:"user_id"`
 }
 
 type ResendOTPRequest struct {
@@ -635,6 +692,13 @@ type UpdateEnvRequest struct {
 	DisablePlayground                *bool    `json:"DISABLE_PLAYGROUND,omitempty"`
 	DisableMailOtpLogin              *bool    `json:"DISABLE_MAIL_OTP_LOGIN,omitempty"`
 	DisableTotpLogin                 *bool    `json:"DISABLE_TOTP_LOGIN,omitempty"`
+}
+
+type UpdateOrganizationRequest struct {
+	ID          string  `json:"id"`
+	Name        *string `json:"name,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
 }
 
 type UpdateProfileRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -345,6 +345,36 @@ type TrustedIssuers {
   trusted_issuers: [TrustedIssuer!]!
 }
 
+type Organization {
+  id: ID!
+  # name is a unique, URL-safe slug identifying the organization.
+  name: String!
+  display_name: String
+  enabled: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type Organizations {
+  pagination: Pagination!
+  organizations: [Organization!]!
+}
+
+type OrgMember {
+  id: ID!
+  org_id: String!
+  user_id: String!
+  # roles is the set of per-organization roles granted to this member.
+  roles: [String!]!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type OrgMembers {
+  pagination: Pagination!
+  org_members: [OrgMember!]!
+}
+
 type WebhookLog {
   id: ID!
   http_status: Int64
@@ -770,6 +800,44 @@ input ListTrustedIssuersRequest {
   pagination: PaginatedRequest
 }
 
+input CreateOrganizationRequest {
+  # name must be a unique, URL-safe slug.
+  name: String!
+  display_name: String
+}
+
+input UpdateOrganizationRequest {
+  id: ID!
+  name: String
+  display_name: String
+  enabled: Boolean
+}
+
+input OrganizationRequest {
+  id: ID!
+}
+
+input ListOrganizationsRequest {
+  pagination: PaginatedRequest
+}
+
+input AddOrgMemberRequest {
+  org_id: String!
+  user_id: String!
+  # roles defaults to an empty set when omitted.
+  roles: [String!]
+}
+
+input RemoveOrgMemberRequest {
+  org_id: String!
+  user_id: String!
+}
+
+input ListOrgMembersRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
 input TestEndpointRequest {
   endpoint: String!
   event_name: String!
@@ -954,6 +1022,12 @@ type Mutation {
   _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
   _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
   _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
+  # Organizations and per-org membership
+  _create_organization(params: CreateOrganizationRequest!): Organization!
+  _update_organization(params: UpdateOrganizationRequest!): Organization!
+  _delete_organization(params: OrganizationRequest!): Response!
+  _add_org_member(params: AddOrgMemberRequest!): OrgMember!
+  _remove_org_member(params: RemoveOrgMemberRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -990,6 +1064,10 @@ type Query {
   # Trusted issuers
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
+  # Organizations and per-org membership
+  _organization(params: OrganizationRequest!): Organization!
+  _organizations(params: ListOrganizationsRequest): Organizations!
+  _org_members(params: ListOrgMembersRequest!): OrgMembers!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -187,6 +187,31 @@ func (r *mutationResolver) DeleteTrustedIssuer(ctx context.Context, params model
 	return r.GraphQLProvider.DeleteTrustedIssuer(ctx, &params)
 }
 
+// CreateOrganization is the resolver for the _create_organization field.
+func (r *mutationResolver) CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error) {
+	return r.GraphQLProvider.CreateOrganization(ctx, &params)
+}
+
+// UpdateOrganization is the resolver for the _update_organization field.
+func (r *mutationResolver) UpdateOrganization(ctx context.Context, params model.UpdateOrganizationRequest) (*model.Organization, error) {
+	return r.GraphQLProvider.UpdateOrganization(ctx, &params)
+}
+
+// DeleteOrganization is the resolver for the _delete_organization field.
+func (r *mutationResolver) DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteOrganization(ctx, &params)
+}
+
+// AddOrgMember is the resolver for the _add_org_member field.
+func (r *mutationResolver) AddOrgMember(ctx context.Context, params model.AddOrgMemberRequest) (*model.OrgMember, error) {
+	return r.GraphQLProvider.AddOrgMember(ctx, &params)
+}
+
+// RemoveOrgMember is the resolver for the _remove_org_member field.
+func (r *mutationResolver) RemoveOrgMember(ctx context.Context, params model.RemoveOrgMemberRequest) (*model.Response, error) {
+	return r.GraphQLProvider.RemoveOrgMember(ctx, &params)
+}
+
 // TestEndpoint is the resolver for the _test_endpoint field.
 func (r *mutationResolver) TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error) {
 	return r.GraphQLProvider.TestEndpoint(ctx, &params)
@@ -315,6 +340,21 @@ func (r *queryResolver) TrustedIssuer(ctx context.Context, params model.TrustedI
 // TrustedIssuers is the resolver for the _trusted_issuers field.
 func (r *queryResolver) TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error) {
 	return r.GraphQLProvider.TrustedIssuers(ctx, params)
+}
+
+// Organization is the resolver for the _organization field.
+func (r *queryResolver) Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error) {
+	return r.GraphQLProvider.Organization(ctx, &params)
+}
+
+// Organizations is the resolver for the _organizations field.
+func (r *queryResolver) Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error) {
+	return r.GraphQLProvider.Organizations(ctx, params)
+}
+
+// OrgMembers is the resolver for the _org_members field.
+func (r *queryResolver) OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error) {
+	return r.GraphQLProvider.OrgMembers(ctx, &params)
 }
 
 // EmailTemplates is the resolver for the _email_templates field.

--- a/internal/graphql/organizations.go
+++ b/internal/graphql/organizations.go
@@ -1,0 +1,122 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateOrganization delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) CreateOrganization(ctx context.Context, params *model.CreateOrganizationRequest) (*model.Organization, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateOrganization(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// UpdateOrganization delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) UpdateOrganization(ctx context.Context, params *model.UpdateOrganizationRequest) (*model.Organization, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateOrganization(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// DeleteOrganization delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteOrganization(ctx context.Context, params *model.OrganizationRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteOrganization(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// Organization delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) Organization(ctx context.Context, params *model.OrganizationRequest) (*model.Organization, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().Organization(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// Organizations delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().Organizations(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// AddOrgMember delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) AddOrgMember(ctx context.Context, params *model.AddOrgMemberRequest) (*model.OrgMember, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().AddOrgMember(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// RemoveOrgMember delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) RemoveOrgMember(ctx context.Context, params *model.RemoveOrgMemberRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RemoveOrgMember(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// OrgMembers delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) OrgMembers(ctx context.Context, params *model.ListOrgMembersRequest) (*model.OrgMembers, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().OrgMembers(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -239,6 +239,30 @@ type Provider interface {
 	// TrustedIssuers lists trusted issuers, optionally filtered by service account.
 	// Permissions: authorizer:admin
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
+	// CreateOrganization creates a new organization.
+	// Permissions: authorizer:admin
+	CreateOrganization(ctx context.Context, params *model.CreateOrganizationRequest) (*model.Organization, error)
+	// UpdateOrganization updates an organization.
+	// Permissions: authorizer:admin
+	UpdateOrganization(ctx context.Context, params *model.UpdateOrganizationRequest) (*model.Organization, error)
+	// DeleteOrganization deletes an organization (cascades to memberships).
+	// Permissions: authorizer:admin
+	DeleteOrganization(ctx context.Context, params *model.OrganizationRequest) (*model.Response, error)
+	// Organization returns a single organization by id.
+	// Permissions: authorizer:admin
+	Organization(ctx context.Context, params *model.OrganizationRequest) (*model.Organization, error)
+	// Organizations lists organizations.
+	// Permissions: authorizer:admin
+	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
+	// AddOrgMember adds a user to an organization.
+	// Permissions: authorizer:admin
+	AddOrgMember(ctx context.Context, params *model.AddOrgMemberRequest) (*model.OrgMember, error)
+	// RemoveOrgMember removes a user from an organization.
+	// Permissions: authorizer:admin
+	RemoveOrgMember(ctx context.Context, params *model.RemoveOrgMemberRequest) (*model.Response, error)
+	// OrgMembers lists an organization's members.
+	// Permissions: authorizer:admin
+	OrgMembers(ctx context.Context, params *model.ListOrgMembersRequest) (*model.OrgMembers, error)
 	// FgaWriteModel installs a new fine-grained authorization model.
 	// Permissions: authorizer:admin
 	FgaWriteModel(ctx context.Context, params *model.FgaWriteModelInput) (*model.FgaModel, error)

--- a/internal/integration_tests/organization_test.go
+++ b/internal/integration_tests/organization_test.go
@@ -1,0 +1,181 @@
+package integration_tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// seedOrgTestUser inserts a basic-auth user directly via storage and returns
+// its id. Org membership operations validate that the user exists.
+func seedOrgTestUser(t *testing.T, ts *testSetup) string {
+	t.Helper()
+	id := uuid.New().String()
+	email := "org-member-" + id + "@authorizer.test"
+	now := int64(1)
+	_, err := ts.StorageProvider.AddUser(context.Background(), &schemas.User{
+		ID:              id,
+		Email:           refs.NewStringRef(email),
+		SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+		Roles:           "user",
+		EmailVerifiedAt: &now,
+	})
+	require.NoError(t, err)
+	return id
+}
+
+func TestOrganizationAdmin(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	t.Run("should reject non-super-admin caller", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: "unauthorized-" + uuid.NewString(),
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	// Everything below runs as super-admin.
+	setAdminCookie(t, ts)
+
+	t.Run("should reject empty/whitespace-only name", func(t *testing.T) {
+		res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: "   ",
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("should create, get and list an organization", func(t *testing.T) {
+		name := "acme-" + uuid.NewString()
+		res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name:        name,
+			DisplayName: refs.NewStringRef("Acme Corporation"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, name, res.Name)
+		assert.True(t, res.Enabled)
+		require.NotNil(t, res.DisplayName)
+		assert.Equal(t, "Acme Corporation", *res.DisplayName)
+
+		fetched, err := ts.GraphQLProvider.Organization(ctx, &model.OrganizationRequest{ID: res.ID})
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		assert.Equal(t, name, fetched.Name)
+
+		list, err := ts.GraphQLProvider.Organizations(ctx, &model.ListOrganizationsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, list)
+		assert.NotNil(t, list.Pagination)
+		assert.Greater(t, len(list.Organizations), 0)
+	})
+
+	t.Run("should reject a duplicate organization name", func(t *testing.T) {
+		name := "dup-" + uuid.NewString()
+		_, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{Name: name})
+		require.NoError(t, err)
+		res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{Name: name})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("should add, list and remove an organization member", func(t *testing.T) {
+		org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: "members-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		userID := seedOrgTestUser(t, ts)
+
+		member, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  org.ID,
+			UserID: userID,
+			Roles:  []string{"admin", "billing"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, member)
+		assert.Equal(t, org.ID, member.OrgID)
+		assert.Equal(t, userID, member.UserID)
+		assert.ElementsMatch(t, []string{"admin", "billing"}, member.Roles)
+
+		// Duplicate membership rejected.
+		dup, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  org.ID,
+			UserID: userID,
+			Roles:  []string{"admin"},
+		})
+		require.Error(t, err)
+		require.Nil(t, dup)
+
+		members, err := ts.GraphQLProvider.OrgMembers(ctx, &model.ListOrgMembersRequest{OrgID: org.ID})
+		require.NoError(t, err)
+		require.NotNil(t, members)
+		require.Len(t, members.OrgMembers, 1)
+		assert.Equal(t, userID, members.OrgMembers[0].UserID)
+
+		removed, err := ts.GraphQLProvider.RemoveOrgMember(ctx, &model.RemoveOrgMemberRequest{
+			OrgID:  org.ID,
+			UserID: userID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, removed)
+
+		after, err := ts.GraphQLProvider.OrgMembers(ctx, &model.ListOrgMembersRequest{OrgID: org.ID})
+		require.NoError(t, err)
+		assert.Len(t, after.OrgMembers, 0)
+	})
+
+	t.Run("should reject adding a member to a nonexistent org or a nonexistent user", func(t *testing.T) {
+		org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: "validate-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		res, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  uuid.NewString(),
+			UserID: seedOrgTestUser(t, ts),
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		res, err = ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  org.ID,
+			UserID: uuid.NewString(),
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("delete removes the organization and cascades its memberships", func(t *testing.T) {
+		org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: "delete-me-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		userID := seedOrgTestUser(t, ts)
+		_, err = ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  org.ID,
+			UserID: userID,
+		})
+		require.NoError(t, err)
+
+		delRes, err := ts.GraphQLProvider.DeleteOrganization(ctx, &model.OrganizationRequest{ID: org.ID})
+		require.NoError(t, err)
+		require.NotNil(t, delRes)
+
+		_, err = ts.StorageProvider.GetOrganizationByID(ctx, org.ID)
+		require.Error(t, err)
+
+		_, err = ts.StorageProvider.GetOrgMembership(ctx, org.ID, userID)
+		require.Error(t, err, "membership must be cascade-deleted with its organization")
+	})
+}

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -1,0 +1,370 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateOrganization provisions a new organization. The name must be a
+// unique, non-empty slug. Requires super-admin auth.
+func (p *provider) CreateOrganization(ctx context.Context, meta RequestMetadata, params *model.CreateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateOrganization").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	name := strings.TrimSpace(params.Name)
+	if name == "" {
+		log.Debug().Msg("name is required")
+		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
+		return nil, nil, fmt.Errorf("name is required")
+	}
+
+	// Unique-name pre-check. The storage layer also enforces uniqueness (unique
+	// index / check-then-insert); this yields a clear error before the write.
+	if existing, _ := p.StorageProvider.GetOrganizationByName(ctx, name); existing != nil {
+		log.Debug().Msg("organization name already exists")
+		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
+		return nil, nil, fmt.Errorf("an organization with this name already exists")
+	}
+
+	org, err := p.StorageProvider.AddOrganization(ctx, &schemas.Organization{
+		Name:        name,
+		DisplayName: params.DisplayName,
+		// Set Enabled explicitly — never rely on the GORM `default:true` column
+		// default (a future create-as-disabled path would silently come back on).
+		Enabled: true,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to add organization")
+		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrganizationCreatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrganization,
+		ResourceID:   org.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return org.AsAPIOrganization(), nil, nil
+}
+
+// UpdateOrganization mutates only the fields present in params (load-then-
+// mutate, so the storage Save does not blank untouched columns). A changed
+// name is re-checked for uniqueness. Requires super-admin auth.
+func (p *provider) UpdateOrganization(ctx context.Context, meta RequestMetadata, params *model.UpdateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "UpdateOrganization").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	org, err := p.StorageProvider.GetOrganizationByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetOrganizationByID")
+		p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
+		return nil, nil, err
+	}
+
+	if params.Name != nil {
+		name := strings.TrimSpace(*params.Name)
+		if name == "" {
+			log.Debug().Msg("name cannot be empty")
+			p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
+			return nil, nil, fmt.Errorf("name cannot be empty")
+		}
+		if name != org.Name {
+			if existing, _ := p.StorageProvider.GetOrganizationByName(ctx, name); existing != nil {
+				log.Debug().Msg("organization name already exists")
+				p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
+				return nil, nil, fmt.Errorf("an organization with this name already exists")
+			}
+			org.Name = name
+		}
+	}
+	if params.DisplayName != nil {
+		org.DisplayName = params.DisplayName
+	}
+	if params.Enabled != nil {
+		org.Enabled = *params.Enabled
+	}
+
+	updated, err := p.StorageProvider.UpdateOrganization(ctx, org)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateOrganization")
+		p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrganizationUpdatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrganization,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return updated.AsAPIOrganization(), nil, nil
+}
+
+// DeleteOrganization removes an organization. The storage layer cascades to
+// its memberships. Requires super-admin auth.
+func (p *provider) DeleteOrganization(ctx context.Context, meta RequestMetadata, params *model.OrganizationRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteOrganization").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if params.ID == "" {
+		log.Debug().Msg("organization ID required")
+		p.logOrgFailure(meta, constants.AuditOrganizationDeleteFailedEvent, "")
+		return nil, nil, fmt.Errorf("organization ID required")
+	}
+
+	org, err := p.StorageProvider.GetOrganizationByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetOrganizationByID")
+		p.logOrgFailure(meta, constants.AuditOrganizationDeleteFailedEvent, params.ID)
+		return nil, nil, err
+	}
+
+	if err := p.StorageProvider.DeleteOrganization(ctx, org); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteOrganization")
+		p.logOrgFailure(meta, constants.AuditOrganizationDeleteFailedEvent, params.ID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrganizationDeletedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrganization,
+		ResourceID:   params.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.Response{
+		Message: "Organization deleted successfully",
+	}, nil, nil
+}
+
+// Organization returns a single organization by id. Requires super-admin auth.
+func (p *provider) Organization(ctx context.Context, meta RequestMetadata, params *model.OrganizationRequest) (*model.Organization, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "Organization").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	org, err := p.StorageProvider.GetOrganizationByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetOrganizationByID")
+		return nil, nil, err
+	}
+	return org.AsAPIOrganization(), nil, nil
+}
+
+// Organizations returns a paginated list of organizations. Requires
+// super-admin auth.
+func (p *provider) Organizations(ctx context.Context, meta RequestMetadata, params *model.ListOrganizationsRequest) (*model.Organizations, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "Organizations").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	var paginatedReq *model.PaginatedRequest
+	if params != nil {
+		paginatedReq = params.Pagination
+	}
+	pagination := utils.GetPagination(paginatedReq)
+
+	orgs, pagination, err := p.StorageProvider.ListOrganizations(ctx, pagination)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed ListOrganizations")
+		return nil, nil, err
+	}
+	res := make([]*model.Organization, len(orgs))
+	for i, org := range orgs {
+		res[i] = org.AsAPIOrganization()
+	}
+	return &model.Organizations{
+		Pagination:    pagination,
+		Organizations: res,
+	}, nil, nil
+}
+
+// AddOrgMember adds a user to an organization with a set of per-org roles.
+// The organization and user must exist and the (org, user) pair must be unique.
+// Requires super-admin auth.
+func (p *provider) AddOrgMember(ctx context.Context, meta RequestMetadata, params *model.AddOrgMemberRequest) (*model.OrgMember, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "AddOrgMember").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	orgID := strings.TrimSpace(params.OrgID)
+	userID := strings.TrimSpace(params.UserID)
+	if orgID == "" || userID == "" {
+		log.Debug().Msg("org_id and user_id are required")
+		p.logOrgMemberFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("org_id and user_id are required")
+	}
+
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Msg("organization not found")
+		p.logOrgMemberFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("organization not found")
+	}
+
+	if _, err := p.StorageProvider.GetUserByID(ctx, userID); err != nil {
+		log.Debug().Err(err).Msg("user not found")
+		p.logOrgMemberFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("user not found")
+	}
+
+	// Membership uniqueness pre-check. The storage layer also enforces it.
+	if existing, _ := p.StorageProvider.GetOrgMembership(ctx, orgID, userID); existing != nil {
+		log.Debug().Msg("user is already a member of this organization")
+		p.logOrgMemberFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("user is already a member of this organization")
+	}
+
+	membership, err := p.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgID,
+		UserID: userID,
+		Roles:  normalizeScopes(params.Roles),
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed AddOrgMembership")
+		p.logOrgMemberFailure(meta, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrgMemberAddedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgMembership,
+		ResourceID:   membership.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return membership.AsAPIOrgMember(), nil, nil
+}
+
+// RemoveOrgMember removes a user from an organization. Requires super-admin auth.
+func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, params *model.RemoveOrgMemberRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "RemoveOrgMember").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	orgID := strings.TrimSpace(params.OrgID)
+	userID := strings.TrimSpace(params.UserID)
+	if orgID == "" || userID == "" {
+		log.Debug().Msg("org_id and user_id are required")
+		p.logOrgMemberRemoveFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("org_id and user_id are required")
+	}
+
+	membership, err := p.StorageProvider.GetOrgMembership(ctx, orgID, userID)
+	if err != nil {
+		log.Debug().Err(err).Msg("membership not found")
+		p.logOrgMemberRemoveFailure(meta, orgID)
+		return nil, nil, fmt.Errorf("membership not found")
+	}
+
+	if err := p.StorageProvider.DeleteOrgMembership(ctx, membership); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteOrgMembership")
+		p.logOrgMemberRemoveFailure(meta, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrgMemberRemovedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgMembership,
+		ResourceID:   membership.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+
+	return &model.Response{
+		Message: "Organization member removed successfully",
+	}, nil, nil
+}
+
+// OrgMembers returns a paginated list of an organization's members. Requires
+// super-admin auth.
+func (p *provider) OrgMembers(ctx context.Context, meta RequestMetadata, params *model.ListOrgMembersRequest) (*model.OrgMembers, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "OrgMembers").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	if params.OrgID == "" {
+		log.Debug().Msg("org_id is required")
+		return nil, nil, fmt.Errorf("org_id is required")
+	}
+	pagination := utils.GetPagination(params.Pagination)
+
+	memberships, pagination, err := p.StorageProvider.ListOrgMembershipsByOrg(ctx, params.OrgID, pagination)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed ListOrgMembershipsByOrg")
+		return nil, nil, err
+	}
+	res := make([]*model.OrgMember, len(memberships))
+	for i, m := range memberships {
+		res[i] = m.AsAPIOrgMember()
+	}
+	return &model.OrgMembers{
+		Pagination: pagination,
+		OrgMembers: res,
+	}, nil, nil
+}
+
+// logOrgFailure records a failed organization admin operation.
+func (p *provider) logOrgFailure(meta RequestMetadata, action, orgID string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   action,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrganization,
+		ResourceID:   orgID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}
+
+// logOrgMemberFailure records a failed add-member operation.
+func (p *provider) logOrgMemberFailure(meta RequestMetadata, orgID string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrgMemberAddFailedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgMembership,
+		ResourceID:   orgID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}
+
+// logOrgMemberRemoveFailure records a failed remove-member operation.
+func (p *provider) logOrgMemberRemoveFailure(meta RequestMetadata, orgID string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditOrgMemberRemoveFailedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgMembership,
+		ResourceID:   orgID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -63,6 +63,16 @@ type AdminProvider interface {
 	TrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error)
 	TrustedIssuers(ctx context.Context, meta RequestMetadata, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, *ResponseSideEffects, error)
 
+	// Organizations and per-org membership.
+	CreateOrganization(ctx context.Context, meta RequestMetadata, params *model.CreateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)
+	UpdateOrganization(ctx context.Context, meta RequestMetadata, params *model.UpdateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)
+	DeleteOrganization(ctx context.Context, meta RequestMetadata, params *model.OrganizationRequest) (*model.Response, *ResponseSideEffects, error)
+	Organization(ctx context.Context, meta RequestMetadata, params *model.OrganizationRequest) (*model.Organization, *ResponseSideEffects, error)
+	Organizations(ctx context.Context, meta RequestMetadata, params *model.ListOrganizationsRequest) (*model.Organizations, *ResponseSideEffects, error)
+	AddOrgMember(ctx context.Context, meta RequestMetadata, params *model.AddOrgMemberRequest) (*model.OrgMember, *ResponseSideEffects, error)
+	RemoveOrgMember(ctx context.Context, meta RequestMetadata, params *model.RemoveOrgMemberRequest) (*model.Response, *ResponseSideEffects, error)
+	OrgMembers(ctx context.Context, meta RequestMetadata, params *model.ListOrgMembersRequest) (*model.OrgMembers, *ResponseSideEffects, error)
+
 	// Email templates.
 	AddEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.AddEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
 	UpdateEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.UpdateEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)

--- a/internal/storage/db/arangodb/org_membership.go
+++ b/internal/storage/db/arangodb/org_membership.go
@@ -1,0 +1,138 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	arangoDriver "github.com/arangodb/go-driver"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgMembership creates a new membership. The unique hash index on
+// (org_id, user_id) rejects duplicates at the database layer.
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	membershipCollection, _ := p.db.Collection(ctx, schemas.Collections.OrgMembership)
+	doc, err := structToDocument(membership)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := membershipCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	membership.Key = meta.Key
+	membership.ID = meta.ID.String()
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	membershipCollection, _ := p.db.Collection(ctx, schemas.Collections.OrgMembership)
+	doc, err := structToDocument(membership)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := membershipCollection.UpdateDocument(ctx, membership.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	membership.Key = meta.Key
+	membership.ID = meta.ID.String()
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	membershipCollection, _ := p.db.Collection(ctx, schemas.Collections.OrgMembership)
+	_, err := membershipCollection.RemoveDocument(ctx, membership.Key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	var membership *schemas.OrgMembership
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.user_id == @user_id LIMIT 1 RETURN d", schemas.Collections.OrgMembership)
+	bindVars := map[string]interface{}{
+		"org_id":  orgID,
+		"user_id": userID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if membership == nil {
+				return nil, fmt.Errorf("org membership not found")
+			}
+			break
+		}
+		m := &schemas.OrgMembership{}
+		if _, err := readDocument(ctx, cursor, m); err != nil {
+			return nil, err
+		}
+		membership = m
+	}
+	return membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "org_id", orgID, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "user_id", userID, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, filterField, filterValue string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	memberships := []*schemas.OrgMembership{}
+	query := fmt.Sprintf("FOR d in %s FILTER d.%s == @filter_value SORT d.created_at DESC LIMIT %d, %d RETURN d", schemas.Collections.OrgMembership, filterField, pagination.Offset, pagination.Limit)
+	bindVars := map[string]interface{}{
+		"filter_value": filterValue,
+	}
+	sctx := arangoDriver.WithQueryFullCount(ctx)
+	cursor, err := p.db.Query(sctx, query, bindVars)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	paginationClone := pagination
+	paginationClone.Total = cursor.Statistics().FullCount()
+	for {
+		membership := &schemas.OrgMembership{}
+		meta, err := readDocument(ctx, cursor, membership)
+		if arangoDriver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, nil, err
+		}
+		if meta.Key != "" {
+			memberships = append(memberships, membership)
+		}
+	}
+	return memberships, paginationClone, nil
+}

--- a/internal/storage/db/arangodb/organization.go
+++ b/internal/storage/db/arangodb/organization.go
@@ -1,0 +1,167 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	arangoDriver "github.com/arangodb/go-driver"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrganization creates a new organization record.
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	orgCollection, _ := p.db.Collection(ctx, schemas.Collections.Organization)
+	doc, err := structToDocument(org)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := orgCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	org.Key = meta.Key
+	org.ID = meta.ID.String()
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	orgCollection, _ := p.db.Collection(ctx, schemas.Collections.Organization)
+	doc, err := structToDocument(org)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := orgCollection.UpdateDocument(ctx, org.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	org.Key = meta.Key
+	org.ID = meta.ID.String()
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Mirrors the DeleteClient cascade-delete pattern.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	orgCollection, _ := p.db.Collection(ctx, schemas.Collections.Organization)
+	_, err := orgCollection.RemoveDocument(ctx, org.Key)
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf("FOR d IN %s FILTER d.org_id == @org_id REMOVE { _key: d._key } IN %s", schemas.Collections.OrgMembership, schemas.Collections.OrgMembership)
+	bindVars := map[string]interface{}{
+		// OrgMembership.OrgID is stored as the bare key (set verbatim from the
+		// external, API-facing id) — compare against org.Key, not org.ID (which
+		// is the full "collection/key" handle after a read).
+		"org_id": org.Key,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cursor.Close() }()
+	return nil
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+// Filters on _key, not _id: every real caller holds the bare id
+// AsAPIOrganization exposes, never the full "collection/key" handle.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	var org *schemas.Organization
+	query := fmt.Sprintf("FOR d in %s FILTER d._key == @id LIMIT 1 RETURN d", schemas.Collections.Organization)
+	bindVars := map[string]interface{}{
+		"id": id,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if org == nil {
+				return nil, fmt.Errorf("organization not found")
+			}
+			break
+		}
+		o := &schemas.Organization{}
+		if _, err := readDocument(ctx, cursor, o); err != nil {
+			return nil, err
+		}
+		org = o
+	}
+	return org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	var org *schemas.Organization
+	query := fmt.Sprintf("FOR d in %s FILTER d.name == @name LIMIT 1 RETURN d", schemas.Collections.Organization)
+	bindVars := map[string]interface{}{
+		"name": name,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if org == nil {
+				return nil, fmt.Errorf("organization not found")
+			}
+			break
+		}
+		o := &schemas.Organization{}
+		if _, err := readDocument(ctx, cursor, o); err != nil {
+			return nil, err
+		}
+		org = o
+	}
+	return org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	orgs := []*schemas.Organization{}
+	query := fmt.Sprintf("FOR d in %s SORT d.created_at DESC LIMIT %d, %d RETURN d", schemas.Collections.Organization, pagination.Offset, pagination.Limit)
+	sctx := arangoDriver.WithQueryFullCount(ctx)
+	cursor, err := p.db.Query(sctx, query, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	paginationClone := pagination
+	paginationClone.Total = cursor.Statistics().FullCount()
+	for {
+		org := &schemas.Organization{}
+		meta, err := readDocument(ctx, cursor, org)
+		if arangoDriver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, nil, err
+		}
+		if meta.Key != "" {
+			orgs = append(orgs, org)
+		}
+	}
+	return orgs, paginationClone, nil
+}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -383,6 +383,48 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Sparse: true,
 	})
 
+	// Organization collection and indexes
+	organizationCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.Organization)
+	if err != nil {
+		return nil, err
+	}
+	if !organizationCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.Organization, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	organizationCollection, err := arangodb.Collection(ctx, schemas.Collections.Organization)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = organizationCollection.EnsureHashIndex(ctx, []string{"name"}, &arangoDriver.EnsureHashIndexOptions{
+		Unique: true,
+		Sparse: true,
+	})
+
+	// OrgMembership collection and indexes
+	orgMembershipCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.OrgMembership)
+	if err != nil {
+		return nil, err
+	}
+	if !orgMembershipCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.OrgMembership, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	orgMembershipCollection, err := arangodb.Collection(ctx, schemas.Collections.OrgMembership)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = orgMembershipCollection.EnsureHashIndex(ctx, []string{"org_id", "user_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Unique: true,
+	})
+	_, _, _ = orgMembershipCollection.EnsureHashIndex(ctx, []string{"user_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Sparse: true,
+	})
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/cassandradb/org_membership.go
+++ b/internal/storage/db/cassandradb/org_membership.go
@@ -1,0 +1,129 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const orgMembershipColumns = "id, org_id, user_id, roles, created_at, updated_at"
+
+// scanOrgMembership maps the orgMembershipColumns projection onto a struct.
+func scanOrgMembership(scan func(...interface{}) error, membership *schemas.OrgMembership) error {
+	return scan(&membership.ID, &membership.OrgID, &membership.UserID, &membership.Roles, &membership.CreatedAt, &membership.UpdatedAt)
+}
+
+// AddOrgMembership creates a new membership. (org_id, user_id) is unique.
+// Cassandra has no cross-attribute unique constraint, so guard with a
+// check-then-insert mirroring AddTrustedIssuer's pre-check.
+// ponytail: inherent TOCTOU race — closes the sequential case only.
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	if existing, _ := p.GetOrgMembership(ctx, membership.OrgID, membership.UserID); existing != nil {
+		return nil, fmt.Errorf("membership for org_id %s and user_id %s already exists", membership.OrgID, membership.UserID)
+	}
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.OrgMembership, orgMembershipColumns)
+	err := p.db.Query(insertQuery, membership.ID, membership.OrgID, membership.UserID, membership.Roles, membership.CreatedAt, membership.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	membershipMap := buildCQLColumnMap(membership)
+	updateFields := ""
+	var updateValues []interface{}
+	for key, value := range membershipMap {
+		if key == "id" || key == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", key)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", key)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, membership.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.OrgMembership, updateFields)
+	if err := p.db.Query(query, updateValues...).Exec(); err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.OrgMembership)
+	return p.db.Query(query, membership.ID).Exec()
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	var membership schemas.OrgMembership
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND user_id = ? LIMIT 1 ALLOW FILTERING", orgMembershipColumns, KeySpace+"."+schemas.Collections.OrgMembership)
+	if err := scanOrgMembership(p.db.Query(query, orgID, userID).Consistency(gocql.One).Scan, &membership); err != nil {
+		return nil, err
+	}
+	return &membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "org_id", orgID, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "user_id", userID, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, filterColumn, filterValue string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	memberships := []*schemas.OrgMembership{}
+	paginationClone := pagination
+	table := KeySpace + "." + schemas.Collections.OrgMembership
+
+	totalCountQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = ? ALLOW FILTERING", table, filterColumn)
+	if err := p.db.Query(totalCountQuery, filterValue).Consistency(gocql.One).Scan(&paginationClone.Total); err != nil {
+		return nil, nil, err
+	}
+
+	// there is no offset in cassandra: fetch limit + offset, return offset..limit
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s = ? LIMIT %d ALLOW FILTERING", orgMembershipColumns, table, filterColumn, pagination.Limit+pagination.Offset)
+	scanner := p.db.Query(query, filterValue).Iter().Scanner()
+	counter := int64(0)
+	for scanner.Next() {
+		if counter >= pagination.Offset {
+			var membership schemas.OrgMembership
+			if err := scanOrgMembership(scanner.Scan, &membership); err != nil {
+				return nil, nil, err
+			}
+			memberships = append(memberships, &membership)
+		}
+		counter++
+	}
+	return memberships, paginationClone, nil
+}

--- a/internal/storage/db/cassandradb/organization.go
+++ b/internal/storage/db/cassandradb/organization.go
@@ -1,0 +1,157 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const organizationColumns = "id, name, display_name, enabled, created_at, updated_at"
+
+// scanOrganization maps the organizationColumns projection onto a struct.
+func scanOrganization(scan func(...interface{}) error, org *schemas.Organization) error {
+	return scan(&org.ID, &org.Name, &org.DisplayName, &org.Enabled, &org.CreatedAt, &org.UpdatedAt)
+}
+
+// AddOrganization creates a new organization record.
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	// name is unique (gorm uniqueIndex on the SQL side). Cassandra has no
+	// cross-attribute unique constraint, so guard with a check-then-insert
+	// mirroring AddTrustedIssuer's issuer_url pre-check.
+	// ponytail: inherent TOCTOU race — two concurrent inserts of the same name
+	// can both pass. Closes the sequential admin-misconfiguration case only;
+	// a race-free guard would need an LWT on a name-keyed table.
+	if existing, _ := p.GetOrganizationByName(ctx, org.Name); existing != nil {
+		return nil, fmt.Errorf("organization with %s name already exists", org.Name)
+	}
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.Organization, organizationColumns)
+	err := p.db.Query(insertQuery, org.ID, org.Name, org.DisplayName, org.Enabled, org.CreatedAt, org.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	orgMap := buildCQLColumnMap(org)
+	updateFields := ""
+	var updateValues []interface{}
+	for key, value := range orgMap {
+		if key == "id" || key == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", key)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", key)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, org.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.Organization, updateFields)
+	if err := p.db.Query(query, updateValues...).Exec(); err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Mirrors the DeleteClient cascade-delete pattern.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.Organization)
+	if err := p.db.Query(query, org.ID).Exec(); err != nil {
+		return err
+	}
+
+	getMembershipsQuery := fmt.Sprintf("SELECT id FROM %s WHERE org_id = ? ALLOW FILTERING", KeySpace+"."+schemas.Collections.OrgMembership)
+	scanner := p.db.Query(getMembershipsQuery, org.ID).Iter().Scanner()
+	var membershipIDList []string
+	for scanner.Next() {
+		var membershipID string
+		if err := scanner.Scan(&membershipID); err != nil {
+			return err
+		}
+		membershipIDList = append(membershipIDList, membershipID)
+	}
+	if len(membershipIDList) > 0 {
+		placeholders := strings.Repeat("?,", len(membershipIDList))
+		placeholders = strings.TrimSuffix(placeholders, ",")
+		deleteValues := make([]interface{}, len(membershipIDList))
+		for i, id := range membershipIDList {
+			deleteValues[i] = id
+		}
+		query = fmt.Sprintf("DELETE FROM %s WHERE id IN (%s)", KeySpace+"."+schemas.Collections.OrgMembership, placeholders)
+		if err := p.db.Query(query, deleteValues...).Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	var org schemas.Organization
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", organizationColumns, KeySpace+"."+schemas.Collections.Organization)
+	if err := scanOrganization(p.db.Query(query, id).Consistency(gocql.One).Scan, &org); err != nil {
+		return nil, err
+	}
+	return &org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	var org schemas.Organization
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE name = ? LIMIT 1 ALLOW FILTERING", organizationColumns, KeySpace+"."+schemas.Collections.Organization)
+	if err := scanOrganization(p.db.Query(query, name).Consistency(gocql.One).Scan, &org); err != nil {
+		return nil, err
+	}
+	return &org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	orgs := []*schemas.Organization{}
+	paginationClone := pagination
+	totalCountQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s`, KeySpace+"."+schemas.Collections.Organization)
+	if err := p.db.Query(totalCountQuery).Consistency(gocql.One).Scan(&paginationClone.Total); err != nil {
+		return nil, nil, err
+	}
+	// there is no offset in cassandra: fetch limit + offset, return offset..limit
+	query := fmt.Sprintf("SELECT %s FROM %s LIMIT %d", organizationColumns, KeySpace+"."+schemas.Collections.Organization, pagination.Limit+pagination.Offset)
+	scanner := p.db.Query(query).Iter().Scanner()
+	counter := int64(0)
+	for scanner.Next() {
+		if counter >= pagination.Offset {
+			var org schemas.Organization
+			if err := scanOrganization(scanner.Scan, &org); err != nil {
+				return nil, nil, err
+			}
+			orgs = append(orgs, &org)
+		}
+		counter++
+	}
+	return orgs, paginationClone, nil
+}

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -398,11 +398,62 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	// index (hot path for client_assertion validation) to become queryable.
 	waitForCassandraTrustedIssuerIndexes(session, KeySpace, schemas.Collections.TrustedIssuer, 30*time.Second)
 
+	// Organization table and index
+	organizationCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, name text, display_name text, enabled boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.Organization)
+	if err = session.Query(organizationCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	organizationNameIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_organization_name ON %s.%s (name)", KeySpace, schemas.Collections.Organization)
+	if err = session.Query(organizationNameIndex).Exec(); err != nil {
+		return nil, err
+	}
+
+	// OrgMembership table and indexes
+	orgMembershipCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, user_id text, roles text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.OrgMembership)
+	if err = session.Query(orgMembershipCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	orgMembershipOrgIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_org_membership_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.OrgMembership)
+	if err = session.Query(orgMembershipOrgIndex).Exec(); err != nil {
+		return nil, err
+	}
+	orgMembershipUserIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_org_membership_user_id ON %s.%s (user_id)", KeySpace, schemas.Collections.OrgMembership)
+	if err = session.Query(orgMembershipUserIndex).Exec(); err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for the lookup
+	// columns used by the uniqueness guard and membership listings.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Organization, "name", 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "org_id", 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "user_id", 30*time.Second)
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,
 		db:           session,
 	}, err
+}
+
+// waitForCassandraSecondaryIndex polls a probe query that requires the given
+// column's secondary index until it succeeds or the timeout is reached.
+// ScyllaDB builds secondary indexes asynchronously; queries on indexed columns
+// fail until the index is ready.
+func waitForCassandraSecondaryIndex(session *cansandraDriver.Session, keyspace, table, column string, timeout time.Duration) {
+	probe := fmt.Sprintf("SELECT id FROM %s.%s WHERE %s='' LIMIT 1 ALLOW FILTERING", keyspace, table, column)
+	deadline := time.Now().Add(timeout)
+	delay := 500 * time.Millisecond
+	for {
+		if err := session.Query(probe).Exec(); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(delay)
+		if delay < 3*time.Second {
+			delay += 500 * time.Millisecond
+		}
+	}
 }
 
 // waitForCassandraIndexes polls a probe query that requires the actor_id secondary

--- a/internal/storage/db/couchbase/org_membership.go
+++ b/internal/storage/db/couchbase/org_membership.go
@@ -1,0 +1,166 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const orgMembershipColumns = "_id, org_id, user_id, roles, created_at, updated_at"
+
+// AddOrgMembership creates a new membership. (org_id, user_id) is unique;
+// Couchbase has no compound unique constraint, so guard with a
+// check-then-insert (closes the sequential case).
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	if existing, _ := p.GetOrgMembership(ctx, membership.OrgID, membership.UserID); existing != nil {
+		return nil, fmt.Errorf("membership for org_id %s and user_id %s already exists", membership.OrgID, membership.UserID)
+	}
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(membership)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.OrgMembership).Insert(membership.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	membershipMap, err := structToDocument(membership)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(membershipMap)
+	params["_id"] = membership.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.OrgMembership, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.OrgMembership).Remove(membership.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	params := make(map[string]interface{}, 2)
+	params["org_id"] = orgID
+	params["user_id"] = userID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND user_id=$user_id LIMIT 1`, orgMembershipColumns, p.scopeName, schemas.Collections.OrgMembership)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	membership := &schemas.OrgMembership{}
+	if err := decodeDocument(raw, membership); err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "org_id", orgID, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "user_id", userID, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, filterColumn, filterValue string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	memberships := []*schemas.OrgMembership{}
+	paginationClone := pagination
+	table := fmt.Sprintf("%s.%s", p.scopeName, schemas.Collections.OrgMembership)
+
+	params := make(map[string]interface{}, 3)
+	params["offset"] = paginationClone.Offset
+	params["limit"] = paginationClone.Limit
+	params["filter_value"] = filterValue
+
+	total := TotalDocs{}
+	countQuery := fmt.Sprintf("SELECT COUNT(*) as Total FROM %s WHERE %s=$filter_value", table, filterColumn)
+	countRes, err := p.db.Query(countQuery, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: map[string]interface{}{"filter_value": filterValue},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = countRes.One(&total)
+	paginationClone.Total = total.Total
+
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s=$filter_value ORDER BY created_at DESC OFFSET $offset LIMIT $limit", orgMembershipColumns, table, filterColumn)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, nil, err
+		}
+		membership := &schemas.OrgMembership{}
+		if err := decodeDocument(raw, membership); err != nil {
+			return nil, nil, err
+		}
+		memberships = append(memberships, membership)
+	}
+	if err := queryResult.Err(); err != nil {
+		return nil, nil, err
+	}
+	return memberships, paginationClone, nil
+}

--- a/internal/storage/db/couchbase/organization.go
+++ b/internal/storage/db/couchbase/organization.go
@@ -1,0 +1,180 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const organizationColumns = "_id, name, display_name, enabled, created_at, updated_at"
+
+// AddOrganization creates a new organization record. name is unique;
+// Couchbase has no cross-attribute unique constraint, so guard with a
+// check-then-insert on name (closes the sequential case).
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	if existing, _ := p.GetOrganizationByName(ctx, org.Name); existing != nil {
+		return nil, fmt.Errorf("organization with %s name already exists", org.Name)
+	}
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(org)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.Organization).Insert(org.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	orgMap, err := structToDocument(org)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(orgMap)
+	params["_id"] = org.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.Organization, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Mirrors the DeleteClient cascade-delete pattern.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.Organization).Remove(org.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	params := make(map[string]interface{}, 1)
+	params["org_id"] = org.ID
+	query := fmt.Sprintf(`DELETE FROM %s.%s WHERE org_id=$org_id`, p.scopeName, schemas.Collections.OrgMembership)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	params := make(map[string]interface{}, 1)
+	params["_id"] = id
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, organizationColumns, p.scopeName, schemas.Collections.Organization)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	org := &schemas.Organization{}
+	if err := decodeDocument(raw, org); err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	params := make(map[string]interface{}, 1)
+	params["name"] = name
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE name=$name LIMIT 1`, organizationColumns, p.scopeName, schemas.Collections.Organization)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	org := &schemas.Organization{}
+	if err := decodeDocument(raw, org); err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	orgs := []*schemas.Organization{}
+	paginationClone := pagination
+	params := make(map[string]interface{}, 2)
+	params["offset"] = paginationClone.Offset
+	params["limit"] = paginationClone.Limit
+	total, err := p.GetTotalDocs(ctx, schemas.Collections.Organization)
+	if err != nil {
+		return nil, nil, err
+	}
+	paginationClone.Total = total
+	query := fmt.Sprintf("SELECT %s FROM %s.%s ORDER BY created_at DESC OFFSET $offset LIMIT $limit", organizationColumns, p.scopeName, schemas.Collections.Organization)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, nil, err
+		}
+		org := &schemas.Organization{}
+		if err := decodeDocument(raw, org); err != nil {
+			return nil, nil, err
+		}
+		orgs = append(orgs, org)
+	}
+	if err := queryResult.Err(); err != nil {
+		return nil, nil, err
+	}
+	return orgs, paginationClone, nil
+}

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -291,5 +291,14 @@ func getIndex(scopeName string) map[string][]string {
 	trustedIssuerIndex2 := fmt.Sprintf("CREATE INDEX TrustedIssuerClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.TrustedIssuer)
 	indices[schemas.Collections.TrustedIssuer] = []string{trustedIssuerIndex1, trustedIssuerIndex2}
 
+	// Organization index
+	organizationIndex1 := fmt.Sprintf("CREATE INDEX OrganizationNameIndex ON %s.%s(name)", scopeName, schemas.Collections.Organization)
+	indices[schemas.Collections.Organization] = []string{organizationIndex1}
+
+	// OrgMembership indexes
+	orgMembershipIndex1 := fmt.Sprintf("CREATE INDEX OrgMembershipOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.OrgMembership)
+	orgMembershipIndex2 := fmt.Sprintf("CREATE INDEX OrgMembershipUserIdIndex ON %s.%s(user_id)", scopeName, schemas.Collections.OrgMembership)
+	indices[schemas.Collections.OrgMembership] = []string{orgMembershipIndex1, orgMembershipIndex2}
+
 	return indices
 }

--- a/internal/storage/db/dynamodb/org_membership.go
+++ b/internal/storage/db/dynamodb/org_membership.go
@@ -62,7 +62,13 @@ func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.
 // org_id GSI with a user_id filter.
 func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
 	f := expression.Name("user_id").Equal(expression.Value(userID))
-	items, err := p.queryEqLimit(ctx, schemas.Collections.OrgMembership, "org_id", "org_id", orgID, &f, 1)
+	// Must NOT pass a Limit alongside a FilterExpression: DynamoDB applies Limit
+	// BEFORE the filter, so Limit=1 reads one arbitrary item from the org_id
+	// partition and returns zero matches for a multi-member org even when the
+	// (org_id, user_id) row exists — silently allowing duplicate memberships and
+	// breaking member removal. queryEq paginates and filters server-side across
+	// the whole partition; the unique (org_id, user_id) invariant means at most one match.
+	items, err := p.queryEq(ctx, schemas.Collections.OrgMembership, "org_id", "org_id", orgID, &f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/dynamodb/org_membership.go
+++ b/internal/storage/db/dynamodb/org_membership.go
@@ -1,0 +1,118 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgMembership creates a new membership. (org_id, user_id) is unique;
+// DynamoDB has no compound unique constraint, so guard with a check-then-insert
+// (closes the sequential case).
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	if existing, _ := p.GetOrgMembership(ctx, membership.OrgID, membership.UserID); existing != nil {
+		return nil, fmt.Errorf("membership for org_id %s and user_id %s already exists", membership.OrgID, membership.UserID)
+	}
+	if err := p.putItem(ctx, schemas.Collections.OrgMembership, membership); err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — UpdateItem applies a partial SET/REMOVE merge, so a partial struct
+// blanks untouched columns to their zero values.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.OrgMembership, "id", membership.ID, membership); err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	if membership == nil {
+		return nil
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.OrgMembership, "id", membership.ID)
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair via the
+// org_id GSI with a user_id filter.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	f := expression.Name("user_id").Equal(expression.Value(userID))
+	items, err := p.queryEqLimit(ctx, schemas.Collections.OrgMembership, "org_id", "org_id", orgID, &f, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var membership schemas.OrgMembership
+	if err := unmarshalItem(items[0], &membership); err != nil {
+		return nil, err
+	}
+	return &membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "org_id", orgID, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "user_id", userID, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, indexAndAttr, value string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	paginationClone := pagination
+	var memberships []*schemas.OrgMembership
+
+	var items []map[string]types.AttributeValue
+	items, err := p.queryEq(ctx, schemas.Collections.OrgMembership, indexAndAttr, indexAndAttr, value, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, it := range items {
+		var membership schemas.OrgMembership
+		if err := unmarshalItem(it, &membership); err != nil {
+			return nil, nil, err
+		}
+		memberships = append(memberships, &membership)
+	}
+
+	sort.Slice(memberships, func(i, j int) bool { return memberships[i].CreatedAt > memberships[j].CreatedAt })
+	paginationClone.Total = int64(len(memberships))
+
+	start := int(pagination.Offset)
+	if start >= len(memberships) {
+		return []*schemas.OrgMembership{}, paginationClone, nil
+	}
+	end := start + int(pagination.Limit)
+	if end > len(memberships) {
+		end = len(memberships)
+	}
+	return memberships[start:end], paginationClone, nil
+}

--- a/internal/storage/db/dynamodb/organization.go
+++ b/internal/storage/db/dynamodb/organization.go
@@ -1,0 +1,133 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrganization creates a new organization record. name is unique;
+// DynamoDB has no cross-attribute unique constraint, so guard with a
+// check-then-insert on the name GSI (closes the sequential case).
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	if existing, _ := p.GetOrganizationByName(ctx, org.Name); existing != nil {
+		return nil, fmt.Errorf("organization with %s name already exists", org.Name)
+	}
+	if err := p.putItem(ctx, schemas.Collections.Organization, org); err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — UpdateItem applies a partial SET/REMOVE merge, so a partial struct
+// blanks untouched columns to their zero values.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.Organization, "id", org.ID, org); err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Deletes child memberships BEFORE the parent (mirrors DeleteClient ordering);
+// any query/delete error is returned so the caller knows the cascade did not
+// complete.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	if org == nil {
+		return nil
+	}
+	items, err := p.queryEq(ctx, schemas.Collections.OrgMembership, "org_id", "org_id", org.ID, nil)
+	if err != nil {
+		return err
+	}
+	for _, it := range items {
+		var membership schemas.OrgMembership
+		if err := unmarshalItem(it, &membership); err != nil {
+			return err
+		}
+		if err := p.deleteItemByHash(ctx, schemas.Collections.OrgMembership, "id", membership.ID); err != nil {
+			return err
+		}
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.Organization, "id", org.ID)
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	var org schemas.Organization
+	err := p.getItemByHash(ctx, schemas.Collections.Organization, "id", id, &org)
+	if err != nil {
+		return nil, err
+	}
+	if org.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	items, err := p.queryEqLimit(ctx, schemas.Collections.Organization, "name", "name", name, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var org schemas.Organization
+	if err := unmarshalItem(items[0], &org); err != nil {
+		return nil, err
+	}
+	return &org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	paginationClone := pagination
+	var orgs []*schemas.Organization
+
+	items, err := p.scanAllRaw(ctx, schemas.Collections.Organization, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, it := range items {
+		var org schemas.Organization
+		if err := unmarshalItem(it, &org); err != nil {
+			return nil, nil, err
+		}
+		orgs = append(orgs, &org)
+	}
+
+	sort.Slice(orgs, func(i, j int) bool { return orgs[i].CreatedAt > orgs[j].CreatedAt })
+	paginationClone.Total = int64(len(orgs))
+
+	start := int(pagination.Offset)
+	if start >= len(orgs) {
+		return []*schemas.Organization{}, paginationClone, nil
+	}
+	end := start + int(pagination.Limit)
+	if end > len(orgs) {
+		end = len(orgs)
+	}
+	return orgs[start:end], paginationClone, nil
+}

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -193,6 +193,28 @@ func (p *provider) ensureTables(ctx context.Context) error {
 				gsi("client_id", "client_id"),
 			},
 		},
+		{
+			name: schemas.Collections.Organization,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("name"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("name", "name")},
+		},
+		{
+			name: schemas.Collections.OrgMembership,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("user_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{
+				gsi("org_id", "org_id"),
+				gsi("user_id", "user_id"),
+			},
+		},
 	}
 
 	for _, t := range tables {

--- a/internal/storage/db/mongodb/org_membership.go
+++ b/internal/storage/db/mongodb/org_membership.go
@@ -1,0 +1,109 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgMembership creates a new membership. The compound unique index on
+// (org_id, user_id) rejects duplicates at the database layer.
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	_, err := membershipCollection.InsertOne(ctx, membership)
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — the $set write replaces every column and will blank zero-value
+// fields on a partial struct.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	_, err := membershipCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": membership.ID}}, bson.M{"$set": membership}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	_, err := membershipCollection.DeleteOne(ctx, bson.M{"_id": membership.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	var membership *schemas.OrgMembership
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	err := membershipCollection.FindOne(ctx, bson.M{"org_id": orgID, "user_id": userID}).Decode(&membership)
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, bson.M{"org_id": orgID}, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, bson.M{"user_id": userID}, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, filter bson.M, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	memberships := []*schemas.OrgMembership{}
+	opts := options.Find()
+	opts.SetLimit(pagination.Limit)
+	opts.SetSkip(pagination.Offset)
+	opts.SetSort(bson.M{"created_at": -1})
+	paginationClone := pagination
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	count, err := membershipCollection.CountDocuments(ctx, filter, options.Count())
+	if err != nil {
+		return nil, nil, err
+	}
+	paginationClone.Total = count
+	cursor, err := membershipCollection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	for cursor.Next(ctx) {
+		var membership *schemas.OrgMembership
+		err := cursor.Decode(&membership)
+		if err != nil {
+			return nil, nil, err
+		}
+		memberships = append(memberships, membership)
+	}
+	return memberships, paginationClone, nil
+}

--- a/internal/storage/db/mongodb/organization.go
+++ b/internal/storage/db/mongodb/organization.go
@@ -1,0 +1,116 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrganization creates a new organization record.
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	_, err := orgCollection.InsertOne(ctx, org)
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — the $set write replaces every column and will blank zero-value
+// fields on a partial struct.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	_, err := orgCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": org.ID}}, bson.M{"$set": org}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Mirrors the DeleteClient cascade-delete pattern.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	_, err := orgCollection.DeleteOne(ctx, bson.M{"_id": org.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	membershipCollection := p.db.Collection(schemas.Collections.OrgMembership, options.Collection())
+	_, err = membershipCollection.DeleteMany(ctx, bson.M{"org_id": org.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	var org *schemas.Organization
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	err := orgCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&org)
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	var org *schemas.Organization
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	err := orgCollection.FindOne(ctx, bson.M{"name": name}).Decode(&org)
+	if err != nil {
+		return nil, err
+	}
+	return org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	orgs := []*schemas.Organization{}
+	opts := options.Find()
+	opts.SetLimit(pagination.Limit)
+	opts.SetSkip(pagination.Offset)
+	opts.SetSort(bson.M{"created_at": -1})
+	paginationClone := pagination
+	orgCollection := p.db.Collection(schemas.Collections.Organization, options.Collection())
+	count, err := orgCollection.CountDocuments(ctx, bson.M{}, options.Count())
+	if err != nil {
+		return nil, nil, err
+	}
+	paginationClone.Total = count
+	cursor, err := orgCollection.Find(ctx, bson.M{}, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	for cursor.Next(ctx) {
+		var org *schemas.Organization
+		err := cursor.Decode(&org)
+		if err != nil {
+			return nil, nil, err
+		}
+		orgs = append(orgs, org)
+	}
+	return orgs, paginationClone, nil
+}

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -219,6 +219,30 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// Organization collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.Organization, options.CreateCollection())
+	organizationCollection := mongodb.Collection(schemas.Collections.Organization, options.Collection())
+	_, _ = organizationCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.M{"name": 1},
+			Options: options.Index().SetUnique(true).SetSparse(true),
+		},
+	}, options.CreateIndexes())
+
+	// OrgMembership collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.OrgMembership, options.CreateCollection())
+	orgMembershipCollection := mongodb.Collection(schemas.Collections.OrgMembership, options.Collection())
+	_, _ = orgMembershipCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "org_id", Value: 1}, {Key: "user_id", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.M{"user_id": 1},
+			Options: options.Index().SetSparse(true),
+		},
+	}, options.CreateIndexes())
+
 	return &provider{
 		config:       config,
 		dependencies: deps,

--- a/internal/storage/db/sql/org_membership.go
+++ b/internal/storage/db/sql/org_membership.go
@@ -1,0 +1,89 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgMembership creates a new membership. The composite unique index on
+// (org_id, user_id) rejects duplicates at the database layer.
+func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.ID == "" {
+		membership.ID = uuid.New().String()
+	}
+	membership.Key = membership.ID
+	now := time.Now().Unix()
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	res := p.db.Create(membership)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return membership, nil
+}
+
+// UpdateOrgMembership updates a membership record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — Save writes every column and will blank zero-value fields on a
+// partial struct.
+func (p *provider) UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if membership.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrgMembership: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	membership.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(membership)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return membership, nil
+}
+
+// DeleteOrgMembership removes a membership record.
+func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error {
+	return p.db.Delete(membership).Error
+}
+
+// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	var membership schemas.OrgMembership
+	res := p.db.Where("org_id = ? AND user_id = ?", orgID, userID).First(&membership)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &membership, nil
+}
+
+// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+func (p *provider) ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "org_id = ?", orgID, pagination)
+}
+
+// ListOrgMembershipsByUser returns paginated memberships held by a user.
+func (p *provider) ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	return p.listOrgMemberships(ctx, "user_id = ?", userID, pagination)
+}
+
+func (p *provider) listOrgMemberships(ctx context.Context, whereClause, whereValue string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	var memberships []*schemas.OrgMembership
+	res := p.db.Where(whereClause, whereValue).Limit(int(pagination.Limit)).Offset(int(pagination.Offset)).Order("created_at DESC").Find(&memberships)
+	if res.Error != nil {
+		return nil, nil, res.Error
+	}
+	var total int64
+	countRes := p.db.Model(&schemas.OrgMembership{}).Where(whereClause, whereValue).Count(&total)
+	if countRes.Error != nil {
+		return nil, nil, countRes.Error
+	}
+	return memberships, &model.Pagination{
+		Limit:  pagination.Limit,
+		Page:   pagination.Page,
+		Offset: pagination.Offset,
+		Total:  total,
+	}, nil
+}

--- a/internal/storage/db/sql/organization.go
+++ b/internal/storage/db/sql/organization.go
@@ -1,0 +1,93 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrganization creates a new organization record.
+func (p *provider) AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.ID == "" {
+		org.ID = uuid.New().String()
+	}
+	org.Key = org.ID
+	now := time.Now().Unix()
+	org.CreatedAt = now
+	org.UpdatedAt = now
+	res := p.db.Create(org)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates an organization record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — Save writes every column and will blank zero-value fields on a
+// partial struct.
+func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error) {
+	if org.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateOrganization: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	org.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(org)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return org, nil
+}
+
+// DeleteOrganization removes an organization and all its memberships.
+// Mirrors the DeleteClient cascade-delete pattern.
+func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
+	if err := p.db.Where("org_id = ?", org.ID).Delete(&schemas.OrgMembership{}).Error; err != nil {
+		return err
+	}
+	return p.db.Delete(org).Error
+}
+
+// GetOrganizationByID fetches an organization by primary key.
+func (p *provider) GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error) {
+	var org schemas.Organization
+	res := p.db.Where("id = ?", id).First(&org)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &org, nil
+}
+
+// GetOrganizationByName fetches an organization by its unique name slug.
+func (p *provider) GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error) {
+	var org schemas.Organization
+	res := p.db.Where("name = ?", name).First(&org)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &org, nil
+}
+
+// ListOrganizations returns a paginated list of organizations.
+func (p *provider) ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error) {
+	var orgs []*schemas.Organization
+	res := p.db.Limit(int(pagination.Limit)).Offset(int(pagination.Offset)).Order("created_at DESC").Find(&orgs)
+	if res.Error != nil {
+		return nil, nil, res.Error
+	}
+	var total int64
+	countRes := p.db.Model(&schemas.Organization{}).Count(&total)
+	if countRes.Error != nil {
+		return nil, nil, countRes.Error
+	}
+	return orgs, &model.Pagination{
+		Limit:  pagination.Limit,
+		Page:   pagination.Page,
+		Offset: pagination.Offset,
+		Total:  total,
+	}, nil
+}

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -213,6 +213,38 @@ type Provider interface {
 	// ListTrustedIssuers returns trusted issuers filtered by serviceAccountID.
 	// Pass an empty serviceAccountID to list all issuers.
 	ListTrustedIssuers(ctx context.Context, serviceAccountID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error)
+
+	// Organization methods.
+
+	// AddOrganization creates a new organization record.
+	AddOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error)
+	// GetOrganizationByID fetches an organization by its primary key.
+	GetOrganizationByID(ctx context.Context, id string) (*schemas.Organization, error)
+	// GetOrganizationByName fetches an organization by its unique name slug.
+	GetOrganizationByName(ctx context.Context, name string) (*schemas.Organization, error)
+	// UpdateOrganization updates name, display_name, or enabled.
+	UpdateOrganization(ctx context.Context, org *schemas.Organization) (*schemas.Organization, error)
+	// DeleteOrganization removes an organization and cascade-deletes its
+	// memberships. Mirrors the DeleteClient cascade pattern.
+	DeleteOrganization(ctx context.Context, org *schemas.Organization) error
+	// ListOrganizations returns a paginated list of all organizations.
+	ListOrganizations(ctx context.Context, pagination *model.Pagination) ([]*schemas.Organization, *model.Pagination, error)
+
+	// OrgMembership methods.
+
+	// AddOrgMembership creates a new membership. The (org_id, user_id) pair is
+	// unique — adding a duplicate returns an error.
+	AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error)
+	// GetOrgMembership fetches the membership for a (orgID, userID) pair.
+	GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error)
+	// UpdateOrgMembership updates the roles of an existing membership.
+	UpdateOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error)
+	// DeleteOrgMembership removes a membership.
+	DeleteOrgMembership(ctx context.Context, membership *schemas.OrgMembership) error
+	// ListOrgMembershipsByOrg returns paginated memberships of an organization.
+	ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
+	// ListOrgMembershipsByUser returns paginated memberships held by a user.
+	ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
 }
 
 // New creates a new database provider based on the configuration

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -1566,6 +1566,34 @@ func testOrgMembershipOperations(t *testing.T, ctx context.Context, provider Pro
 	_, err = provider.GetOrgMembership(ctx, orgBID, userID)
 	assert.NoError(t, err, "deleting the Org A membership must not affect the Org B membership")
 
+	// Multi-member org: two distinct users in ONE org. This exercises the path
+	// where the DynamoDB GetOrgMembership filter+Limit bug (now fixed) returned a
+	// false "not found" — Limit was applied before the user_id filter, so a lookup
+	// for a member not scanned first missed it, silently allowing duplicate
+	// memberships and breaking member removal. Single-member-per-org tests above
+	// never hit this. Guards the regression under TEST_DBS=dynamodb.
+	orgC, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "org-c-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgCID := orgC.AsAPIOrganization().ID
+	userX := uuid.New().String()
+	userY := uuid.New().String()
+	_, err = provider.AddOrgMembership(ctx, &schemas.OrgMembership{OrgID: orgCID, UserID: userX, Roles: "admin"})
+	require.NoError(t, err)
+	_, err = provider.AddOrgMembership(ctx, &schemas.OrgMembership{OrgID: orgCID, UserID: userY, Roles: "viewer"})
+	require.NoError(t, err)
+	gx, err := provider.GetOrgMembership(ctx, orgCID, userX)
+	require.NoError(t, err, "first member must be found in a multi-member org")
+	assert.Equal(t, userX, gx.UserID)
+	gy, err := provider.GetOrgMembership(ctx, orgCID, userY)
+	require.NoError(t, err, "second member must be found in a multi-member org (filter+Limit regression)")
+	assert.Equal(t, userY, gy.UserID)
+	_, err = provider.AddOrgMembership(ctx, &schemas.OrgMembership{OrgID: orgCID, UserID: userY, Roles: "viewer"})
+	assert.Error(t, err, "duplicate membership in a multi-member org must be rejected")
+	require.NoError(t, provider.DeleteOrganization(ctx, orgC))
+
 	require.NoError(t, provider.DeleteOrganization(ctx, orgA))
 	require.NoError(t, provider.DeleteOrganization(ctx, orgB))
 }

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -187,6 +187,14 @@ func TestStorageProvider(t *testing.T) {
 				testTrustedIssuerOperations(t, ctx, provider, dbType)
 			})
 
+			t.Run("Organization Operations", func(t *testing.T) {
+				testOrganizationOperations(t, ctx, provider)
+			})
+
+			t.Run("Org Membership Operations", func(t *testing.T) {
+				testOrgMembershipOperations(t, ctx, provider)
+			})
+
 			if isSQLTestDB(dbType) {
 				t.Run("SQL CRUD Correctness Fixes", func(t *testing.T) {
 					testSQLCRUDCorrectnessFixes(t, ctx, provider)
@@ -1403,4 +1411,161 @@ func testTrustedIssuerOperations(t *testing.T, ctx context.Context, provider Pro
 	assert.Error(t, err, "trusted issuer should be gone after delete")
 
 	require.NoError(t, provider.DeleteClient(ctx, sa))
+}
+
+// testOrganizationOperations exercises Organization CRUD plus the cascade that
+// removes an org's memberships on delete. Every lookup uses the API-facing id.
+func testOrganizationOperations(t *testing.T, ctx context.Context, provider Provider) {
+	displayName := "Acme Corporation"
+	org := &schemas.Organization{
+		Name:        "acme-" + uuid.New().String(),
+		DisplayName: &displayName,
+		Enabled:     true,
+	}
+
+	created, err := provider.AddOrganization(ctx, org)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	orgID := created.AsAPIOrganization().ID
+	require.NotEmpty(t, orgID)
+
+	fetched, err := provider.GetOrganizationByID(ctx, orgID)
+	require.NoError(t, err, "GetOrganizationByID must resolve the API-facing id")
+	assert.Equal(t, org.Name, fetched.Name)
+	require.NotNil(t, fetched.DisplayName)
+	assert.Equal(t, displayName, *fetched.DisplayName)
+	assert.True(t, fetched.Enabled)
+
+	byName, err := provider.GetOrganizationByName(ctx, org.Name)
+	require.NoError(t, err)
+	assert.Equal(t, orgID, byName.AsAPIOrganization().ID, "GetOrganizationByName must resolve the same org")
+
+	// Update: disable and rename display name — must persist (not silently no-op).
+	newDisplay := "Acme Inc"
+	fetched.Enabled = false
+	fetched.DisplayName = &newDisplay
+	updated, err := provider.UpdateOrganization(ctx, fetched)
+	require.NoError(t, err)
+	assert.False(t, updated.Enabled)
+	refetched, err := provider.GetOrganizationByID(ctx, orgID)
+	require.NoError(t, err)
+	assert.False(t, refetched.Enabled, "disabled state must persist")
+	require.NotNil(t, refetched.DisplayName)
+	assert.Equal(t, newDisplay, *refetched.DisplayName)
+
+	// A membership bound to this org (via the API-facing id) must cascade-delete
+	// with the organization — not survive as an orphan.
+	userID := uuid.New().String()
+	membership, err := provider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgID,
+		UserID: userID,
+		Roles:  "admin",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, membership)
+
+	// ListOrganizations should include the created org.
+	list, _, err := provider.ListOrganizations(ctx, &model.Pagination{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	foundInList := false
+	for _, o := range list {
+		if o.AsAPIOrganization().ID == orgID {
+			foundInList = true
+			break
+		}
+	}
+	assert.True(t, foundInList, "created organization should appear in ListOrganizations")
+
+	// DeleteOrganization must cascade: the membership must be gone too.
+	require.NoError(t, provider.DeleteOrganization(ctx, refetched))
+
+	_, err = provider.GetOrganizationByID(ctx, orgID)
+	assert.Error(t, err, "organization should be gone after delete")
+
+	_, err = provider.GetOrgMembership(ctx, orgID, userID)
+	assert.Error(t, err, "membership must be cascade-deleted with its organization, not orphaned")
+
+	remaining, _, err := provider.ListOrgMembershipsByOrg(ctx, orgID, &model.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(remaining), "no orphaned memberships should remain after cascade delete")
+}
+
+// testOrgMembershipOperations exercises membership uniqueness, cross-org role
+// independence, and the by-user listing.
+func testOrgMembershipOperations(t *testing.T, ctx context.Context, provider Provider) {
+	orgA, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "org-a-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgAID := orgA.AsAPIOrganization().ID
+
+	orgB, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "org-b-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgBID := orgB.AsAPIOrganization().ID
+
+	userID := uuid.New().String()
+
+	// Same user is admin in Org A and viewer in Org B — roles independent.
+	memberA, err := provider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgAID,
+		UserID: userID,
+		Roles:  "admin",
+	})
+	require.NoError(t, err)
+	_, err = provider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgBID,
+		UserID: userID,
+		Roles:  "viewer",
+	})
+	require.NoError(t, err)
+
+	inA, err := provider.GetOrgMembership(ctx, orgAID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"admin"}, inA.ParsedRoles())
+	inB, err := provider.GetOrgMembership(ctx, orgBID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"viewer"}, inB.ParsedRoles())
+
+	// Duplicate membership: the same (org_id, user_id) must be rejected. Every
+	// provider enforces this (unique index or check-then-insert guard).
+	_, err = provider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgAID,
+		UserID: userID,
+		Roles:  "admin",
+	})
+	assert.Error(t, err, "a duplicate (org_id, user_id) membership must be rejected")
+
+	// The user must be a member of exactly two organizations.
+	byUser, _, err := provider.ListOrgMembershipsByUser(ctx, userID, &model.Pagination{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(byUser), "user should have memberships in exactly two organizations")
+
+	// Org A must list exactly this one member.
+	byOrg, _, err := provider.ListOrgMembershipsByOrg(ctx, orgAID, &model.Pagination{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(byOrg))
+	assert.Equal(t, userID, byOrg[0].UserID)
+
+	// UpdateOrgMembership: load-then-mutate the roles — must persist.
+	inA.Roles = "admin,billing"
+	_, err = provider.UpdateOrgMembership(ctx, inA)
+	require.NoError(t, err)
+	refetched, err := provider.GetOrgMembership(ctx, orgAID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"admin", "billing"}, refetched.ParsedRoles(), "updated roles must persist")
+
+	// Direct membership delete removes only the targeted membership.
+	require.NoError(t, provider.DeleteOrgMembership(ctx, memberA))
+	_, err = provider.GetOrgMembership(ctx, orgAID, userID)
+	assert.Error(t, err, "membership should be gone after delete")
+	_, err = provider.GetOrgMembership(ctx, orgBID, userID)
+	assert.NoError(t, err, "deleting the Org A membership must not affect the Org B membership")
+
+	require.NoError(t, provider.DeleteOrganization(ctx, orgA))
+	require.NoError(t, provider.DeleteOrganization(ctx, orgB))
 }

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -18,6 +18,8 @@ type CollectionList struct {
 	AuditLog               string
 	Client                 string
 	TrustedIssuer          string
+	Organization           string
+	OrgMembership          string
 }
 
 var (
@@ -41,5 +43,7 @@ var (
 		AuditLog:               Prefix + "audit_logs",
 		Client:                 Prefix + "clients",
 		TrustedIssuer:          Prefix + "trusted_issuers",
+		Organization:           Prefix + "organizations",
+		OrgMembership:          Prefix + "org_memberships",
 	}
 )

--- a/internal/storage/schemas/org_membership.go
+++ b/internal/storage/schemas/org_membership.go
@@ -1,0 +1,74 @@
+package schemas
+
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// OrgMembership links a User to an Organization with a set of per-org roles.
+//
+// A user may belong to many organizations, each with independent roles; an
+// organization has many members. The (OrgID, UserID) pair is UNIQUE — a user
+// can be a member of a given organization at most once. The SQL providers
+// enforce this with a composite unique index; the NoSQL providers enforce it
+// with a compound unique index (Mongo/Arango) or a check-then-insert guard
+// (Cassandra/Couchbase/DynamoDB). The service layer additionally rejects
+// duplicates up-front so behaviour is uniform across every backend.
+//
+// Roles is a comma-separated list of per-organization role names, mirroring the
+// storage convention used by Client.AllowedScopes. Use ParsedRoles to interpret
+// it; the service layer normalizes on write.
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type OrgMembership struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID references the Organization this membership belongs to.
+	// Part of the unique (org_id, user_id) constraint.
+	OrgID string `gorm:"uniqueIndex:idx_org_membership_org_user" json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" index:"org_id,hash"`
+
+	// UserID references the User who is a member.
+	// Part of the unique (org_id, user_id) constraint; also indexed on its own
+	// for the "list an org membership by user" query.
+	UserID string `gorm:"uniqueIndex:idx_org_membership_org_user;index" json:"user_id" bson:"user_id" cql:"user_id" dynamo:"user_id" index:"user_id,hash"`
+
+	// Roles is a comma-separated list of per-organization roles.
+	Roles string `json:"roles" bson:"roles" cql:"roles" dynamo:"roles"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// ParsedRoles returns Roles as a slice: comma-separated, whitespace trimmed,
+// empty segments dropped. An empty or whitespace-only Roles yields an empty
+// slice.
+func (m *OrgMembership) ParsedRoles() []string {
+	roles := []string{}
+	for _, r := range strings.Split(m.Roles, ",") {
+		if r = strings.TrimSpace(r); r != "" {
+			roles = append(roles, r)
+		}
+	}
+	return roles
+}
+
+// AsAPIOrgMember converts the storage record into the GraphQL model.
+func (m *OrgMembership) AsAPIOrgMember() *model.OrgMember {
+	id := m.ID
+	if strings.Contains(id, Collections.OrgMembership+"/") {
+		id = strings.TrimPrefix(id, Collections.OrgMembership+"/")
+	}
+	return &model.OrgMember{
+		ID:        id,
+		OrgID:     m.OrgID,
+		UserID:    m.UserID,
+		Roles:     m.ParsedRoles(),
+		CreatedAt: refs.NewInt64Ref(m.CreatedAt),
+		UpdatedAt: refs.NewInt64Ref(m.UpdatedAt),
+	}
+}

--- a/internal/storage/schemas/organization.go
+++ b/internal/storage/schemas/organization.go
@@ -1,0 +1,57 @@
+package schemas
+
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// Organization is a tenant grouping that owns per-org memberships (and, in
+// later phases, SSO/SCIM connections and (org, client) grants). It is managed
+// by platform admins through the `_organization`/`_organizations` admin API.
+//
+// Name is a unique, URL-safe slug (the stable external identifier); DisplayName
+// is the human-readable label. Enabled gates whether the organization is
+// active; disabling it does not delete its memberships.
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type Organization struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// Name is the unique organization slug (e.g. "acme-corp").
+	Name string `gorm:"uniqueIndex" json:"name" bson:"name" cql:"name" dynamo:"name" index:"name,hash"`
+
+	// DisplayName is the human-readable organization name.
+	DisplayName *string `json:"display_name" bson:"display_name" cql:"display_name" dynamo:"display_name"`
+
+	// Enabled controls whether the organization is active.
+	//
+	// GORM NOTE: gorm:"default:true" means db.Create with Enabled=false will
+	// persist as true (Go zero-value triggers the column default). The service
+	// layer must always set Enabled explicitly and use Save (not Create-only)
+	// when creating a disabled organization.
+	Enabled bool `json:"enabled" bson:"enabled" cql:"enabled" dynamo:"enabled" gorm:"default:true"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPIOrganization converts the storage record into the GraphQL model.
+func (o *Organization) AsAPIOrganization() *model.Organization {
+	id := o.ID
+	if strings.Contains(id, Collections.Organization+"/") {
+		id = strings.TrimPrefix(id, Collections.Organization+"/")
+	}
+	return &model.Organization{
+		ID:          id,
+		Name:        o.Name,
+		DisplayName: o.DisplayName,
+		Enabled:     o.Enabled,
+		CreatedAt:   refs.NewInt64Ref(o.CreatedAt),
+		UpdatedAt:   refs.NewInt64Ref(o.UpdatedAt),
+	}
+}


### PR DESCRIPTION
Organization + membership entities across all 6 providers + admin GraphQL. Same content as CI-green #650 (reopened against main after the stacked-merge base deletion). Includes the DynamoDB Limit-before-filter membership fix verified on dynamodb-local. See #650 for full description.