### PR TITLE
feat(http): registry-authoritative introspect/revoke/client-check + discovery

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -418,6 +418,13 @@ func runRoot(c *cobra.Command, args []string) {
 		strings.TrimSpace(rootArgs.config.TwilioAccountSID) != "" &&
 		strings.TrimSpace(rootArgs.config.TwilioSender) != ""
 
+	// Canonicalize Config.ClientID once at load so the seeded registry client_id
+	// (which is trimmed) is byte-identical to every remaining raw Config.ClientID
+	// comparison — introspection audience, revocation ownership, client_check, and
+	// the /app bootstrap all key on the exact same string. Closes the whitespace
+	// edge where a padded --client-id would seed a trimmed row but compare raw.
+	rootArgs.config.ClientID = strings.TrimSpace(rootArgs.config.ClientID)
+
 	// Storage provider
 	storageProvider, err := storage.New(&rootArgs.config, &storage.Dependencies{
 		Log: &log,

--- a/internal/http_handlers/client_check.go
+++ b/internal/http_handlers/client_check.go
@@ -34,12 +34,21 @@ func (h *httpProvider) ClientCheckMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		if clientID != h.Config.ClientID {
+		// Resolve the client_id against the authoritative registry rather than a
+		// single static Config.ClientID, so any registered, active client's id is
+		// accepted here. The reserved client remains valid via the Config fallback
+		// when its registry row is absent (e.g. a read-only replica where the boot
+		// seed was skipped) — login is never locked out.
+		client, err := h.StorageProvider.GetClientByClientID(c.Request.Context(), clientID)
+		valid := (err == nil && client != nil && client.IsActive) || clientID == h.Config.ClientID
+		if !valid {
 			// Record metric for client-id mismatch, but skip dashboard and app UI routes
 			// as those are internal requests that should not trigger security alerts.
 			metrics.RecordSecurityEvent("client_id_mismatch", "invalid_client_id")
 			log.Debug().Str("client_id", clientID).Msg("Client ID is invalid")
-			c.JSON(http.StatusBadRequest, gin.H{
+			// Abort so the GraphQL handler does not still execute after the 400 is
+			// written (gin continues the chain on a bare return).
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_client_id",
 				"error_description": "The client id is invalid",
 			})

--- a/internal/http_handlers/introspect.go
+++ b/internal/http_handlers/introspect.go
@@ -1,7 +1,7 @@
 package http_handlers
 
 import (
-	"crypto/subtle"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/authorizerdev/authorizer/internal/parsers"
+	"github.com/authorizerdev/authorizer/internal/service/clientauth"
 )
 
 // IntrospectHandler implements RFC 7662 OAuth 2.0 Token Introspection at
@@ -29,66 +30,28 @@ func (h *httpProvider) IntrospectHandler() gin.HandlerFunc {
 		tokenTypeHint := strings.TrimSpace(gc.PostForm("token_type_hint"))
 		_ = tokenTypeHint // Per RFC 7662 §2.1, unknown hints are ignored.
 
-		clientID := strings.TrimSpace(gc.PostForm("client_id"))
-		clientSecret := strings.TrimSpace(gc.PostForm("client_secret"))
-
-		// If no form creds, fall back to HTTP Basic.
-		hasBasicAuth := false
-		if clientID == "" && clientSecret == "" {
-			if id, secret, ok := gc.Request.BasicAuth(); ok {
-				clientID = id
-				clientSecret = secret
-				hasBasicAuth = true
-			}
-		}
-
-		if clientID == "" {
-			log.Debug().Msg("client_id missing on introspect request")
-			gc.JSON(http.StatusBadRequest, gin.H{
-				"error":             "invalid_request",
-				"error_description": "The client_id parameter is required",
-			})
+		// RFC 7662 §2.1: the introspection caller MUST authenticate. Route the
+		// credential through the shared registry resolver (RFC 6749 §2.3) so the
+		// caller is authenticated against the authoritative client registry rather
+		// than the single static Config.ClientID/Secret. RequireSecret enforces a
+		// secret on every caller (introspection is a confidential-client endpoint);
+		// the reserved client keeps working via the resolver's Config fallback when
+		// its registry row is absent.
+		basicClientID, basicClientSecret, hasBasicAuth := gc.Request.BasicAuth()
+		resolvedClient, authErr := h.clientAuthProvider.ResolveClient(gc, clientauth.ResolveParams{
+			BodyClientID:  strings.TrimSpace(gc.PostForm("client_id")),
+			BodySecret:    gc.PostForm("client_secret"),
+			BasicClientID: basicClientID,
+			BasicSecret:   basicClientSecret,
+			HasBasicAuth:  hasBasicAuth,
+			RequireSecret: true,
+		})
+		if authErr != nil {
+			log.Debug().Err(authErr).Msg("introspection caller authentication failed")
+			// Non-basic invalid_client maps to 400 on the introspection endpoint,
+			// preserving the pre-registry response shape.
+			respondResourceClientAuthError(gc, authErr, hasBasicAuth, http.StatusBadRequest)
 			return
-		}
-
-		// Client authentication: client_id must match, and when the server
-		// has a client_secret configured the caller MUST supply it.
-		if h.Config.ClientID != clientID {
-			log.Debug().Str("client_id", clientID).Msg("client_id mismatch on introspect")
-			if hasBasicAuth {
-				gc.Header("WWW-Authenticate", `Basic realm="authorizer"`)
-				gc.JSON(http.StatusUnauthorized, gin.H{
-					"error":             "invalid_client",
-					"error_description": "Client authentication failed",
-				})
-			} else {
-				gc.JSON(http.StatusBadRequest, gin.H{
-					"error":             "invalid_client",
-					"error_description": "The client_id is invalid",
-				})
-			}
-			return
-		}
-		// When the server has a client_secret, always require it.
-		// Previously the check was `clientSecret != "" && h.Config.ClientSecret != ""`
-		// which allowed callers to skip authentication by omitting the secret.
-		if h.Config.ClientSecret != "" {
-			if clientSecret == "" || subtle.ConstantTimeCompare([]byte(clientSecret), []byte(h.Config.ClientSecret)) != 1 {
-				log.Debug().Msg("client_secret missing or mismatch on introspect")
-				if hasBasicAuth {
-					gc.Header("WWW-Authenticate", `Basic realm="authorizer"`)
-					gc.JSON(http.StatusUnauthorized, gin.H{
-						"error":             "invalid_client",
-						"error_description": "Client authentication failed",
-					})
-				} else {
-					gc.JSON(http.StatusBadRequest, gin.H{
-						"error":             "invalid_client",
-						"error_description": "The client_secret is required",
-					})
-				}
-				return
-			}
 		}
 
 		if tokenValue == "" {
@@ -137,8 +100,12 @@ func (h *httpProvider) IntrospectHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Check aud matches our client_id.
-		if !audienceMatchesIntrospect(claims["aud"], h.Config.ClientID) {
+		// Registry-aware audience check: a token's aud is its client's client_id.
+		// The token is only "active" for the authenticated caller when it was
+		// issued to that caller — validate against the resolved caller's client_id,
+		// not a single static Config.ClientID. A token minted for a different client
+		// yields {"active": false} (no oracle) rather than leaking its claims.
+		if !audienceMatchesIntrospect(claims["aud"], resolvedClient.ClientID) {
 			gc.JSON(http.StatusOK, gin.H{"active": false})
 			return
 		}
@@ -151,12 +118,11 @@ func (h *httpProvider) IntrospectHandler() gin.HandlerFunc {
 			}
 		}
 		copyIfPresent("scope", "scope")
-		// RFC 7662 §2.2: client_id MUST be a string — set it directly
-		// from h.Config.ClientID rather than copying from the `aud`
-		// claim, which may be a JSON array for multi-audience tokens.
-		// The audience check above already confirmed h.Config.ClientID
-		// is in the audience set.
-		resp["client_id"] = h.Config.ClientID
+		// RFC 7662 §2.2: client_id MUST be a string — set it to the resolved
+		// caller's client_id rather than copying from the `aud` claim, which may be
+		// a JSON array for multi-audience tokens. The audience check above already
+		// confirmed the resolved client's id is in the audience set.
+		resp["client_id"] = resolvedClient.ClientID
 		copyIfPresent("exp", "exp")
 		copyIfPresent("iat", "iat")
 		copyIfPresent("sub", "sub")
@@ -170,6 +136,42 @@ func (h *httpProvider) IntrospectHandler() gin.HandlerFunc {
 		}
 		gc.JSON(http.StatusOK, resp)
 	}
+}
+
+// respondResourceClientAuthError maps a clientauth resolver error for the
+// resource-facing endpoints that authenticate a calling client — introspection
+// (RFC 7662 §2.1) and revocation (RFC 7009 §2.1). A missing client_id or more
+// than one auth method maps to invalid_request (400). Any other failure maps to
+// invalid_client: 401 + WWW-Authenticate when the caller used HTTP Basic
+// (RFC 6749 §5.2), otherwise nonBasicStatus (400 for introspection, 401 for
+// revocation — each preserving that endpoint's pre-registry response).
+func respondResourceClientAuthError(gc *gin.Context, err error, hasBasicAuth bool, nonBasicStatus int) {
+	switch {
+	case errors.Is(err, clientauth.ErrMissingClientID):
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_request",
+			"error_description": "The client_id parameter is required",
+		})
+		return
+	case errors.Is(err, clientauth.ErrMultipleAuthMethods):
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_request",
+			"error_description": "Only one client authentication method may be used per request",
+		})
+		return
+	}
+	if hasBasicAuth {
+		gc.Header("WWW-Authenticate", `Basic realm="authorizer"`)
+		gc.JSON(http.StatusUnauthorized, gin.H{
+			"error":             "invalid_client",
+			"error_description": "Client authentication failed",
+		})
+		return
+	}
+	gc.JSON(nonBasicStatus, gin.H{
+		"error":             "invalid_client",
+		"error_description": "Client authentication failed",
+	})
 }
 
 // audienceMatchesIntrospect accepts either a string aud or a []interface{}

--- a/internal/http_handlers/openid_config.go
+++ b/internal/http_handlers/openid_config.go
@@ -28,7 +28,9 @@ func (h *httpProvider) OpenIDConfigurationHandler() gin.HandlerFunc {
 
 		// grant_types_supported stays consistent with response_types_supported:
 		// "implicit" corresponds to response_type=token / id_token / id_token token.
-		grantTypes := []string{"authorization_code", "refresh_token", "implicit"}
+		// "client_credentials" is the machine/service-account grant (RFC 6749 §4.4)
+		// served by the token endpoint via the client registry.
+		grantTypes := []string{"authorization_code", "refresh_token", "client_credentials", "implicit"}
 
 		// Back-channel logout is advertised only when the operator has
 		// configured a backchannel_logout_uri — avoids lying to RPs.

--- a/internal/http_handlers/revoke_refresh_token.go
+++ b/internal/http_handlers/revoke_refresh_token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/audit"
 	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service/clientauth"
 	"github.com/authorizerdev/authorizer/internal/utils"
 	"github.com/gin-gonic/gin"
 )
@@ -68,12 +69,22 @@ func (h *httpProvider) RevokeRefreshTokenHandler() gin.HandlerFunc {
 			return
 		}
 
-		if h.Config.ClientID != clientID {
-			log.Debug().Str("client_id", clientID).Msg("Client ID is invalid")
-			gc.JSON(http.StatusUnauthorized, gin.H{
-				"error":             "invalid_client",
-				"error_description": "Client authentication failed",
-			})
+		// RFC 7009 §2.1: authenticate the calling client through the shared registry
+		// resolver (RFC 6749 §2.3) with refresh_token-grant semantics — the client_id
+		// is authenticated against the authoritative registry (the reserved client via
+		// the Config fallback), but the secret is not required. This preserves the
+		// pre-registry behavior where revocation clients present only a client_id and
+		// prove possession of the token; token-ownership (checked after parsing) is the
+		// real protection.
+		_, _, hasBasicAuth := gc.Request.BasicAuth()
+		resolvedClient, authErr := h.clientAuthProvider.ResolveClient(gc, clientauth.ResolveParams{
+			BodyClientID: clientID,
+		})
+		if authErr != nil {
+			log.Debug().Err(authErr).Str("client_id", clientID).Msg("client authentication failed")
+			// Non-basic invalid_client maps to 401 on the revocation endpoint,
+			// preserving the pre-registry response shape.
+			respondResourceClientAuthError(gc, authErr, hasBasicAuth, http.StatusUnauthorized)
 			return
 		}
 
@@ -98,6 +109,16 @@ func (h *httpProvider) RevokeRefreshTokenHandler() gin.HandlerFunc {
 		if err != nil {
 			// RFC 7009 §2.2: Invalid token - return 200
 			log.Debug().Err(err).Msg("Failed to parse token, returning 200 per RFC 7009")
+			gc.JSON(http.StatusOK, gin.H{})
+			return
+		}
+
+		// RFC 7009 token-ownership: only revoke a token issued to the authenticated
+		// client. A token's aud is its client's client_id; when it does not match the
+		// resolved caller, respond 200 {} (RFC 7009 §2.2, no oracle) without touching
+		// the session — one client must not be able to revoke another client's token.
+		if !audienceMatchesIntrospect(claims["aud"], resolvedClient.ClientID) {
+			log.Debug().Msg("Token not issued to authenticated client, returning 200 per RFC 7009")
 			gc.JSON(http.StatusOK, gin.H{})
 			return
 		}

--- a/internal/integration_tests/mai_registry_authoritative_test.go
+++ b/internal/integration_tests/mai_registry_authoritative_test.go
@@ -1,0 +1,241 @@
+package integration_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// addServiceAccountClient inserts an active service_account client into the
+// registry with a bcrypt-hashed secret and returns its client_id + plaintext
+// secret. Mirrors the reserved-client seed hashing (cost 12).
+func addServiceAccountClient(t *testing.T, ts *testSetup, secret string) string {
+	t.Helper()
+	_, ctx := createContext(ts)
+	clientID := "sa-" + uuid.New().String()
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), 12)
+	require.NoError(t, err)
+	_, err = ts.StorageProvider.AddClient(ctx, &schemas.Client{
+		ClientID:                clientID,
+		Kind:                    constants.ClientKindServiceAccount,
+		Name:                    "test-sa",
+		ClientSecret:            string(hash),
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
+		IsActive:                true,
+	})
+	require.NoError(t, err)
+	return clientID
+}
+
+// TestClientCheckMiddleware_RegistryAware verifies the X-Authorizer-Client-ID
+// middleware now resolves against the client registry, while preserving the
+// backward-compat allowances: an empty header passes (SDKs that don't send it),
+// and the reserved client_id passes. A bogus id is rejected; a registered client
+// id is accepted.
+func TestClientCheckMiddleware_RegistryAware(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	registeredClientID := addServiceAccountClient(t, ts, "sa-secret")
+
+	router := gin.New()
+	router.Use(ts.HttpProvider.ClientCheckMiddleware())
+	router.POST("/graphql", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	call := func(clientID string, sendHeader bool) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/graphql", nil)
+		if sendHeader {
+			req.Header.Set("X-Authorizer-Client-ID", clientID)
+		}
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("empty_header_allowed_backward_compat", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, call("", false).Code)
+	})
+	t.Run("explicit_empty_header_allowed", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, call("", true).Code)
+	})
+	t.Run("reserved_client_id_allowed", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, call(cfg.ClientID, true).Code)
+	})
+	t.Run("registered_client_id_allowed", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, call(registeredClientID, true).Code)
+	})
+	t.Run("bogus_client_id_rejected", func(t *testing.T) {
+		w := call("definitely-not-a-client", true)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, "invalid_client_id", body["error"])
+	})
+}
+
+// TestIntrospect_RegistryAwareCallerAndAudience verifies that a registered
+// (non-reserved) client authenticates as the introspection caller through the
+// registry (RFC 7662 §2.1), and that the audience check is registry-aware: a
+// token minted for a different client (aud != caller's client_id) returns
+// {"active": false} — no oracle, no claim leakage across clients.
+func TestIntrospect_RegistryAwareCallerAndAudience(t *testing.T) {
+	// Token whose aud is the reserved client (Config.ClientID).
+	ts, _, authToken := setupIntrospectTest(t)
+	cfg := ts.Config
+	saSecret := "sa-introspect-secret"
+	saClientID := addServiceAccountClient(t, ts, saSecret)
+
+	// The service_account caller authenticates successfully (200), but the token's
+	// aud is the reserved client, not the caller — so it is reported inactive.
+	form := url.Values{}
+	form.Set("token", authToken.AccessToken.Token)
+	form.Set("client_id", saClientID)
+	form.Set("client_secret", saSecret)
+	w := postIntrospect(t, ts, form.Encode())
+	require.Equal(t, http.StatusOK, w.Code, "authenticated caller must not be rejected")
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, false, body["active"], "token minted for another client MUST be inactive for this caller")
+	assert.Nil(t, body["sub"], "inactive response MUST NOT leak sub across clients")
+	assert.Nil(t, body["client_id"], "inactive response MUST NOT leak client_id")
+
+	// Sanity: the reserved caller (via Config fallback) still sees it active — the
+	// audience check keys on the caller, and here caller == token aud.
+	form2 := url.Values{}
+	form2.Set("token", authToken.AccessToken.Token)
+	form2.Set("client_id", cfg.ClientID)
+	form2.Set("client_secret", cfg.ClientSecret)
+	w2 := postIntrospect(t, ts, form2.Encode())
+	require.Equal(t, http.StatusOK, w2.Code)
+	var body2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &body2))
+	assert.Equal(t, true, body2["active"])
+	assert.Equal(t, cfg.ClientID, body2["client_id"])
+}
+
+// TestIntrospect_UnauthenticatedCallerRejected verifies RFC 7662 §2.1: a caller
+// that presents no client credential is rejected, not answered with active:false.
+func TestIntrospect_UnauthenticatedCallerRejected(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	form := url.Values{}
+	form.Set("token", "some-token")
+	// No client_id / client_secret at all.
+	w := postIntrospect(t, ts, form.Encode())
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "invalid_request", body["error"], "missing client_id MUST be rejected per RFC 7662 §2.1")
+}
+
+// TestRevoke_ForeignClientCannotRevoke verifies RFC 7009 token-ownership: a
+// different authenticated client cannot revoke a token issued to the reserved
+// client. The response is 200 (no oracle) but the session is left intact; the
+// legitimate owner then revokes it successfully.
+func TestRevoke_ForeignClientCannotRevoke(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	email := "revoke_own_" + uuid.New().String() + "@authorizer.dev"
+	password := "Password@123"
+	_, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email:           &email,
+		Password:        password,
+		ConfirmPassword: password,
+	})
+	require.NoError(t, err)
+	loginRes, err := ts.GraphQLProvider.Login(ctx, &model.LoginRequest{
+		Email:    &email,
+		Password: password,
+		Scope:    []string{"openid", "email", "profile", "offline_access"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, loginRes.RefreshToken)
+	refreshToken := *loginRes.RefreshToken
+
+	// Compute the session key the handler uses, to assert the session's presence.
+	claims, err := ts.TokenProvider.ParseJWTToken(refreshToken)
+	require.NoError(t, err)
+	userID := claims["sub"].(string)
+	nonce := claims["nonce"].(string)
+	sessionToken := userID
+	if lm, ok := claims["login_method"].(string); ok && lm != "" {
+		sessionToken = lm + ":" + userID
+	}
+	sessionKey := constants.TokenTypeRefreshToken + "_" + nonce
+
+	saClientID := addServiceAccountClient(t, ts, "sa-revoke-secret")
+
+	router := gin.New()
+	router.POST("/oauth/revoke", ts.HttpProvider.RevokeRefreshTokenHandler())
+
+	doRevoke := func(clientID string) *httptest.ResponseRecorder {
+		form := url.Values{}
+		form.Set("token", refreshToken)
+		form.Set("client_id", clientID)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/oauth/revoke", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Foreign client: 200 (no oracle) but MUST NOT revoke.
+	w := doRevoke(saClientID)
+	assert.Equal(t, http.StatusOK, w.Code)
+	got, _ := ts.MemoryStoreProvider.GetUserSession(sessionToken, sessionKey)
+	assert.NotEmpty(t, got, "foreign client MUST NOT revoke another client's token")
+
+	// Legitimate owner (reserved client): revokes successfully.
+	w = doRevoke(cfg.ClientID)
+	assert.Equal(t, http.StatusOK, w.Code)
+	got, _ = ts.MemoryStoreProvider.GetUserSession(sessionToken, sessionKey)
+	assert.Empty(t, got, "token owner MUST be able to revoke its token")
+}
+
+// TestDiscovery_AdvertisesNewCapabilities verifies the discovery metadata now
+// advertises client_credentials (grant) and private_key_jwt (token-endpoint auth
+// method) per §4.6 / RFC 8414 / OIDC Discovery.
+func TestDiscovery_AdvertisesNewCapabilities(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	router := gin.New()
+	router.GET("/.well-known/openid-configuration", ts.HttpProvider.OpenIDConfigurationHandler())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/.well-known/openid-configuration", nil)
+	req.Host = "localhost"
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	assert.Contains(t, toStringSlice(body["grant_types_supported"]), constants.GrantTypeClientCredentials,
+		"grant_types_supported MUST advertise client_credentials")
+	assert.Contains(t, toStringSlice(body["token_endpoint_auth_methods_supported"]), "private_key_jwt",
+		"token_endpoint_auth_methods_supported MUST advertise private_key_jwt")
+}
+
+func toStringSlice(v interface{}) []string {
+	arr, _ := v.([]interface{})
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Makes the client registry authoritative on the remaining `/oauth/*` client-auth sites — introspection, revocation, and the `/graphql` client-check middleware now route through the merged `clientauth` resolver instead of comparing against static `Config.ClientID`/`ClientSecret`. Adds `client_credentials` to discovery metadata and canonicalizes `Config.ClientID` at load.

## Changes

- **introspect.go** (RFC 7662) — caller authenticated via the resolver (`RequireSecret`); audience check + response `client_id` key on the resolved caller's own `client_id`. A token minted for a different client returns `{"active":false}` with no leaked fields — no cross-client oracle. Unauthenticated caller rejected (anti-scanning).
- **revoke_refresh_token.go** (RFC 7009) — client authenticated (id, per the possession model — no weaker than main); a **token-ownership** check (`token.aud == resolved client`) is the guard, so a foreign client cannot revoke another client's token. Token possession + constant-time compare unchanged.
- **client_check.go** — registry lookup for `X-Authorizer-Client-ID`; **empty-header backward-compat allowance preserved**. Fixes a **latent bug**: the reject path wrote 400 but never `Abort()`ed, so the GraphQL handler still ran after a rejected client-id — now `AbortWithStatusJSON`.
- **openid_config.go** — `client_credentials` added to `grant_types_supported`.
- **cmd/root.go** — `Config.ClientID` trimmed once at load, so the seeded registry `client_id` is byte-identical to every comparison site (closes the whitespace edge). Cookie AES key (`Config.ClientSecret`) untouched.

## Backward compatibility (verified)

Existing introspection/revocation/login flows unchanged; reserved client works via the resolver's Config fallback; `/graphql` with no client-id header still works; cookie crypto untouched.

## Testing

- `go build`/`vet`/`gofmt`/`make lint-go` clean; `make generate-graphql` no drift.
- Endpoint + BC integration tests (`mai_registry_authoritative_test.go`); **full integration suite green 2×**.
- Security review: **ship, no CRITICAL/HIGH** — introspection no-oracle confirmed, revoke-without-secret ruled acceptable (token-ownership guard), client_check fix preserves empty-header BC, config canonicalization consistent + doesn't touch the cookie key.

## Follow-up (non-blocking, pre-existing)

Discovery advertises `revocation_endpoint_auth_methods_supported: [client_secret_basic, client_secret_post]` but revoke uses the possession model (id-only) — a pre-existing honesty gap; a later pass should either enforce the secret on revoke or adjust the metadata.
