### PR TITLE
feat(scim): per-org inbound SCIM 2.0 provisioning (+ 3 pre-existing storage/revocation fixes)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,12 +23,14 @@ import (
 	"github.com/authorizerdev/authorizer/internal/events"
 	"github.com/authorizerdev/authorizer/internal/grpcsrv"
 	"github.com/authorizerdev/authorizer/internal/http_handlers"
+	scimhttp "github.com/authorizerdev/authorizer/internal/http_handlers/scim"
 	"github.com/authorizerdev/authorizer/internal/memory_store"
 	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/oauth"
 	"github.com/authorizerdev/authorizer/internal/rate_limit"
 	"github.com/authorizerdev/authorizer/internal/server"
 	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/service/scim"
 	"github.com/authorizerdev/authorizer/internal/sms"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/token"
@@ -591,11 +593,24 @@ func runRoot(c *cobra.Command, args []string) {
 	}
 	rootArgs.server.GRPCPort = rootArgs.config.GRPCPort
 
+	// Inbound SCIM 2.0 server (per-org user provisioning). Transport-thin
+	// handler over the scim service; org resolved only from the bearer token.
+	scimService := scim.New(&scim.Dependencies{
+		Log:                 &log,
+		StorageProvider:     storageProvider,
+		MemoryStoreProvider: memoryStoreProvider,
+	})
+	scimHandler := scimhttp.New(&scimhttp.Dependencies{
+		Log:     &log,
+		Service: scimService,
+	})
+
 	// Prepare server
 	deps := &server.Dependencies{
 		Log:          &log,
 		AppConfig:    &rootArgs.config,
 		HTTPProvider: httpProvider,
+		ScimHandler:  scimHandler,
 		GRPCServer:   grpcSrv,
 	}
 	// Create the server

--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -37,6 +37,8 @@ const (
 	AuditResourceTypeOrganization = "organization"
 	// AuditResourceTypeOrgMembership represents an org membership entity.
 	AuditResourceTypeOrgMembership = "org_membership"
+	// AuditResourceTypeScimEndpoint represents a per-org SCIM endpoint.
+	AuditResourceTypeScimEndpoint = "scim_endpoint"
 )
 
 // Audit event type constants used for structured audit logging.
@@ -184,6 +186,19 @@ const (
 	AuditOrgMemberRemovedEvent = "admin.org_member_removed"
 	// AuditOrgMemberRemoveFailedEvent is logged when removing an org member fails.
 	AuditOrgMemberRemoveFailedEvent = "admin.org_member_remove_failed"
+
+	// AuditScimEndpointCreatedEvent is logged when an admin creates a SCIM endpoint.
+	AuditScimEndpointCreatedEvent = "admin.scim_endpoint_created"
+	// AuditScimEndpointCreateFailedEvent is logged when SCIM endpoint creation fails.
+	AuditScimEndpointCreateFailedEvent = "admin.scim_endpoint_create_failed"
+	// AuditScimTokenRotatedEvent is logged when an admin rotates a SCIM token.
+	AuditScimTokenRotatedEvent = "admin.scim_token_rotated"
+	// AuditScimTokenRotateFailedEvent is logged when a SCIM token rotation fails.
+	AuditScimTokenRotateFailedEvent = "admin.scim_token_rotate_failed"
+	// AuditScimEndpointDeletedEvent is logged when an admin deletes a SCIM endpoint.
+	AuditScimEndpointDeletedEvent = "admin.scim_endpoint_deleted"
+	// AuditScimEndpointDeleteFailedEvent is logged when a SCIM endpoint delete fails.
+	AuditScimEndpointDeleteFailedEvent = "admin.scim_endpoint_delete_failed"
 
 	// AuditTokenClientCredentialsEvent is logged when a service account obtains a token
 	// via the client_credentials grant (RFC 6749 §4.4).

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -110,6 +110,11 @@ type ComplexityRoot struct {
 		ClientSecret func(childComplexity int) int
 	}
 
+	CreateScimEndpointResponse struct {
+		ScimEndpoint func(childComplexity int) int
+		Token        func(childComplexity int) int
+	}
+
 	EmailTemplate struct {
 		CreatedAt func(childComplexity int) int
 		Design    func(childComplexity int) int
@@ -283,10 +288,12 @@ type ComplexityRoot struct {
 		AdminSignup         func(childComplexity int, params model.AdminSignupRequest) int
 		CreateClient        func(childComplexity int, params model.CreateClientRequest) int
 		CreateOrganization  func(childComplexity int, params model.CreateOrganizationRequest) int
+		CreateScimEndpoint  func(childComplexity int, params model.CreateScimEndpointRequest) int
 		DeactivateAccount   func(childComplexity int) int
 		DeleteClient        func(childComplexity int, params model.ClientRequest) int
 		DeleteEmailTemplate func(childComplexity int, params model.DeleteEmailTemplateRequest) int
 		DeleteOrganization  func(childComplexity int, params model.OrganizationRequest) int
+		DeleteScimEndpoint  func(childComplexity int, params model.ScimEndpointRequest) int
 		DeleteTrustedIssuer func(childComplexity int, params model.TrustedIssuerRequest) int
 		DeleteUser          func(childComplexity int, params model.DeleteUserRequest) int
 		DeleteWebhook       func(childComplexity int, params model.WebhookRequest) int
@@ -310,6 +317,7 @@ type ComplexityRoot struct {
 		Revoke              func(childComplexity int, params model.OAuthRevokeRequest) int
 		RevokeAccess        func(childComplexity int, param model.UpdateAccessRequest) int
 		RotateClientSecret  func(childComplexity int, params model.ClientRequest) int
+		RotateScimToken     func(childComplexity int, params model.ScimEndpointRequest) int
 		Signup              func(childComplexity int, params model.SignUpRequest) int
 		TestEndpoint        func(childComplexity int, params model.TestEndpointRequest) int
 		UpdateClient        func(childComplexity int, params model.UpdateClientRequest) int
@@ -389,6 +397,7 @@ type ComplexityRoot struct {
 		Organization         func(childComplexity int, params model.OrganizationRequest) int
 		Organizations        func(childComplexity int, params *model.ListOrganizationsRequest) int
 		Profile              func(childComplexity int) int
+		ScimEndpoint         func(childComplexity int, params model.ScimEndpointRequest) int
 		Session              func(childComplexity int, params *model.SessionQueryRequest) int
 		TrustedIssuer        func(childComplexity int, params model.TrustedIssuerRequest) int
 		TrustedIssuers       func(childComplexity int, params *model.ListTrustedIssuersRequest) int
@@ -404,6 +413,14 @@ type ComplexityRoot struct {
 
 	Response struct {
 		Message func(childComplexity int) int
+	}
+
+	ScimEndpoint struct {
+		CreatedAt func(childComplexity int) int
+		Enabled   func(childComplexity int) int
+		ID        func(childComplexity int) int
+		OrgID     func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
 	}
 
 	TestEndpointResponse struct {
@@ -561,6 +578,9 @@ type MutationResolver interface {
 	DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error)
 	AddOrgMember(ctx context.Context, params model.AddOrgMemberRequest) (*model.OrgMember, error)
 	RemoveOrgMember(ctx context.Context, params model.RemoveOrgMemberRequest) (*model.Response, error)
+	CreateScimEndpoint(ctx context.Context, params model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
+	RotateScimToken(ctx context.Context, params model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
+	DeleteScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.Response, error)
 	TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error)
 	AddEmailTemplate(ctx context.Context, params model.AddEmailTemplateRequest) (*model.Response, error)
 	UpdateEmailTemplate(ctx context.Context, params model.UpdateEmailTemplateRequest) (*model.Response, error)
@@ -592,6 +612,7 @@ type QueryResolver interface {
 	Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error)
 	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
 	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
+	ScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.ScimEndpoint, error)
 	EmailTemplates(ctx context.Context, params *model.PaginatedRequest) (*model.EmailTemplates, error)
 	AuditLogs(ctx context.Context, params *model.ListAuditLogRequest) (*model.AuditLogs, error)
 	FgaGetModel(ctx context.Context) (*model.FgaModel, error)
@@ -900,6 +921,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CreateClientResponse.ClientSecret(childComplexity), true
+
+	case "CreateScimEndpointResponse.scim_endpoint":
+		if e.complexity.CreateScimEndpointResponse.ScimEndpoint == nil {
+			break
+		}
+
+		return e.complexity.CreateScimEndpointResponse.ScimEndpoint(childComplexity), true
+
+	case "CreateScimEndpointResponse.token":
+		if e.complexity.CreateScimEndpointResponse.Token == nil {
+			break
+		}
+
+		return e.complexity.CreateScimEndpointResponse.Token(childComplexity), true
 
 	case "EmailTemplate.created_at":
 		if e.complexity.EmailTemplate.CreatedAt == nil {
@@ -1851,6 +1886,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateOrganization(childComplexity, args["params"].(model.CreateOrganizationRequest)), true
 
+	case "Mutation._create_scim_endpoint":
+		if e.complexity.Mutation.CreateScimEndpoint == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_scim_endpoint_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateScimEndpoint(childComplexity, args["params"].(model.CreateScimEndpointRequest)), true
+
 	case "Mutation.deactivate_account":
 		if e.complexity.Mutation.DeactivateAccount == nil {
 			break
@@ -1893,6 +1940,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteOrganization(childComplexity, args["params"].(model.OrganizationRequest)), true
+
+	case "Mutation._delete_scim_endpoint":
+		if e.complexity.Mutation.DeleteScimEndpoint == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_scim_endpoint_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteScimEndpoint(childComplexity, args["params"].(model.ScimEndpointRequest)), true
 
 	case "Mutation._delete_trusted_issuer":
 		if e.complexity.Mutation.DeleteTrustedIssuer == nil {
@@ -2159,6 +2218,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.RotateClientSecret(childComplexity, args["params"].(model.ClientRequest)), true
+
+	case "Mutation._rotate_scim_token":
+		if e.complexity.Mutation.RotateScimToken == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__rotate_scim_token_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RotateScimToken(childComplexity, args["params"].(model.ScimEndpointRequest)), true
 
 	case "Mutation.signup":
 		if e.complexity.Mutation.Signup == nil {
@@ -2665,6 +2736,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.Profile(childComplexity), true
 
+	case "Query._scim_endpoint":
+		if e.complexity.Query.ScimEndpoint == nil {
+			break
+		}
+
+		args, err := ec.field_Query__scim_endpoint_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ScimEndpoint(childComplexity, args["params"].(model.ScimEndpointRequest)), true
+
 	case "Query.session":
 		if e.complexity.Query.Session == nil {
 			break
@@ -2803,6 +2886,41 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Response.Message(childComplexity), true
+
+	case "ScimEndpoint.created_at":
+		if e.complexity.ScimEndpoint.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.ScimEndpoint.CreatedAt(childComplexity), true
+
+	case "ScimEndpoint.enabled":
+		if e.complexity.ScimEndpoint.Enabled == nil {
+			break
+		}
+
+		return e.complexity.ScimEndpoint.Enabled(childComplexity), true
+
+	case "ScimEndpoint.id":
+		if e.complexity.ScimEndpoint.ID == nil {
+			break
+		}
+
+		return e.complexity.ScimEndpoint.ID(childComplexity), true
+
+	case "ScimEndpoint.org_id":
+		if e.complexity.ScimEndpoint.OrgID == nil {
+			break
+		}
+
+		return e.complexity.ScimEndpoint.OrgID(childComplexity), true
+
+	case "ScimEndpoint.updated_at":
+		if e.complexity.ScimEndpoint.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.ScimEndpoint.UpdatedAt(childComplexity), true
 
 	case "TestEndpointResponse.http_status":
 		if e.complexity.TestEndpointResponse.HTTPStatus == nil {
@@ -3340,6 +3458,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputClientRequest,
 		ec.unmarshalInputCreateClientRequest,
 		ec.unmarshalInputCreateOrganizationRequest,
+		ec.unmarshalInputCreateScimEndpointRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
 		ec.unmarshalInputDeleteUserRequest,
 		ec.unmarshalInputFgaExpandInput,
@@ -3373,6 +3492,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputResendOTPRequest,
 		ec.unmarshalInputResendVerifyEmailRequest,
 		ec.unmarshalInputResetPasswordRequest,
+		ec.unmarshalInputScimEndpointRequest,
 		ec.unmarshalInputSessionQueryRequest,
 		ec.unmarshalInputSignUpRequest,
 		ec.unmarshalInputTestEndpointRequest,
@@ -3852,6 +3972,25 @@ type Organizations {
   organizations: [Organization!]!
 }
 
+# ScimEndpoint is the per-org inbound SCIM 2.0 connection credential. The bearer
+# token is NEVER returned here; it is returned exactly once in
+# CreateScimEndpointResponse (creation and rotation) and never again.
+type ScimEndpoint {
+  id: ID!
+  org_id: String!
+  enabled: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type CreateScimEndpointResponse {
+  scim_endpoint: ScimEndpoint!
+  # token is the bearer credential the org's IdP presents at /scim/v2/. It is
+  # returned ONCE at creation and ONCE at rotation. Store it securely; it can
+  # never be retrieved again.
+  token: String!
+}
+
 type OrgMember {
   id: ID!
   org_id: String!
@@ -4318,6 +4457,15 @@ input ListOrganizationsRequest {
   pagination: PaginatedRequest
 }
 
+# All SCIM endpoint admin ops are keyed by org_id — one endpoint per org.
+input CreateScimEndpointRequest {
+  org_id: String!
+}
+
+input ScimEndpointRequest {
+  org_id: String!
+}
+
 input AddOrgMemberRequest {
   org_id: String!
   user_id: String!
@@ -4525,6 +4673,10 @@ type Mutation {
   _delete_organization(params: OrganizationRequest!): Response!
   _add_org_member(params: AddOrgMemberRequest!): OrgMember!
   _remove_org_member(params: RemoveOrgMemberRequest!): Response!
+  # Per-org inbound SCIM 2.0 endpoints. The token is revealed once.
+  _create_scim_endpoint(params: CreateScimEndpointRequest!): CreateScimEndpointResponse!
+  _rotate_scim_token(params: ScimEndpointRequest!): CreateScimEndpointResponse!
+  _delete_scim_endpoint(params: ScimEndpointRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -4565,6 +4717,8 @@ type Query {
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!
   _org_members(params: ListOrgMembersRequest!): OrgMembers!
+  # Per-org inbound SCIM 2.0 endpoint metadata (token never returned here).
+  _scim_endpoint(params: ScimEndpointRequest!): ScimEndpoint!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)
@@ -4808,6 +4962,34 @@ func (ec *executionContext) field_Mutation__create_organization_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_scim_endpoint_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_scim_endpoint_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_scim_endpoint_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateScimEndpointRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateScimEndpointRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateScimEndpointRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__delete_client_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -4889,6 +5071,34 @@ func (ec *executionContext) field_Mutation__delete_organization_argsParams(
 	}
 
 	var zeroVal model.OrganizationRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_scim_endpoint_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_scim_endpoint_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_scim_endpoint_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ScimEndpointRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ScimEndpointRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpointRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ScimEndpointRequest
 	return zeroVal, nil
 }
 
@@ -5225,6 +5435,34 @@ func (ec *executionContext) field_Mutation__rotate_client_secret_argsParams(
 	}
 
 	var zeroVal model.ClientRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__rotate_scim_token_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__rotate_scim_token_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__rotate_scim_token_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ScimEndpointRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ScimEndpointRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpointRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ScimEndpointRequest
 	return zeroVal, nil
 }
 
@@ -6121,6 +6359,34 @@ func (ec *executionContext) field_Query__organizations_argsParams(
 	}
 
 	var zeroVal *model.ListOrganizationsRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__scim_endpoint_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__scim_endpoint_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__scim_endpoint_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ScimEndpointRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ScimEndpointRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpointRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ScimEndpointRequest
 	return zeroVal, nil
 }
 
@@ -8412,6 +8678,106 @@ func (ec *executionContext) _CreateClientResponse_client_secret(ctx context.Cont
 func (ec *executionContext) fieldContext_CreateClientResponse_client_secret(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CreateClientResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateScimEndpointResponse_scim_endpoint(ctx context.Context, field graphql.CollectedField, obj *model.CreateScimEndpointResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateScimEndpointResponse_scim_endpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ScimEndpoint, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ScimEndpoint)
+	fc.Result = res
+	return ec.marshalNScimEndpoint2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpoint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateScimEndpointResponse_scim_endpoint(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateScimEndpointResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ScimEndpoint_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_ScimEndpoint_org_id(ctx, field)
+			case "enabled":
+				return ec.fieldContext_ScimEndpoint_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ScimEndpoint_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ScimEndpoint_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ScimEndpoint", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateScimEndpointResponse_token(ctx context.Context, field graphql.CollectedField, obj *model.CreateScimEndpointResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateScimEndpointResponse_token(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Token, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateScimEndpointResponse_token(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateScimEndpointResponse",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -16248,6 +16614,187 @@ func (ec *executionContext) fieldContext_Mutation__remove_org_member(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_scim_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_scim_endpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateScimEndpoint(rctx, fc.Args["params"].(model.CreateScimEndpointRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreateScimEndpointResponse)
+	fc.Result = res
+	return ec.marshalNCreateScimEndpointResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_scim_endpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "scim_endpoint":
+				return ec.fieldContext_CreateScimEndpointResponse_scim_endpoint(ctx, field)
+			case "token":
+				return ec.fieldContext_CreateScimEndpointResponse_token(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateScimEndpointResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_scim_endpoint_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__rotate_scim_token(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__rotate_scim_token(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RotateScimToken(rctx, fc.Args["params"].(model.ScimEndpointRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreateScimEndpointResponse)
+	fc.Result = res
+	return ec.marshalNCreateScimEndpointResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__rotate_scim_token(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "scim_endpoint":
+				return ec.fieldContext_CreateScimEndpointResponse_scim_endpoint(ctx, field)
+			case "token":
+				return ec.fieldContext_CreateScimEndpointResponse_token(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateScimEndpointResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__rotate_scim_token_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_scim_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_scim_endpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteScimEndpoint(rctx, fc.Args["params"].(model.ScimEndpointRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_scim_endpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_scim_endpoint_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__test_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__test_endpoint(ctx, field)
 	if err != nil {
@@ -19392,6 +19939,73 @@ func (ec *executionContext) fieldContext_Query__org_members(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Query__scim_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__scim_endpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ScimEndpoint(rctx, fc.Args["params"].(model.ScimEndpointRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ScimEndpoint)
+	fc.Result = res
+	return ec.marshalNScimEndpoint2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpoint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__scim_endpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ScimEndpoint_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_ScimEndpoint_org_id(ctx, field)
+			case "enabled":
+				return ec.fieldContext_ScimEndpoint_enabled(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ScimEndpoint_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ScimEndpoint_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ScimEndpoint", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__scim_endpoint_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query__email_templates(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query__email_templates(ctx, field)
 	if err != nil {
@@ -20035,6 +20649,220 @@ func (ec *executionContext) fieldContext_Response_message(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ScimEndpoint_id(ctx context.Context, field graphql.CollectedField, obj *model.ScimEndpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScimEndpoint_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScimEndpoint_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScimEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ScimEndpoint_org_id(ctx context.Context, field graphql.CollectedField, obj *model.ScimEndpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScimEndpoint_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScimEndpoint_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScimEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ScimEndpoint_enabled(ctx context.Context, field graphql.CollectedField, obj *model.ScimEndpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScimEndpoint_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScimEndpoint_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScimEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ScimEndpoint_created_at(ctx context.Context, field graphql.CollectedField, obj *model.ScimEndpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScimEndpoint_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScimEndpoint_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScimEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ScimEndpoint_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.ScimEndpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScimEndpoint_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScimEndpoint_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScimEndpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -25757,6 +26585,33 @@ func (ec *executionContext) unmarshalInputCreateOrganizationRequest(ctx context.
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateScimEndpointRequest(ctx context.Context, obj any) (model.CreateScimEndpointRequest, error) {
+	var it model.CreateScimEndpointRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteEmailTemplateRequest(ctx context.Context, obj any) (model.DeleteEmailTemplateRequest, error) {
 	var it model.DeleteEmailTemplateRequest
 	asMap := map[string]any{}
@@ -27111,6 +27966,33 @@ func (ec *executionContext) unmarshalInputResetPasswordRequest(ctx context.Conte
 				return it, err
 			}
 			it.ConfirmPassword = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputScimEndpointRequest(ctx context.Context, obj any) (model.ScimEndpointRequest, error) {
+	var it model.ScimEndpointRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
 		}
 	}
 
@@ -29005,6 +29887,50 @@ func (ec *executionContext) _CreateClientResponse(ctx context.Context, sel ast.S
 	return out
 }
 
+var createScimEndpointResponseImplementors = []string{"CreateScimEndpointResponse"}
+
+func (ec *executionContext) _CreateScimEndpointResponse(ctx context.Context, sel ast.SelectionSet, obj *model.CreateScimEndpointResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createScimEndpointResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateScimEndpointResponse")
+		case "scim_endpoint":
+			out.Values[i] = ec._CreateScimEndpointResponse_scim_endpoint(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "token":
+			out.Values[i] = ec._CreateScimEndpointResponse_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var emailTemplateImplementors = []string{"EmailTemplate"}
 
 func (ec *executionContext) _EmailTemplate(ctx context.Context, sel ast.SelectionSet, obj *model.EmailTemplate) graphql.Marshaler {
@@ -30202,6 +31128,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_scim_endpoint":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_scim_endpoint(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_rotate_scim_token":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__rotate_scim_token(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_scim_endpoint":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_scim_endpoint(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_test_endpoint":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__test_endpoint(ctx, field)
@@ -31110,6 +32057,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_scim_endpoint":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__scim_endpoint(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "_email_templates":
 			field := field
 
@@ -31333,6 +32302,59 @@ func (ec *executionContext) _Response(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var scimEndpointImplementors = []string{"ScimEndpoint"}
+
+func (ec *executionContext) _ScimEndpoint(ctx context.Context, sel ast.SelectionSet, obj *model.ScimEndpoint) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, scimEndpointImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ScimEndpoint")
+		case "id":
+			out.Values[i] = ec._ScimEndpoint_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._ScimEndpoint_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "enabled":
+			out.Values[i] = ec._ScimEndpoint_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._ScimEndpoint_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._ScimEndpoint_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -32633,6 +33655,25 @@ func (ec *executionContext) unmarshalNCreateOrganizationRequest2githubᚗcomᚋa
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNCreateScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointRequest(ctx context.Context, v any) (model.CreateScimEndpointRequest, error) {
+	res, err := ec.unmarshalInputCreateScimEndpointRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateScimEndpointResponse2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointResponse(ctx context.Context, sel ast.SelectionSet, v model.CreateScimEndpointResponse) graphql.Marshaler {
+	return ec._CreateScimEndpointResponse(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateScimEndpointResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointResponse(ctx context.Context, sel ast.SelectionSet, v *model.CreateScimEndpointResponse) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateScimEndpointResponse(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNDeleteEmailTemplateRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteEmailTemplateRequest(ctx context.Context, v any) (model.DeleteEmailTemplateRequest, error) {
 	res, err := ec.unmarshalInputDeleteEmailTemplateRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -33356,6 +34397,25 @@ func (ec *executionContext) marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋa
 		return graphql.Null
 	}
 	return ec._Response(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNScimEndpoint2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpoint(ctx context.Context, sel ast.SelectionSet, v model.ScimEndpoint) graphql.Marshaler {
+	return ec._ScimEndpoint(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNScimEndpoint2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpoint(ctx context.Context, sel ast.SelectionSet, v *model.ScimEndpoint) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ScimEndpoint(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpointRequest(ctx context.Context, v any) (model.ScimEndpointRequest, error) {
+	res, err := ec.unmarshalInputScimEndpointRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNSignUpRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSignUpRequest(ctx context.Context, v any) (model.SignUpRequest, error) {

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -128,6 +128,15 @@ type CreateOrganizationRequest struct {
 	DisplayName *string `json:"display_name,omitempty"`
 }
 
+type CreateScimEndpointRequest struct {
+	OrgID string `json:"org_id"`
+}
+
+type CreateScimEndpointResponse struct {
+	ScimEndpoint *ScimEndpoint `json:"scim_endpoint"`
+	Token        string        `json:"token"`
+}
+
 type DeleteEmailTemplateRequest struct {
 	ID string `json:"id"`
 }
@@ -544,6 +553,18 @@ type ResetPasswordRequest struct {
 
 type Response struct {
 	Message string `json:"message"`
+}
+
+type ScimEndpoint struct {
+	ID        string `json:"id"`
+	OrgID     string `json:"org_id"`
+	Enabled   bool   `json:"enabled"`
+	CreatedAt *int64 `json:"created_at,omitempty"`
+	UpdatedAt *int64 `json:"updated_at,omitempty"`
+}
+
+type ScimEndpointRequest struct {
+	OrgID string `json:"org_id"`
 }
 
 type SessionQueryRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -362,6 +362,25 @@ type Organizations {
   organizations: [Organization!]!
 }
 
+# ScimEndpoint is the per-org inbound SCIM 2.0 connection credential. The bearer
+# token is NEVER returned here; it is returned exactly once in
+# CreateScimEndpointResponse (creation and rotation) and never again.
+type ScimEndpoint {
+  id: ID!
+  org_id: String!
+  enabled: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type CreateScimEndpointResponse {
+  scim_endpoint: ScimEndpoint!
+  # token is the bearer credential the org's IdP presents at /scim/v2/. It is
+  # returned ONCE at creation and ONCE at rotation. Store it securely; it can
+  # never be retrieved again.
+  token: String!
+}
+
 type OrgMember {
   id: ID!
   org_id: String!
@@ -828,6 +847,15 @@ input ListOrganizationsRequest {
   pagination: PaginatedRequest
 }
 
+# All SCIM endpoint admin ops are keyed by org_id — one endpoint per org.
+input CreateScimEndpointRequest {
+  org_id: String!
+}
+
+input ScimEndpointRequest {
+  org_id: String!
+}
+
 input AddOrgMemberRequest {
   org_id: String!
   user_id: String!
@@ -1035,6 +1063,10 @@ type Mutation {
   _delete_organization(params: OrganizationRequest!): Response!
   _add_org_member(params: AddOrgMemberRequest!): OrgMember!
   _remove_org_member(params: RemoveOrgMemberRequest!): Response!
+  # Per-org inbound SCIM 2.0 endpoints. The token is revealed once.
+  _create_scim_endpoint(params: CreateScimEndpointRequest!): CreateScimEndpointResponse!
+  _rotate_scim_token(params: ScimEndpointRequest!): CreateScimEndpointResponse!
+  _delete_scim_endpoint(params: ScimEndpointRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -1075,6 +1107,8 @@ type Query {
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!
   _org_members(params: ListOrgMembersRequest!): OrgMembers!
+  # Per-org inbound SCIM 2.0 endpoint metadata (token never returned here).
+  _scim_endpoint(params: ScimEndpointRequest!): ScimEndpoint!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -212,6 +212,21 @@ func (r *mutationResolver) RemoveOrgMember(ctx context.Context, params model.Rem
 	return r.GraphQLProvider.RemoveOrgMember(ctx, &params)
 }
 
+// CreateScimEndpoint is the resolver for the _create_scim_endpoint field.
+func (r *mutationResolver) CreateScimEndpoint(ctx context.Context, params model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, error) {
+	return r.GraphQLProvider.CreateScimEndpoint(ctx, &params)
+}
+
+// RotateScimToken is the resolver for the _rotate_scim_token field.
+func (r *mutationResolver) RotateScimToken(ctx context.Context, params model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, error) {
+	return r.GraphQLProvider.RotateScimToken(ctx, &params)
+}
+
+// DeleteScimEndpoint is the resolver for the _delete_scim_endpoint field.
+func (r *mutationResolver) DeleteScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteScimEndpoint(ctx, &params)
+}
+
 // TestEndpoint is the resolver for the _test_endpoint field.
 func (r *mutationResolver) TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error) {
 	return r.GraphQLProvider.TestEndpoint(ctx, &params)
@@ -355,6 +370,11 @@ func (r *queryResolver) Organizations(ctx context.Context, params *model.ListOrg
 // OrgMembers is the resolver for the _org_members field.
 func (r *queryResolver) OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error) {
 	return r.GraphQLProvider.OrgMembers(ctx, &params)
+}
+
+// ScimEndpoint is the resolver for the _scim_endpoint field.
+func (r *queryResolver) ScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.ScimEndpoint, error) {
+	return r.GraphQLProvider.ScimEndpoint(ctx, &params)
 }
 
 // EmailTemplates is the resolver for the _email_templates field.

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -263,6 +263,18 @@ type Provider interface {
 	// OrgMembers lists an organization's members.
 	// Permissions: authorizer:admin
 	OrgMembers(ctx context.Context, params *model.ListOrgMembersRequest) (*model.OrgMembers, error)
+	// CreateScimEndpoint provisions a per-org SCIM endpoint and returns its token once.
+	// Permissions: authorizer:admin
+	CreateScimEndpoint(ctx context.Context, params *model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
+	// RotateScimToken mints a fresh SCIM bearer token for an org endpoint.
+	// Permissions: authorizer:admin
+	RotateScimToken(ctx context.Context, params *model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
+	// DeleteScimEndpoint removes an org's SCIM endpoint.
+	// Permissions: authorizer:admin
+	DeleteScimEndpoint(ctx context.Context, params *model.ScimEndpointRequest) (*model.Response, error)
+	// ScimEndpoint returns an org's SCIM endpoint metadata (token never returned).
+	// Permissions: authorizer:admin
+	ScimEndpoint(ctx context.Context, params *model.ScimEndpointRequest) (*model.ScimEndpoint, error)
 	// FgaWriteModel installs a new fine-grained authorization model.
 	// Permissions: authorizer:admin
 	FgaWriteModel(ctx context.Context, params *model.FgaWriteModelInput) (*model.FgaModel, error)

--- a/internal/graphql/scim_endpoints.go
+++ b/internal/graphql/scim_endpoints.go
@@ -1,0 +1,66 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateScimEndpoint delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) CreateScimEndpoint(ctx context.Context, params *model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateScimEndpoint(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// RotateScimToken delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) RotateScimToken(ctx context.Context, params *model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RotateScimToken(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// DeleteScimEndpoint delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteScimEndpoint(ctx context.Context, params *model.ScimEndpointRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteScimEndpoint(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// ScimEndpoint delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) ScimEndpoint(ctx context.Context, params *model.ScimEndpointRequest) (*model.ScimEndpoint, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ScimEndpoint(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/http_handlers/csrf.go
+++ b/internal/http_handlers/csrf.go
@@ -50,6 +50,14 @@ func (h *httpProvider) CSRFMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		// Exempt the inbound SCIM 2.0 surface. SCIM requests are machine-to-
+		// machine, authenticated by a per-org bearer token (never cookies), so
+		// CSRF does not apply — same rationale as /oauth/token above.
+		if strings.HasPrefix(c.Request.URL.Path, "/scim/v2/") {
+			c.Next()
+			return
+		}
+
 		// === Origin / Referer enforcement ===
 		// Browsers always send Origin on cross-origin POST. A missing
 		// Origin header on a state-changing request is suspicious and

--- a/internal/http_handlers/introspect.go
+++ b/internal/http_handlers/introspect.go
@@ -143,6 +143,19 @@ func (h *httpProvider) IntrospectHandler() gin.HandlerFunc {
 			return
 		}
 
+		// Revocation awareness: for a first-party user token (sub == user id), a
+		// revoked/deprovisioned user's token must introspect as inactive even
+		// before the short access-token TTL elapses (SCIM active:false, account
+		// deactivation). RevokedTimestamp is the reliable, provider-agnostic
+		// signal. A sub that resolves to no user (e.g. a machine/service-account
+		// token) is left untouched — this check only demotes, never promotes.
+		if sub, _ := claims["sub"].(string); sub != "" {
+			if user, uErr := h.StorageProvider.GetUserByID(gc, sub); uErr == nil && user != nil && user.RevokedTimestamp != nil {
+				gc.JSON(http.StatusOK, gin.H{"active": false})
+				return
+			}
+		}
+
 		// Build active response. Omit keys whose source value is missing.
 		resp := gin.H{"active": true}
 		copyIfPresent := func(srcKey, dstKey string) {

--- a/internal/http_handlers/scim/discovery.go
+++ b/internal/http_handlers/scim/discovery.go
@@ -1,0 +1,106 @@
+package scim
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// serviceProviderConfig advertises which SCIM features this server supports so
+// an IdP knows to use PATCH (deprovisioning), no bulk, no filtering beyond the
+// single `userName eq` probe, and bearer auth (RFC 7644 §5).
+func (h *Handler) serviceProviderConfig(c *gin.Context) {
+	cfg := gin.H{
+		"schemas":          []string{schemaSPConfig},
+		"documentationUri": "https://docs.authorizer.dev",
+		"patch":            gin.H{"supported": true},
+		"bulk":             gin.H{"supported": false, "maxOperations": 0, "maxPayloadSize": 0},
+		"filter":           gin.H{"supported": true, "maxResults": 1},
+		"changePassword":   gin.H{"supported": false},
+		"sort":             gin.H{"supported": false},
+		"etag":             gin.H{"supported": false},
+		"authenticationSchemes": []gin.H{{
+			"type":        "oauthbearertoken",
+			"name":        "OAuth Bearer Token",
+			"description": "Authentication via the per-organization SCIM bearer token.",
+			"primary":     true,
+		}},
+		"meta": gin.H{"resourceType": "ServiceProviderConfig"},
+	}
+	c.Header("Content-Type", contentType)
+	c.JSON(http.StatusOK, cfg)
+}
+
+// resourceTypes lists the provisionable resource types. Only User is supported;
+// Group is deferred (org-namespaced FGA roles, design §4.4 CR2).
+func (h *Handler) resourceTypes(c *gin.Context) {
+	user := gin.H{
+		"schemas":     []string{schemaRestype},
+		"id":          "User",
+		"name":        "User",
+		"endpoint":    "/Users",
+		"description": "User Account",
+		"schema":      schemaUser,
+		"meta":        gin.H{"resourceType": "ResourceType"},
+	}
+	resp := gin.H{
+		"schemas":      []string{schemaListResp},
+		"totalResults": 1,
+		"startIndex":   1,
+		"itemsPerPage": 1,
+		"Resources":    []gin.H{user},
+	}
+	c.Header("Content-Type", contentType)
+	c.JSON(http.StatusOK, resp)
+}
+
+// schemas describes the User attributes this server understands. Kept to the
+// subset actually mapped (userName, name, emails, externalId, active).
+func (h *Handler) schemas(c *gin.Context) {
+	attr := func(name, typ string, required bool) gin.H {
+		return gin.H{
+			"name": name, "type": typ, "required": required,
+			"multiValued": false, "mutability": "readWrite",
+			"returned": "default", "uniqueness": "none",
+		}
+	}
+	userSchema := gin.H{
+		"schemas":     []string{schemaSchema},
+		"id":          schemaUser,
+		"name":        "User",
+		"description": "User Account",
+		"attributes": []gin.H{
+			attr("userName", "string", true),
+			attr("externalId", "string", false),
+			attr("active", "boolean", false),
+			{
+				"name": "name", "type": "complex", "required": false,
+				"multiValued": false, "mutability": "readWrite",
+				"returned": "default", "uniqueness": "none",
+				"subAttributes": []gin.H{
+					attr("givenName", "string", false),
+					attr("familyName", "string", false),
+				},
+			},
+			{
+				"name": "emails", "type": "complex", "required": false,
+				"multiValued": true, "mutability": "readWrite",
+				"returned": "default", "uniqueness": "none",
+				"subAttributes": []gin.H{
+					attr("value", "string", false),
+					attr("primary", "boolean", false),
+				},
+			},
+		},
+		"meta": gin.H{"resourceType": "Schema"},
+	}
+	resp := gin.H{
+		"schemas":      []string{schemaListResp},
+		"totalResults": 1,
+		"startIndex":   1,
+		"itemsPerPage": 1,
+		"Resources":    []gin.H{userSchema},
+	}
+	c.Header("Content-Type", contentType)
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/http_handlers/scim/scim.go
+++ b/internal/http_handlers/scim/scim.go
@@ -1,0 +1,129 @@
+// Package scim exposes the per-organization inbound SCIM 2.0 HTTP surface
+// (RFC 7644) at /scim/v2/. Transport only: every operation delegates to
+// internal/service/scim, and the org is resolved solely from the bearer token
+// (design §4.4 H6). Errors use the SCIM error schema, not the OAuth envelope.
+package scim
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+
+	svcscim "github.com/authorizerdev/authorizer/internal/service/scim"
+)
+
+const (
+	// contentType is the SCIM media type (RFC 7644 §3.1).
+	contentType = "application/scim+json"
+
+	schemaUser     = "urn:ietf:params:scim:schemas:core:2.0:User"
+	schemaError    = "urn:ietf:params:scim:api:messages:2.0:Error"
+	schemaListResp = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+	schemaSPConfig = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+	schemaRestype  = "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+	schemaSchema   = "urn:ietf:params:scim:schemas:core:2.0:Schema"
+
+	// ctxOrgID is the gin context key holding the org resolved from the token.
+	ctxOrgID = "scim_org_id"
+)
+
+// Dependencies for the SCIM HTTP handler.
+type Dependencies struct {
+	Log     *zerolog.Logger
+	Service svcscim.Provider
+}
+
+// Handler mounts the SCIM routes and authenticates every request via bearer
+// token.
+type Handler struct {
+	Dependencies
+}
+
+// New constructs a SCIM HTTP handler.
+func New(deps *Dependencies) *Handler {
+	return &Handler{Dependencies: *deps}
+}
+
+// Register wires the SCIM routes onto a router group (mounted at /scim/v2). All
+// routes are behind the bearer-auth middleware.
+func (h *Handler) Register(rg *gin.RouterGroup) {
+	rg.Use(h.authMiddleware())
+
+	rg.POST("/Users", h.createUser)
+	rg.GET("/Users", h.listUsers)
+	rg.GET("/Users/:id", h.getUser)
+	rg.PUT("/Users/:id", h.replaceUser)
+	rg.PATCH("/Users/:id", h.patchUser)
+	rg.DELETE("/Users/:id", h.deleteUser)
+
+	rg.GET("/ServiceProviderConfig", h.serviceProviderConfig)
+	rg.GET("/ResourceTypes", h.resourceTypes)
+	rg.GET("/Schemas", h.schemas)
+}
+
+// scimError is the RFC 7644 §3.12 error body.
+type scimError struct {
+	Schemas  []string `json:"schemas"`
+	Status   string   `json:"status"`
+	SCIMType string   `json:"scimType,omitempty"`
+	Detail   string   `json:"detail,omitempty"`
+}
+
+// writeError emits a SCIM-shaped error with the given HTTP status.
+func writeError(c *gin.Context, status int, scimType, detail string) {
+	c.Header("Content-Type", contentType)
+	c.JSON(status, scimError{
+		Schemas:  []string{schemaError},
+		Status:   strconv.Itoa(status),
+		SCIMType: scimType,
+		Detail:   detail,
+	})
+	c.Abort()
+}
+
+// authMiddleware extracts the bearer token, resolves the org from it, and
+// stores the org id in the gin context. A missing/invalid/disabled credential
+// is a constant-time 401 — the org is NEVER taken from the URL or body (H6).
+func (h *Handler) authMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		bearer := ""
+		if auth := c.GetHeader("Authorization"); len(auth) > 7 && strings.EqualFold(auth[:7], "Bearer ") {
+			bearer = auth[7:]
+		}
+		orgID, err := h.Service.Authenticate(c.Request.Context(), bearer)
+		if err != nil {
+			// Do not leak whether the token was absent, malformed, unknown, or
+			// wrong — all collapse to one constant-time 401.
+			writeError(c, http.StatusUnauthorized, "", "authentication failed")
+			return
+		}
+		c.Set(ctxOrgID, orgID)
+		c.Next()
+	}
+}
+
+func (h *Handler) orgID(c *gin.Context) string {
+	v, _ := c.Get(ctxOrgID)
+	orgID, _ := v.(string)
+	return orgID
+}
+
+// mapServiceError translates a scim-service sentinel into a SCIM HTTP error.
+func mapServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, svcscim.ErrNotFound):
+		writeError(c, http.StatusNotFound, "", "resource not found")
+	case errors.Is(err, svcscim.ErrConflict):
+		writeError(c, http.StatusConflict, "uniqueness", "userName already exists")
+	case errors.Is(err, svcscim.ErrInvalid):
+		writeError(c, http.StatusBadRequest, "invalidValue", "invalid request")
+	case errors.Is(err, svcscim.ErrUnauthorized):
+		writeError(c, http.StatusUnauthorized, "", "authentication failed")
+	default:
+		writeError(c, http.StatusInternalServerError, "", "internal error")
+	}
+}

--- a/internal/http_handlers/scim/scim_test.go
+++ b/internal/http_handlers/scim/scim_test.go
@@ -1,0 +1,192 @@
+package scim
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	svcscim "github.com/authorizerdev/authorizer/internal/service/scim"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// fakeService is a scim.Provider stub the handler tests drive.
+type fakeService struct {
+	authOrg  string
+	authErr  error
+	created  *schemas.User
+	existed  bool
+	getErr   error
+	setErr   error
+	lastOrg  string
+	lastUser string
+}
+
+func (f *fakeService) Authenticate(_ context.Context, bearer string) (string, error) {
+	if f.authErr != nil {
+		return "", f.authErr
+	}
+	return f.authOrg, nil
+}
+func (f *fakeService) CreateUser(_ context.Context, orgID string, _ svcscim.User) (*schemas.User, bool, error) {
+	f.lastOrg = orgID
+	return f.created, f.existed, nil
+}
+func (f *fakeService) GetUser(_ context.Context, orgID, userID string) (*schemas.User, error) {
+	f.lastOrg, f.lastUser = orgID, userID
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.created, nil
+}
+func (f *fakeService) FindByUserName(_ context.Context, orgID, _ string) (*schemas.User, error) {
+	f.lastOrg = orgID
+	return f.created, nil
+}
+func (f *fakeService) ReplaceUser(_ context.Context, orgID, userID string, _ svcscim.User) (*schemas.User, error) {
+	f.lastOrg, f.lastUser = orgID, userID
+	return f.created, f.setErr
+}
+func (f *fakeService) SetActive(_ context.Context, orgID, userID string, _ bool) (*schemas.User, error) {
+	f.lastOrg, f.lastUser = orgID, userID
+	if f.setErr != nil {
+		return nil, f.setErr
+	}
+	return f.created, nil
+}
+
+func newTestServer(svc svcscim.Provider) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	log := zerolog.Nop()
+	r := gin.New()
+	New(&Dependencies{Log: &log, Service: svc}).Register(r.Group("/scim/v2"))
+	return r
+}
+
+func do(r *gin.Engine, method, path, bearer, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func strptr(s string) *string { return &s }
+
+func TestBadBearerReturns401WithSCIMError(t *testing.T) {
+	r := newTestServer(&fakeService{authErr: svcscim.ErrUnauthorized})
+	for _, tc := range []struct{ name, bearer string }{
+		{"missing", ""},
+		{"wrong", "ep-a.bad"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := do(r, http.MethodGet, "/scim/v2/Users/u1", tc.bearer, "")
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+			assert.Contains(t, w.Header().Get("Content-Type"), "application/scim+json")
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			schemas, _ := body["schemas"].([]any)
+			require.Len(t, schemas, 1)
+			assert.Equal(t, "urn:ietf:params:scim:api:messages:2.0:Error", schemas[0])
+			assert.Equal(t, "401", body["status"])
+		})
+	}
+}
+
+// H6 at the transport boundary: a cross-org id resolves to the service's
+// ErrNotFound → 404, and the org handed to the service came from the token, not
+// the URL.
+func TestCrossOrgGetMapsTo404(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a", getErr: svcscim.ErrNotFound}
+	r := newTestServer(svc)
+	w := do(r, http.MethodGet, "/scim/v2/Users/victim-in-org-b", "ep.secret", "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "org-a", svc.lastOrg, "org must come from the token, never the path")
+}
+
+func TestCreateUserReturns201AndSCIMShape(t *testing.T) {
+	svc := &fakeService{
+		authOrg: "org-a",
+		created: &schemas.User{ID: "u1", Email: strptr("bob@acme.com"), ExternalID: strptr("org-a:okta-1"), IsActive: true},
+	}
+	r := newTestServer(svc)
+	w := do(r, http.MethodPost, "/scim/v2/Users", "ep.secret",
+		`{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"bob@acme.com","externalId":"okta-1","active":true}`)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "u1", body["id"])
+	assert.Equal(t, "bob@acme.com", body["userName"])
+	// externalId must be de-namespaced back to the raw IdP value.
+	assert.Equal(t, "okta-1", body["externalId"])
+	assert.Equal(t, true, body["active"])
+}
+
+func TestDedupCreateReturns200(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a", existed: true,
+		created: &schemas.User{ID: "u1", Email: strptr("bob@acme.com"), IsActive: true}}
+	r := newTestServer(svc)
+	w := do(r, http.MethodPost, "/scim/v2/Users", "ep.secret", `{"userName":"bob@acme.com"}`)
+	assert.Equal(t, http.StatusOK, w.Code, "idempotent create returns the existing resource")
+}
+
+func TestPatchActiveFalseDeactivates(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a",
+		created: &schemas.User{ID: "u1", Email: strptr("bob@acme.com"), IsActive: false}}
+	r := newTestServer(svc)
+	// Both the standard and the Entra/no-path PatchOp shapes must deactivate.
+	for _, body := range []string{
+		`{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":false}]}`,
+		`{"Operations":[{"op":"Replace","value":{"active":false}}]}`,
+	} {
+		w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret", body)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "u1", svc.lastUser)
+	}
+}
+
+func TestDeleteReturns204(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: false}}
+	r := newTestServer(svc)
+	w := do(r, http.MethodDelete, "/scim/v2/Users/u1", "ep.secret", "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "u1", svc.lastUser)
+}
+
+func TestListUserNameFilter(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a",
+		created: &schemas.User{ID: "u1", Email: strptr("bob@acme.com"), IsActive: true}}
+	r := newTestServer(svc)
+	w := do(r, http.MethodGet, `/scim/v2/Users?filter=userName+eq+%22bob@acme.com%22`, "ep.secret", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.EqualValues(t, 1, body["totalResults"])
+}
+
+func TestDiscoveryEndpointsServed(t *testing.T) {
+	r := newTestServer(&fakeService{authOrg: "org-a"})
+	for _, path := range []string{"/scim/v2/ServiceProviderConfig", "/scim/v2/Schemas", "/scim/v2/ResourceTypes"} {
+		w := do(r, http.MethodGet, path, "ep.secret", "")
+		assert.Equal(t, http.StatusOK, w.Code, path)
+		assert.Contains(t, w.Header().Get("Content-Type"), "application/scim+json", path)
+	}
+	// ServiceProviderConfig must advertise PATCH support so IdPs deprovision.
+	w := do(r, http.MethodGet, "/scim/v2/ServiceProviderConfig", "ep.secret", "")
+	assert.Contains(t, w.Body.String(), `"patch":{"supported":true}`)
+}
+
+func TestDiscoveryStillRequiresAuth(t *testing.T) {
+	r := newTestServer(&fakeService{authErr: svcscim.ErrUnauthorized})
+	w := do(r, http.MethodGet, "/scim/v2/ServiceProviderConfig", "", "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/internal/http_handlers/scim/users.go
+++ b/internal/http_handlers/scim/users.go
@@ -1,0 +1,296 @@
+package scim
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/authorizerdev/authorizer/internal/refs"
+	svcscim "github.com/authorizerdev/authorizer/internal/service/scim"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// scimName is the SCIM complex "name" attribute (subset).
+type scimName struct {
+	GivenName  string `json:"givenName,omitempty"`
+	FamilyName string `json:"familyName,omitempty"`
+}
+
+// scimEmail is one entry of the multi-valued "emails" attribute.
+type scimEmail struct {
+	Value   string `json:"value"`
+	Primary bool   `json:"primary,omitempty"`
+}
+
+// scimMeta is the resource metadata block.
+type scimMeta struct {
+	ResourceType string `json:"resourceType"`
+	Location     string `json:"location,omitempty"`
+}
+
+// scimUserResource is the wire representation of a SCIM User (request + response).
+type scimUserResource struct {
+	Schemas    []string    `json:"schemas"`
+	ID         string      `json:"id,omitempty"`
+	ExternalID string      `json:"externalId,omitempty"`
+	UserName   string      `json:"userName"`
+	Name       scimName    `json:"name"`
+	Emails     []scimEmail `json:"emails,omitempty"`
+	Active     bool        `json:"active"`
+	Meta       scimMeta    `json:"meta"`
+}
+
+// scimListResponse is the RFC 7644 §3.4.2 list envelope.
+type scimListResponse struct {
+	Schemas      []string           `json:"schemas"`
+	TotalResults int                `json:"totalResults"`
+	StartIndex   int                `json:"startIndex"`
+	ItemsPerPage int                `json:"itemsPerPage"`
+	Resources    []scimUserResource `json:"Resources"`
+}
+
+// toResource maps a stored user to the SCIM wire form. externalId is de-
+// namespaced back to the raw IdP value (stored as "<orgID>:<raw>").
+func toResource(orgID string, u *schemas.User) scimUserResource {
+	email := refs.StringValue(u.Email)
+	res := scimUserResource{
+		Schemas:  []string{schemaUser},
+		ID:       u.ID,
+		UserName: email,
+		Name: scimName{
+			GivenName:  refs.StringValue(u.GivenName),
+			FamilyName: refs.StringValue(u.FamilyName),
+		},
+		Active: u.IsActive,
+		Meta:   scimMeta{ResourceType: "User"},
+	}
+	if email != "" {
+		res.Emails = []scimEmail{{Value: email, Primary: true}}
+	}
+	if u.ExternalID != nil {
+		res.ExternalID = strings.TrimPrefix(refs.StringValue(u.ExternalID), orgID+":")
+	}
+	return res
+}
+
+// parseUser decodes a SCIM User request body into the service input. active
+// defaults to true when the attribute is absent (SCIM create default).
+func parseUser(c *gin.Context) (svcscim.User, bool) {
+	body := struct {
+		ExternalID string      `json:"externalId"`
+		UserName   string      `json:"userName"`
+		Name       scimName    `json:"name"`
+		Emails     []scimEmail `json:"emails"`
+		Active     *bool       `json:"active"`
+	}{}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		return svcscim.User{}, false
+	}
+	userName := strings.TrimSpace(body.UserName)
+	if userName == "" {
+		// Fall back to the primary/first email as userName (some IdPs omit it).
+		for _, e := range body.Emails {
+			if e.Value != "" {
+				userName = strings.TrimSpace(e.Value)
+				break
+			}
+		}
+	}
+	active := true
+	if body.Active != nil {
+		active = *body.Active
+	}
+	return svcscim.User{
+		ExternalID: strings.TrimSpace(body.ExternalID),
+		UserName:   userName,
+		GivenName:  body.Name.GivenName,
+		FamilyName: body.Name.FamilyName,
+		Active:     active,
+	}, true
+}
+
+func (h *Handler) createUser(c *gin.Context) {
+	in, ok := parseUser(c)
+	if !ok || in.UserName == "" {
+		writeError(c, http.StatusBadRequest, "invalidValue", "userName is required")
+		return
+	}
+	user, existed, err := h.Service.CreateUser(c.Request.Context(), h.orgID(c), in)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	status := http.StatusCreated
+	if existed {
+		// Idempotent create (IdP re-POSTed an already-provisioned user): return
+		// the existing resource rather than a duplicate.
+		status = http.StatusOK
+	}
+	writeUser(c, status, h.orgID(c), user)
+}
+
+func (h *Handler) getUser(c *gin.Context) {
+	user, err := h.Service.GetUser(c.Request.Context(), h.orgID(c), c.Param("id"))
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	writeUser(c, http.StatusOK, h.orgID(c), user)
+}
+
+// listUsers supports only the `userName eq "..."` filter (the IdP dedup probe).
+// An unfiltered list returns an empty set — full org enumeration is out of scope.
+func (h *Handler) listUsers(c *gin.Context) {
+	orgID := h.orgID(c)
+	filter := c.Query("filter")
+	resp := scimListResponse{
+		Schemas:      []string{schemaListResp},
+		StartIndex:   1,
+		ItemsPerPage: 0,
+		Resources:    []scimUserResource{},
+	}
+	if userName, ok := parseUserNameEq(filter); ok {
+		if user, err := h.Service.FindByUserName(c.Request.Context(), orgID, userName); err == nil && user != nil {
+			resp.Resources = append(resp.Resources, toResource(orgID, user))
+		}
+	}
+	resp.TotalResults = len(resp.Resources)
+	resp.ItemsPerPage = len(resp.Resources)
+	c.Header("Content-Type", contentType)
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) replaceUser(c *gin.Context) {
+	in, ok := parseUser(c)
+	if !ok {
+		writeError(c, http.StatusBadRequest, "invalidValue", "invalid body")
+		return
+	}
+	user, err := h.Service.ReplaceUser(c.Request.Context(), h.orgID(c), c.Param("id"), in)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	writeUser(c, http.StatusOK, h.orgID(c), user)
+}
+
+// patchUser applies a SCIM PatchOp. ponytail: only the `active` attribute is
+// honoured (the deprovision path Okta/Entra drive); other paths are accepted
+// and ignored. Full attribute PATCH is a follow-up — use PUT for profile edits.
+func (h *Handler) patchUser(c *gin.Context) {
+	active, hasActive, ok := parseActivePatch(c)
+	if !ok {
+		writeError(c, http.StatusBadRequest, "invalidValue", "invalid PatchOp body")
+		return
+	}
+	if !hasActive {
+		// Nothing we act on — return the current resource unchanged.
+		user, err := h.Service.GetUser(c.Request.Context(), h.orgID(c), c.Param("id"))
+		if err != nil {
+			mapServiceError(c, err)
+			return
+		}
+		writeUser(c, http.StatusOK, h.orgID(c), user)
+		return
+	}
+	user, err := h.Service.SetActive(c.Request.Context(), h.orgID(c), c.Param("id"), active)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	writeUser(c, http.StatusOK, h.orgID(c), user)
+}
+
+// deleteUser maps DELETE to soft-deactivation (active:false) so the user's
+// sessions/tokens are revoked but the audit trail and memberships survive.
+func (h *Handler) deleteUser(c *gin.Context) {
+	_, err := h.Service.SetActive(c.Request.Context(), h.orgID(c), c.Param("id"), false)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func writeUser(c *gin.Context, status int, orgID string, user *schemas.User) {
+	c.Header("Content-Type", contentType)
+	c.JSON(status, toResource(orgID, user))
+}
+
+// parseUserNameEq extracts X from `userName eq "X"` (case-insensitive operator).
+func parseUserNameEq(filter string) (string, bool) {
+	f := strings.TrimSpace(filter)
+	lower := strings.ToLower(f)
+	if !strings.HasPrefix(lower, "username eq ") {
+		return "", false
+	}
+	val := strings.TrimSpace(f[len("username eq "):])
+	val = strings.Trim(val, `"`)
+	if val == "" {
+		return "", false
+	}
+	return val, true
+}
+
+// parseActivePatch reads a SCIM PatchOp and returns the requested active value.
+// It tolerates the two shapes IdPs send:
+//
+//	{"op":"replace","path":"active","value":false}
+//	{"op":"replace","value":{"active":false}}
+//
+// op case is ignored; value may be a bool or the string "true"/"false".
+func parseActivePatch(c *gin.Context) (active bool, hasActive bool, ok bool) {
+	body := struct {
+		Operations []struct {
+			Op    string          `json:"op"`
+			Path  string          `json:"path"`
+			Value json.RawMessage `json:"value"`
+		} `json:"Operations"`
+	}{}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		return false, false, false
+	}
+	for _, op := range body.Operations {
+		path := strings.ToLower(strings.TrimSpace(op.Path))
+		if path == "active" {
+			if v, valOK := parseBoolValue(op.Value); valOK {
+				active, hasActive = v, true
+			}
+			continue
+		}
+		if path == "" {
+			// Value is an attribute map, e.g. {"active": false}.
+			m := map[string]json.RawMessage{}
+			if err := json.Unmarshal(op.Value, &m); err == nil {
+				for k, raw := range m {
+					if strings.EqualFold(k, "active") {
+						if v, valOK := parseBoolValue(raw); valOK {
+							active, hasActive = v, true
+						}
+					}
+				}
+			}
+		}
+	}
+	return active, hasActive, true
+}
+
+// parseBoolValue accepts a JSON bool or a quoted "true"/"false" string.
+func parseBoolValue(raw json.RawMessage) (bool, bool) {
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b, true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+	}
+	return false, false
+}

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -423,6 +423,21 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			})
 			return
 		}
+		// Defense-in-depth for deprovisioning: a revoked user (SCIM active:false,
+		// account deactivation) must never renew a token, even if a session-store
+		// delete was missed on some instance. RevokedTimestamp is the reliable
+		// signal — it is explicitly stamped on revocation and nil otherwise, so it
+		// is correct across every provider. IsActive is NOT used here: on the NoSQL
+		// providers a normally-signed-up user is stored with is_active=false (no
+		// GORM column default), so gating on it would reject legitimate refreshes.
+		if user.RevokedTimestamp != nil {
+			log.Debug().Str("user_id", userID).Msg("refresh rejected: user revoked")
+			gc.JSON(http.StatusUnauthorized, gin.H{
+				"error":             "unauthorized",
+				"error_description": "User is not active",
+			})
+			return
+		}
 		hostname := parsers.GetHost(gc)
 		nonce := uuid.New().String()
 		authToken, err := h.TokenProvider.CreateAuthToken(gc, &token.AuthTokenConfig{

--- a/internal/integration_tests/scim_deprovision_test.go
+++ b/internal/integration_tests/scim_deprovision_test.go
@@ -1,0 +1,102 @@
+package integration_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+)
+
+// TestDeprovisionedUserRevocation asserts the deprovision (revoked) invariant at
+// the token endpoints: once a user's RevokedTimestamp is stamped (what SCIM
+// active:false / account deactivation do), that user can neither renew via the
+// refresh_token grant nor have a still-held access token introspect as active.
+func TestDeprovisionedUserRevocation(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	email := "scim_deprov_" + uuid.New().String() + "@authorizer.dev"
+	password := "Password@123"
+
+	signupRes, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email:           &email,
+		Password:        password,
+		ConfirmPassword: password,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, signupRes)
+
+	loginRes, err := ts.GraphQLProvider.Login(ctx, &model.LoginRequest{
+		Email:    &email,
+		Password: password,
+		Scope:    []string{"openid", "email", "profile", "offline_access"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, loginRes)
+	require.NotNil(t, loginRes.RefreshToken)
+	require.NotNil(t, loginRes.AccessToken)
+
+	issuer := "http://" + ts.HttpServer.Listener.Addr().String()
+
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+	router.POST("/oauth/introspect", ts.HttpProvider.IntrospectHandler())
+
+	introspect := func(token string) bool {
+		form := url.Values{}
+		form.Set("token", token)
+		form.Set("client_id", cfg.ClientID)
+		form.Set("client_secret", cfg.ClientSecret)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/oauth/introspect", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Authorizer-URL", issuer)
+		router.ServeHTTP(w, req)
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		active, _ := body["active"].(bool)
+		return active
+	}
+
+	refresh := func() int {
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", *loginRes.RefreshToken)
+		form.Set("client_id", cfg.ClientID)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Authorizer-URL", issuer)
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Baseline: before deprovision the token is active and refresh works.
+	assert.True(t, introspect(*loginRes.AccessToken), "access token should be active before deprovision")
+	require.Equal(t, http.StatusOK, refresh(), "refresh should succeed before deprovision")
+
+	// Deprovision: stamp RevokedTimestamp (the provider-agnostic signal SCIM
+	// active:false sets) and drop live sessions, mirroring the SCIM service.
+	user, err := ts.StorageProvider.GetUserByID(ctx, signupRes.User.ID)
+	require.NoError(t, err)
+	now := time.Now().Unix()
+	user.RevokedTimestamp = &now
+	_, err = ts.StorageProvider.UpdateUser(ctx, user)
+	require.NoError(t, err)
+	require.NoError(t, ts.MemoryStoreProvider.DeleteAllUserSessions(user.ID))
+
+	// After deprovision: refresh is rejected and introspection reports inactive.
+	assert.Equal(t, http.StatusUnauthorized, refresh(), "refresh must be rejected for a revoked user")
+	assert.False(t, introspect(*loginRes.AccessToken), "a revoked user's access token must introspect as inactive")
+}

--- a/internal/memory_store/provider_test.go
+++ b/internal/memory_store/provider_test.go
@@ -134,6 +134,13 @@ func TestMemoryStoreProvider(t *testing.T) {
 			key, err = p.GetUserSession("auth_provider1:123", "access_token_key")
 			assert.Empty(t, key)
 			assert.Error(t, err)
+			// Boundary: DeleteAllUserSessions("123") must NOT over-match a
+			// different user whose sessions are keyed "<method>:124:...". User
+			// 124's still-live session (auth_provider1:124, 60s TTL) must survive —
+			// the userID is matched as a colon-bounded segment, not a substring.
+			key, err = p.GetUserSession("auth_provider1:124", "session_token_key")
+			assert.NoError(t, err, "DeleteAllUserSessions(123) must not delete user 124's session")
+			assert.Equal(t, "test_hash124", key)
 			// Delete namespace
 			err = p.DeleteSessionForNamespace("auth_provider")
 			assert.NoError(t, err)

--- a/internal/memory_store/redis/store.go
+++ b/internal/memory_store/redis/store.go
@@ -54,25 +54,39 @@ func (p *provider) DeleteUserSession(userId, key string) error {
 	return nil
 }
 
-// DeleteAllUserSessions deletes all the user session from redis
+// DeleteAllUserSessions deletes all of a user's sessions from redis.
+//
+// Session keys are stored as "<sessionStoreKey>:<type>_<nonce>" where
+// sessionStoreKey is "<loginMethod>:<userID>" (see token/auth_token.go and
+// login.go). The userID is therefore the MIDDLE segment, not the prefix — a
+// bare "<userID>:*" glob (the previous pattern) never matched, so revocation
+// was a silent no-op on Redis. Match on the colon-bounded ":<userID>:" segment
+// so held access tokens and renewable refresh tokens are actually dropped. The
+// legacy "<userID>:*" form is also scanned in case any caller stores a session
+// keyed directly by user id.
 func (p *provider) DeleteAllUserSessions(userID string) error {
-	var cursor uint64
-	pattern := fmt.Sprintf("%s:*", userID)
-	for {
-		keys, nextCursor, err := p.store.Scan(p.ctx, cursor, pattern, 100).Result()
-		if err != nil {
-			p.dependencies.Log.Debug().Err(err).Msg("Error scanning user sessions from redis")
-			return err
-		}
-		for _, key := range keys {
-			if err := p.store.Del(p.ctx, key).Err(); err != nil {
-				p.dependencies.Log.Debug().Err(err).Msg("Error deleting user session from redis")
-				continue
+	patterns := []string{
+		fmt.Sprintf("*:%s:*", userID), // "<loginMethod>:<userID>:<type>_<nonce>"
+		fmt.Sprintf("%s:*", userID),   // legacy: keyed directly by user id
+	}
+	for _, pattern := range patterns {
+		var cursor uint64
+		for {
+			keys, nextCursor, err := p.store.Scan(p.ctx, cursor, pattern, 100).Result()
+			if err != nil {
+				p.dependencies.Log.Debug().Err(err).Msg("Error scanning user sessions from redis")
+				return err
 			}
-		}
-		cursor = nextCursor
-		if cursor == 0 {
-			break
+			for _, key := range keys {
+				if err := p.store.Del(p.ctx, key).Err(); err != nil {
+					p.dependencies.Log.Debug().Err(err).Msg("Error deleting user session from redis")
+					continue
+				}
+			}
+			cursor = nextCursor
+			if cursor == 0 {
+				break
+			}
 		}
 	}
 	return nil

--- a/internal/server/http_routes.go
+++ b/internal/server/http_routes.go
@@ -76,6 +76,14 @@ func (s *server) NewRouter() *gin.Engine {
 	router.POST("/oauth/revoke", s.Dependencies.HTTPProvider.RevokeRefreshTokenHandler())
 	router.POST("/oauth/introspect", s.Dependencies.HTTPProvider.IntrospectHandler())
 
+	// Inbound SCIM 2.0 (per-org user provisioning). Its own route group with a
+	// bearer-token auth middleware; the org is derived only from the token, so
+	// there is no org segment in the path (design §4.4 H6). CSRF is exempted for
+	// /scim/v2/ in the CSRF middleware (bearer-authenticated, cookieless).
+	if s.Dependencies.ScimHandler != nil {
+		s.Dependencies.ScimHandler.Register(router.Group("/scim/v2"))
+	}
+
 	// gRPC-gateway REST surface at /v1/*. Mounted only when the gRPC
 	// server is configured. Shares all gin middleware (CORS, security
 	// headers, rate limit, logging) automatically since the route group

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/graphql"
 	"github.com/authorizerdev/authorizer/internal/grpcsrv"
 	"github.com/authorizerdev/authorizer/internal/http_handlers"
+	scimhttp "github.com/authorizerdev/authorizer/internal/http_handlers/scim"
 )
 
 // Config holds the configuration of a server.
@@ -37,6 +38,8 @@ type Dependencies struct {
 	AppConfig       *config.Config
 	GraphQLProvider graphql.Provider
 	HTTPProvider    http_handlers.Provider
+	// ScimHandler serves the per-org inbound SCIM 2.0 surface at /scim/v2.
+	ScimHandler *scimhttp.Handler
 	// GRPCServer is the configured (but not yet listening) gRPC server.
 	// nil disables both the gRPC listener and the REST `/v1/*` gateway.
 	GRPCServer *grpcsrv.Server

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -73,6 +73,12 @@ type AdminProvider interface {
 	RemoveOrgMember(ctx context.Context, meta RequestMetadata, params *model.RemoveOrgMemberRequest) (*model.Response, *ResponseSideEffects, error)
 	OrgMembers(ctx context.Context, meta RequestMetadata, params *model.ListOrgMembersRequest) (*model.OrgMembers, *ResponseSideEffects, error)
 
+	// Per-org inbound SCIM 2.0 endpoints. The bearer token is revealed once.
+	CreateScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error)
+	RotateScimToken(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error)
+	DeleteScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.Response, *ResponseSideEffects, error)
+	ScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.ScimEndpoint, *ResponseSideEffects, error)
+
 	// Email templates.
 	AddEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.AddEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
 	UpdateEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.UpdateEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)

--- a/internal/service/admin_scim.go
+++ b/internal/service/admin_scim.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/service/scim"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// CreateScimEndpoint provisions the per-org inbound SCIM connection and returns
+// its bearer token exactly once (bcrypt-hashed at rest, crypto/rand entropy).
+// One endpoint per org. Requires super-admin auth.
+func (p *provider) CreateScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateScimEndpoint").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	if orgID == "" {
+		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, "")
+		return nil, nil, fmt.Errorf("org_id is required")
+	}
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Msg("organization not found")
+		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("organization not found")
+	}
+	if existing, _ := p.StorageProvider.GetScimEndpointByOrgID(ctx, orgID); existing != nil {
+		log.Debug().Msg("scim endpoint already exists for org")
+		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("a scim endpoint already exists for this organization")
+	}
+
+	// The endpoint id is embedded (non-secret) in the token; generate it first
+	// so the token references the row it will authenticate.
+	id := uuid.New().String()
+	token, hash, err := scim.GenerateToken(id)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to generate scim token")
+		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
+		return nil, nil, err
+	}
+	endpoint, err := p.StorageProvider.AddScimEndpoint(ctx, &schemas.ScimEndpoint{
+		ID:        id,
+		OrgID:     orgID,
+		TokenHash: hash,
+		// Set Enabled explicitly — never rely on the GORM default:true quirk.
+		Enabled: true,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to add scim endpoint")
+		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditScimEndpointCreatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeScimEndpoint,
+		ResourceID:   endpoint.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.CreateScimEndpointResponse{
+		ScimEndpoint: endpoint.AsAPIScimEndpoint(),
+		Token:        token,
+	}, nil, nil
+}
+
+// RotateScimToken mints a fresh bearer token for an org's endpoint, invalidating
+// the previous one, and returns it once. Requires super-admin auth.
+func (p *provider) RotateScimToken(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "RotateScimToken").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	endpoint, err := p.StorageProvider.GetScimEndpointByOrgID(ctx, orgID)
+	if err != nil || endpoint == nil {
+		log.Debug().Err(err).Msg("scim endpoint not found")
+		p.logScimFailure(meta, constants.AuditScimTokenRotateFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("scim endpoint not found")
+	}
+	token, hash, err := scim.GenerateToken(endpoint.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to generate scim token")
+		p.logScimFailure(meta, constants.AuditScimTokenRotateFailedEvent, orgID)
+		return nil, nil, err
+	}
+	endpoint.TokenHash = hash
+	updated, err := p.StorageProvider.UpdateScimEndpoint(ctx, endpoint)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to update scim endpoint")
+		p.logScimFailure(meta, constants.AuditScimTokenRotateFailedEvent, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditScimTokenRotatedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeScimEndpoint,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.CreateScimEndpointResponse{
+		ScimEndpoint: updated.AsAPIScimEndpoint(),
+		Token:        token,
+	}, nil, nil
+}
+
+// DeleteScimEndpoint removes an org's SCIM connection. Requires super-admin auth.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteScimEndpoint").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	endpoint, err := p.StorageProvider.GetScimEndpointByOrgID(ctx, orgID)
+	if err != nil || endpoint == nil {
+		log.Debug().Err(err).Msg("scim endpoint not found")
+		p.logScimFailure(meta, constants.AuditScimEndpointDeleteFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("scim endpoint not found")
+	}
+	if err := p.StorageProvider.DeleteScimEndpoint(ctx, endpoint); err != nil {
+		log.Debug().Err(err).Msg("failed to delete scim endpoint")
+		p.logScimFailure(meta, constants.AuditScimEndpointDeleteFailedEvent, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   constants.AuditScimEndpointDeletedEvent,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeScimEndpoint,
+		ResourceID:   endpoint.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.Response{Message: "scim endpoint deleted successfully"}, nil, nil
+}
+
+// ScimEndpoint returns an org's SCIM endpoint metadata (never the token).
+// Requires super-admin auth.
+func (p *provider) ScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.ScimEndpoint, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "ScimEndpoint").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	endpoint, err := p.StorageProvider.GetScimEndpointByOrgID(ctx, strings.TrimSpace(params.OrgID))
+	if err != nil || endpoint == nil {
+		log.Debug().Err(err).Msg("scim endpoint not found")
+		return nil, nil, fmt.Errorf("scim endpoint not found")
+	}
+	return endpoint.AsAPIScimEndpoint(), nil, nil
+}
+
+// logScimFailure records a failed SCIM endpoint admin operation.
+func (p *provider) logScimFailure(meta RequestMetadata, action, orgID string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:   action,
+		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeScimEndpoint,
+		ResourceID:   orgID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}

--- a/internal/service/scim/scim.go
+++ b/internal/service/scim/scim.go
@@ -204,6 +204,13 @@ func (p *provider) CreateUser(ctx context.Context, orgID string, in User) (*sche
 			log.Debug().Msg("dedup by userName within org")
 			return existing, true, nil
 		}
+		// ponytail: accepted risk. Authorizer enforces global email uniqueness, so
+		// a userName already owned by another org cannot be re-provisioned here —
+		// return 409. This leaks only that *some* account with that email exists
+		// (an existence oracle on an email the caller's IdP already knows), never
+		// the other org's user data or membership. H6 (by-id read/mutate isolation)
+		// is unaffected. Upgrade path if even existence must be hidden: per-org
+		// user rows keyed by (org, email) instead of global email uniqueness.
 		log.Debug().Msg("userName exists outside this org")
 		return nil, false, ErrConflict
 	}
@@ -246,9 +253,12 @@ func (p *provider) CreateUser(ctx context.Context, orgID string, in User) (*sche
 	// (RevokedTimestamp above already blocks token issuance regardless.)
 	if !in.Active {
 		created.IsActive = false
-		if updated, uErr := p.StorageProvider.UpdateUser(ctx, created); uErr == nil {
-			created = updated
+		updated, uErr := p.StorageProvider.UpdateUser(ctx, created)
+		if uErr != nil {
+			log.Debug().Err(uErr).Msg("failed to persist inactive state on provisioned user")
+			return nil, false, uErr
 		}
+		created = updated
 	}
 	// Bind the user to the org. Without this membership the user would not be an
 	// org member and every subsequent by-id op would (correctly) 404.

--- a/internal/service/scim/scim.go
+++ b/internal/service/scim/scim.go
@@ -1,0 +1,357 @@
+// Package scim implements a per-organization inbound SCIM 2.0 server for user
+// provisioning and deprovisioning (RFC 7643/7644, users only). A customer's IdP
+// (Okta, Entra, …) authenticates with a per-org bearer token and the org it may
+// act on is derived ONLY from the matched endpoint — never from the URL or
+// payload (design §4.4 H6, the C3 confused-deputy class).
+//
+// ponytail: users only. SCIM Groups → org-namespaced FGA roles is deferred to a
+// follow-up (needs the FGA engine + org-admin permission model, design §4.4
+// CR2). Also deferred: ETag/versioning and pagination cursors.
+package scim
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/memory_store"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// Sentinel errors the transport maps to SCIM status codes.
+var (
+	// ErrUnauthorized — missing/malformed/invalid bearer token, or a disabled
+	// endpoint. Map to 401. Deliberately generic: it never distinguishes an
+	// unknown endpoint id from a wrong secret (constant-time, dummy-compare).
+	ErrUnauthorized = errors.New("scim: unauthorized")
+	// ErrNotFound — the resource does not exist OR belongs to another org (H6:
+	// a cross-org id is indistinguishable from a non-existent one). Map to 404.
+	ErrNotFound = errors.New("scim: resource not found")
+	// ErrConflict — a create collides with an existing userName owned outside
+	// this org (global email uniqueness). Map to 409.
+	ErrConflict = errors.New("scim: userName already exists")
+	// ErrInvalid — malformed input (e.g. missing userName). Map to 400.
+	ErrInvalid = errors.New("scim: invalid request")
+)
+
+// tokenCost is the bcrypt cost for SCIM bearer-token secrets. Matches the
+// client-secret cost so a dummy compare is timing-indistinguishable.
+const tokenCost = 12
+
+var (
+	dummyHash []byte
+	dummyOnce sync.Once
+)
+
+// performDummyCompare burns an equivalent bcrypt cost for an unknown endpoint so
+// timing does not reveal whether an endpoint id exists (mirrors clientauth).
+func performDummyCompare(secret string) {
+	dummyOnce.Do(func() {
+		dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-scim-token"), tokenCost)
+	})
+	_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(secret))
+}
+
+// User is the transport-neutral SCIM user projection the handler maps to/from
+// SCIM JSON. Only the attributes Okta/Entra send for provisioning are modelled.
+type User struct {
+	ExternalID string
+	UserName   string // SCIM userName → the user's email
+	GivenName  string
+	FamilyName string
+	Active     bool
+}
+
+// Dependencies for the SCIM service.
+type Dependencies struct {
+	Log                 *zerolog.Logger
+	StorageProvider     storage.Provider
+	MemoryStoreProvider memory_store.Provider
+}
+
+// Provider is the org-bounded SCIM operation surface. Every method takes the
+// orgID resolved by Authenticate — callers MUST NOT source it from the request
+// path or body (H6).
+type Provider interface {
+	// Authenticate verifies the presented bearer token and returns the org it
+	// authorizes. The org is derived solely from the matched endpoint.
+	Authenticate(ctx context.Context, bearer string) (orgID string, err error)
+
+	// CreateUser provisions a user into the org. Idempotent: a repeat with the
+	// same externalId (or an existing org member with the same userName) returns
+	// the existing user with existed=true and creates no duplicate.
+	CreateUser(ctx context.Context, orgID string, in User) (user *schemas.User, existed bool, err error)
+	// GetUser fetches an org member by id (404 if not a member — H6).
+	GetUser(ctx context.Context, orgID, userID string) (*schemas.User, error)
+	// FindByUserName returns the org member with the given userName, or nil when
+	// none (the IdP's pre-create dedup probe). Never leaks another org's user.
+	FindByUserName(ctx context.Context, orgID, userName string) (*schemas.User, error)
+	// ReplaceUser (PUT) overwrites the mutable profile + active flag of an org
+	// member. A true→false active transition revokes the user's sessions.
+	ReplaceUser(ctx context.Context, orgID, userID string, in User) (*schemas.User, error)
+	// SetActive (PATCH active / DELETE) flips the active flag. Deactivation
+	// synchronously revokes the user's sessions + refresh tokens.
+	SetActive(ctx context.Context, orgID, userID string, active bool) (*schemas.User, error)
+}
+
+type provider struct {
+	Dependencies
+}
+
+var _ Provider = &provider{}
+
+// New constructs a SCIM service provider.
+func New(deps *Dependencies) Provider {
+	return &provider{Dependencies: *deps}
+}
+
+// namespacedExternalID composes the org-scoped external id key. Storing and
+// looking up external ids in this form is what makes GetUserByExternalID
+// org-isolating without a cross-table join (H6, works identically on all 6 DBs).
+func namespacedExternalID(orgID, externalID string) string {
+	return orgID + ":" + externalID
+}
+
+// Authenticate parses "<endpointID>.<hexSecret>", resolves the endpoint by id,
+// and constant-time verifies the secret against its bcrypt hash.
+func (p *provider) Authenticate(ctx context.Context, bearer string) (string, error) {
+	log := p.Log.With().Str("func", "scim.Authenticate").Logger()
+	id, secret, ok := strings.Cut(strings.TrimSpace(bearer), ".")
+	if !ok || id == "" || secret == "" {
+		performDummyCompare(bearer)
+		return "", ErrUnauthorized
+	}
+	endpoint, err := p.StorageProvider.GetScimEndpointByID(ctx, id)
+	if err != nil || endpoint == nil {
+		// Unknown endpoint id: burn an equivalent bcrypt cost so an unknown id
+		// and a wrong secret take the same time.
+		log.Debug().Msg("scim endpoint not found for presented token")
+		performDummyCompare(secret)
+		return "", ErrUnauthorized
+	}
+	if bcrypt.CompareHashAndPassword([]byte(endpoint.TokenHash), []byte(secret)) != nil {
+		log.Debug().Str("org_id", endpoint.OrgID).Msg("scim token secret mismatch")
+		return "", ErrUnauthorized
+	}
+	if !endpoint.Enabled {
+		log.Debug().Str("org_id", endpoint.OrgID).Msg("scim endpoint disabled")
+		return "", ErrUnauthorized
+	}
+	return endpoint.OrgID, nil
+}
+
+// GenerateToken builds "<endpointID>.<hexSecret>" with 256 bits of entropy and
+// returns the plaintext plus its bcrypt hash. Only the hash is persisted; the
+// plaintext is revealed once at create/rotate. Stateless — the admin surface
+// calls it directly when provisioning an endpoint.
+func GenerateToken(endpointID string) (plaintext, hash string, err error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+	secret := hex.EncodeToString(raw)
+	h, err := bcrypt.GenerateFromPassword([]byte(secret), tokenCost)
+	if err != nil {
+		return "", "", err
+	}
+	return endpointID + "." + secret, string(h), nil
+}
+
+// requireMember is the H6 isolation gate: a user is visible/mutable through a
+// SCIM connection only if they hold a membership in that connection's org. A
+// cross-org id therefore returns ErrNotFound, never another org's data.
+func (p *provider) requireMember(ctx context.Context, orgID, userID string) (*schemas.User, error) {
+	if _, err := p.StorageProvider.GetOrgMembership(ctx, orgID, userID); err != nil {
+		return nil, ErrNotFound
+	}
+	user, err := p.StorageProvider.GetUserByID(ctx, userID)
+	if err != nil || user == nil {
+		return nil, ErrNotFound
+	}
+	return user, nil
+}
+
+func (p *provider) CreateUser(ctx context.Context, orgID string, in User) (*schemas.User, bool, error) {
+	log := p.Log.With().Str("func", "scim.CreateUser").Str("org_id", orgID).Logger()
+	userName := strings.TrimSpace(in.UserName)
+	if userName == "" {
+		return nil, false, ErrInvalid
+	}
+
+	// Dedup #1: same externalId already provisioned into this org (org-scoped
+	// composite key). Idempotent — return the existing user.
+	if in.ExternalID != "" {
+		if existing, err := p.StorageProvider.GetUserByExternalID(ctx, orgID, in.ExternalID); err == nil && existing != nil {
+			log.Debug().Msg("dedup by external_id")
+			return existing, true, nil
+		}
+	}
+
+	// Dedup #2: a user with this userName (email) already exists. If they are a
+	// member of this org, return them (idempotent). If they exist but belong to
+	// another org, email is globally unique so we cannot re-provision — 409.
+	if existing, err := p.StorageProvider.GetUserByEmail(ctx, userName); err == nil && existing != nil {
+		if _, mErr := p.StorageProvider.GetOrgMembership(ctx, orgID, existing.ID); mErr == nil {
+			log.Debug().Msg("dedup by userName within org")
+			return existing, true, nil
+		}
+		log.Debug().Msg("userName exists outside this org")
+		return nil, false, ErrConflict
+	}
+
+	now := time.Now().Unix()
+	email := userName
+	nsExt := namespacedExternalID(orgID, in.ExternalID)
+	newUser := &schemas.User{
+		ID:            uuid.New().String(),
+		Email:         &email,
+		SignupMethods: "scim",
+		IsActive:      in.Active,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if in.ExternalID != "" {
+		newUser.ExternalID = &nsExt
+	}
+	if in.GivenName != "" {
+		gn := in.GivenName
+		newUser.GivenName = &gn
+	}
+	if in.FamilyName != "" {
+		fn := in.FamilyName
+		newUser.FamilyName = &fn
+	}
+	// A user provisioned as active:false is deprovisioned from birth — stamp the
+	// revocation marker so no token can ever be minted for them.
+	if !in.Active {
+		newUser.RevokedTimestamp = &now
+	}
+	created, err := p.StorageProvider.AddUser(ctx, newUser)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to add scim user")
+		return nil, false, err
+	}
+	// GORM's `default:true` on IsActive means a Create with IsActive=false is
+	// persisted as true (Go zero-value → column default). Force it via a Save
+	// so a user provisioned directly as inactive is actually stored inactive.
+	// (RevokedTimestamp above already blocks token issuance regardless.)
+	if !in.Active {
+		created.IsActive = false
+		if updated, uErr := p.StorageProvider.UpdateUser(ctx, created); uErr == nil {
+			created = updated
+		}
+	}
+	// Bind the user to the org. Without this membership the user would not be an
+	// org member and every subsequent by-id op would (correctly) 404.
+	if _, err := p.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  orgID,
+		UserID: created.ID,
+		Roles:  "",
+	}); err != nil {
+		log.Debug().Err(err).Msg("failed to add org membership for scim user")
+		return nil, false, err
+	}
+	return created, false, nil
+}
+
+func (p *provider) GetUser(ctx context.Context, orgID, userID string) (*schemas.User, error) {
+	return p.requireMember(ctx, orgID, userID)
+}
+
+func (p *provider) FindByUserName(ctx context.Context, orgID, userName string) (*schemas.User, error) {
+	userName = strings.TrimSpace(userName)
+	if userName == "" {
+		return nil, nil
+	}
+	user, err := p.StorageProvider.GetUserByEmail(ctx, userName)
+	if err != nil || user == nil {
+		return nil, nil
+	}
+	// Only surface the user if they belong to this org (H6): otherwise the probe
+	// would confirm another org's user exists.
+	if _, err := p.StorageProvider.GetOrgMembership(ctx, orgID, user.ID); err != nil {
+		return nil, nil
+	}
+	return user, nil
+}
+
+func (p *provider) ReplaceUser(ctx context.Context, orgID, userID string, in User) (*schemas.User, error) {
+	user, err := p.requireMember(ctx, orgID, userID)
+	if err != nil {
+		return nil, err
+	}
+	wasActive := user.IsActive
+	if in.GivenName != "" {
+		gn := in.GivenName
+		user.GivenName = &gn
+	}
+	if in.FamilyName != "" {
+		fn := in.FamilyName
+		user.FamilyName = &fn
+	}
+	user.IsActive = in.Active
+	if wasActive && !in.Active {
+		return p.deactivate(ctx, user)
+	}
+	if !wasActive && in.Active {
+		user.RevokedTimestamp = nil
+	}
+	user.UpdatedAt = time.Now().Unix()
+	return p.StorageProvider.UpdateUser(ctx, user)
+}
+
+func (p *provider) SetActive(ctx context.Context, orgID, userID string, active bool) (*schemas.User, error) {
+	user, err := p.requireMember(ctx, orgID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !active {
+		if !user.IsActive {
+			return user, nil
+		}
+		user.IsActive = false
+		return p.deactivate(ctx, user)
+	}
+	// Reactivation: clear the revocation marker.
+	user.IsActive = true
+	user.RevokedTimestamp = nil
+	user.UpdatedAt = time.Now().Unix()
+	return p.StorageProvider.UpdateUser(ctx, user)
+}
+
+// deactivate is the enterprise-offboarding path: mark the user inactive+revoked
+// and SYNCHRONOUSLY drop every session and refresh/session token so a held
+// access token stops working immediately (across instances via the shared
+// store). This is the whole point of SCIM deprovisioning.
+func (p *provider) deactivate(ctx context.Context, user *schemas.User) (*schemas.User, error) {
+	log := p.Log.With().Str("func", "scim.deactivate").Str("user_id", user.ID).Logger()
+	now := time.Now().Unix()
+	user.IsActive = false
+	user.RevokedTimestamp = &now
+	user.UpdatedAt = now
+	updated, err := p.StorageProvider.UpdateUser(ctx, user)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to update user on deactivate")
+		return nil, err
+	}
+	// Kill live sessions/access/refresh tokens in the shared memory store
+	// (validation for all three token types routes through GetUserSession,
+	// keyed by user id) and any DB-backed session tokens. Synchronous — the
+	// caller must not observe a still-valid token after deprovision returns.
+	if err := p.MemoryStoreProvider.DeleteAllUserSessions(updated.ID); err != nil {
+		log.Debug().Err(err).Msg("failed to delete user sessions from memory store")
+	}
+	if err := p.StorageProvider.DeleteAllSessionTokensByUserID(ctx, updated.ID); err != nil {
+		log.Debug().Err(err).Msg("failed to delete session tokens from storage")
+	}
+	return updated, nil
+}

--- a/internal/service/scim/scim_test.go
+++ b/internal/service/scim/scim_test.go
@@ -1,0 +1,296 @@
+package scim
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/memory_store"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// fakeStore is a stateful in-memory storage.Provider covering only the methods
+// the SCIM service touches. Every other method panics via the embedded nil.
+type fakeStore struct {
+	storage.Provider
+	endpoints   map[string]*schemas.ScimEndpoint // by id
+	users       map[string]*schemas.User         // by id
+	memberships map[string]bool                  // "orgID|userID"
+	deletedTok  []string                         // user ids passed to DeleteAllSessionTokensByUserID
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		endpoints:   map[string]*schemas.ScimEndpoint{},
+		users:       map[string]*schemas.User{},
+		memberships: map[string]bool{},
+	}
+}
+
+var errNotFound = errors.New("not found")
+
+func (f *fakeStore) GetScimEndpointByID(_ context.Context, id string) (*schemas.ScimEndpoint, error) {
+	if e, ok := f.endpoints[id]; ok {
+		return e, nil
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) GetUserByExternalID(_ context.Context, orgID, externalID string) (*schemas.User, error) {
+	key := orgID + ":" + externalID
+	for _, u := range f.users {
+		if u.ExternalID != nil && *u.ExternalID == key {
+			return u, nil
+		}
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) GetUserByEmail(_ context.Context, email string) (*schemas.User, error) {
+	for _, u := range f.users {
+		if u.Email != nil && *u.Email == email {
+			return u, nil
+		}
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) GetUserByID(_ context.Context, id string) (*schemas.User, error) {
+	if u, ok := f.users[id]; ok {
+		return u, nil
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) AddUser(_ context.Context, u *schemas.User) (*schemas.User, error) {
+	f.users[u.ID] = u
+	return u, nil
+}
+
+func (f *fakeStore) UpdateUser(_ context.Context, u *schemas.User) (*schemas.User, error) {
+	f.users[u.ID] = u
+	return u, nil
+}
+
+func (f *fakeStore) GetOrgMembership(_ context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
+	if f.memberships[orgID+"|"+userID] {
+		return &schemas.OrgMembership{OrgID: orgID, UserID: userID}, nil
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) AddOrgMembership(_ context.Context, m *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	f.memberships[m.OrgID+"|"+m.UserID] = true
+	return m, nil
+}
+
+func (f *fakeStore) DeleteAllSessionTokensByUserID(_ context.Context, userID string) error {
+	f.deletedTok = append(f.deletedTok, userID)
+	return nil
+}
+
+// fakeMem records the user ids whose sessions were dropped.
+type fakeMem struct {
+	memory_store.Provider
+	deleted []string
+}
+
+func (m *fakeMem) DeleteAllUserSessions(userID string) error {
+	m.deleted = append(m.deleted, userID)
+	return nil
+}
+
+func newSvc(t *testing.T) (*provider, *fakeStore, *fakeMem) {
+	t.Helper()
+	log := zerolog.Nop()
+	store := newFakeStore()
+	mem := &fakeMem{}
+	p := &provider{Dependencies: Dependencies{Log: &log, StorageProvider: store, MemoryStoreProvider: mem}}
+	return p, store, mem
+}
+
+// seedEndpoint inserts an endpoint whose bearer secret is `secret`.
+func seedEndpoint(t *testing.T, store *fakeStore, id, orgID, secret string, enabled bool) {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(secret), tokenCost)
+	require.NoError(t, err)
+	store.endpoints[id] = &schemas.ScimEndpoint{ID: id, OrgID: orgID, TokenHash: string(h), Enabled: enabled}
+}
+
+func TestAuthenticate(t *testing.T) {
+	p, store, _ := newSvc(t)
+	seedEndpoint(t, store, "ep-a", "org-a", "s3cr3t", true)
+	seedEndpoint(t, store, "ep-disabled", "org-x", "s3cr3t", false)
+	ctx := context.Background()
+
+	t.Run("valid token resolves org from the endpoint only", func(t *testing.T) {
+		org, err := p.Authenticate(ctx, "ep-a.s3cr3t")
+		require.NoError(t, err)
+		assert.Equal(t, "org-a", org)
+	})
+	t.Run("wrong secret rejected", func(t *testing.T) {
+		_, err := p.Authenticate(ctx, "ep-a.wrong")
+		assert.ErrorIs(t, err, ErrUnauthorized)
+	})
+	t.Run("unknown endpoint id rejected", func(t *testing.T) {
+		_, err := p.Authenticate(ctx, "ep-nope.s3cr3t")
+		assert.ErrorIs(t, err, ErrUnauthorized)
+	})
+	t.Run("malformed token rejected", func(t *testing.T) {
+		for _, tok := range []string{"", "no-dot", "ep-a.", ".secret"} {
+			_, err := p.Authenticate(ctx, tok)
+			assert.ErrorIs(t, err, ErrUnauthorized, tok)
+		}
+	})
+	t.Run("disabled endpoint rejected", func(t *testing.T) {
+		_, err := p.Authenticate(ctx, "ep-disabled.s3cr3t")
+		assert.ErrorIs(t, err, ErrUnauthorized)
+	})
+}
+
+func TestGenerateToken(t *testing.T) {
+	tok, hash, err := GenerateToken("ep-1")
+	require.NoError(t, err)
+	// Format: "<id>.<hexSecret>", 64 hex chars (256 bits).
+	assert.Regexp(t, `^ep-1\.[0-9a-f]{64}$`, tok)
+	secret := tok[len("ep-1."):]
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(hash), []byte(secret)))
+}
+
+func TestCreateUser_ProvisionsWithNamespacedExternalID(t *testing.T) {
+	p, store, _ := newSvc(t)
+	ctx := context.Background()
+	u, existed, err := p.CreateUser(ctx, "org-a", User{ExternalID: "okta-123", UserName: "bob@acme.com", GivenName: "Bob", Active: true})
+	require.NoError(t, err)
+	assert.False(t, existed)
+	require.NotNil(t, u.ExternalID)
+	assert.Equal(t, "org-a:okta-123", *u.ExternalID, "external_id must be org-namespaced")
+	assert.True(t, u.IsActive)
+	// Membership binds the user to the org (required for later by-id ops).
+	_, err = store.GetOrgMembership(ctx, "org-a", u.ID)
+	assert.NoError(t, err)
+}
+
+func TestCreateUser_ProvisionInactiveIsRevoked(t *testing.T) {
+	p, _, _ := newSvc(t)
+	ctx := context.Background()
+	u, _, err := p.CreateUser(ctx, "org-a", User{ExternalID: "okta-9", UserName: "eve@acme.com", Active: false})
+	require.NoError(t, err)
+	assert.False(t, u.IsActive, "a user provisioned active:false must be stored inactive")
+	require.NotNil(t, u.RevokedTimestamp, "an inactive-provisioned user must be revocation-stamped so no token can be minted")
+}
+
+func TestCreateUser_DedupByExternalID(t *testing.T) {
+	p, _, _ := newSvc(t)
+	ctx := context.Background()
+	first, _, err := p.CreateUser(ctx, "org-a", User{ExternalID: "okta-123", UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	second, existed, err := p.CreateUser(ctx, "org-a", User{ExternalID: "okta-123", UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	assert.True(t, existed, "repeat create with same externalId must dedup")
+	assert.Equal(t, first.ID, second.ID, "no duplicate user")
+}
+
+func TestCreateUser_DedupByUserNameWithinOrg(t *testing.T) {
+	p, _, _ := newSvc(t)
+	ctx := context.Background()
+	first, _, err := p.CreateUser(ctx, "org-a", User{UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	second, existed, err := p.CreateUser(ctx, "org-a", User{UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	assert.True(t, existed)
+	assert.Equal(t, first.ID, second.ID)
+}
+
+func TestCreateUser_CrossOrgEmailConflict(t *testing.T) {
+	p, _, _ := newSvc(t)
+	ctx := context.Background()
+	_, _, err := p.CreateUser(ctx, "org-a", User{UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	// A different org tries to provision the same email → global email
+	// uniqueness means we cannot, and we must not silently adopt org-a's user.
+	_, _, err = p.CreateUser(ctx, "org-b", User{UserName: "bob@acme.com", Active: true})
+	assert.ErrorIs(t, err, ErrConflict)
+}
+
+// TestH6_CrossOrgMutationRejected is the core cross-org isolation guarantee:
+// org-a's SCIM connection can never read or mutate a user provisioned into
+// org-b, even with that user's exact id.
+func TestH6_CrossOrgMutationRejected(t *testing.T) {
+	p, _, mem := newSvc(t)
+	ctx := context.Background()
+	victim, _, err := p.CreateUser(ctx, "org-b", User{ExternalID: "b-1", UserName: "victim@b.com", Active: true})
+	require.NoError(t, err)
+
+	t.Run("GET by id from another org 404s", func(t *testing.T) {
+		_, err := p.GetUser(ctx, "org-a", victim.ID)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+	t.Run("PATCH active:false from another org 404s and does NOT revoke", func(t *testing.T) {
+		_, err := p.SetActive(ctx, "org-a", victim.ID, false)
+		assert.ErrorIs(t, err, ErrNotFound)
+		assert.Empty(t, mem.deleted, "a cross-org deprovision must not touch the victim's sessions")
+		got, _ := p.GetUser(ctx, "org-b", victim.ID)
+		assert.True(t, got.IsActive, "victim must remain active")
+	})
+	t.Run("PUT replace from another org 404s", func(t *testing.T) {
+		_, err := p.ReplaceUser(ctx, "org-a", victim.ID, User{UserName: "victim@b.com", Active: false})
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+	t.Run("owning org CAN mutate", func(t *testing.T) {
+		u, err := p.SetActive(ctx, "org-b", victim.ID, false)
+		require.NoError(t, err)
+		assert.False(t, u.IsActive)
+	})
+}
+
+// TestDeactivateRevokesSessions proves the enterprise-offboarding contract:
+// active:false disables the user AND synchronously drops sessions + refresh/
+// session tokens so held credentials stop working immediately.
+func TestDeactivateRevokesSessions(t *testing.T) {
+	p, store, mem := newSvc(t)
+	ctx := context.Background()
+	u, _, err := p.CreateUser(ctx, "org-a", User{ExternalID: "a-1", UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+
+	got, err := p.SetActive(ctx, "org-a", u.ID, false)
+	require.NoError(t, err)
+	assert.False(t, got.IsActive)
+	require.NotNil(t, got.RevokedTimestamp, "revoked_timestamp must be stamped so already-issued tokens fail")
+	assert.Contains(t, mem.deleted, u.ID, "memory-store sessions must be dropped")
+	assert.Contains(t, store.deletedTok, u.ID, "db session/refresh tokens must be dropped")
+}
+
+func TestDelete_MapsToDeactivate(t *testing.T) {
+	p, _, mem := newSvc(t)
+	ctx := context.Background()
+	u, _, err := p.CreateUser(ctx, "org-a", User{UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	// DELETE is modelled as SetActive(false) at the handler; assert the same
+	// revocation happens through the service path it calls.
+	_, err = p.SetActive(ctx, "org-a", u.ID, false)
+	require.NoError(t, err)
+	assert.Contains(t, mem.deleted, u.ID)
+}
+
+func TestFindByUserName_OrgScoped(t *testing.T) {
+	p, _, _ := newSvc(t)
+	ctx := context.Background()
+	u, _, err := p.CreateUser(ctx, "org-b", User{UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	// Same email, probed from another org → not surfaced (H6 for the dedup probe).
+	got, err := p.FindByUserName(ctx, "org-a", "bob@acme.com")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	// Owning org sees it.
+	got, err = p.FindByUserName(ctx, "org-b", "bob@acme.com")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, u.ID, got.ID)
+}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -436,6 +436,26 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Sparse: true,
 	})
 
+	// ScimEndpoint collection and indexes
+	scimEndpointCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.ScimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	if !scimEndpointCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.ScimEndpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	scimEndpointCollection, err := arangodb.Collection(ctx, schemas.Collections.ScimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	// OrgID is unique: one SCIM endpoint per org.
+	_, _, _ = scimEndpointCollection.EnsurePersistentIndex(ctx, []string{"org_id"}, &arangoDriver.EnsurePersistentIndexOptions{
+		Unique: true,
+	})
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/arangodb/scim_endpoint.go
+++ b/internal/storage/db/arangodb/scim_endpoint.go
@@ -1,0 +1,126 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimEndpoint creates a new SCIM endpoint record.
+func (p *provider) AddScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if scimEndpoint.ID == "" {
+		scimEndpoint.ID = uuid.New().String()
+	}
+	scimEndpoint.Key = scimEndpoint.ID
+	now := time.Now().Unix()
+	scimEndpoint.CreatedAt = now
+	scimEndpoint.UpdatedAt = now
+	scimEndpointCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimEndpoint)
+	doc, err := structToDocument(scimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := scimEndpointCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	scimEndpoint.Key = meta.Key
+	scimEndpoint.ID = meta.ID.String()
+	return scimEndpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if scimEndpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	scimEndpoint.UpdatedAt = time.Now().Unix()
+	scimEndpointCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimEndpoint)
+	doc, err := structToDocument(scimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := scimEndpointCollection.UpdateDocument(ctx, scimEndpoint.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	scimEndpoint.Key = meta.Key
+	scimEndpoint.ID = meta.ID.String()
+	return scimEndpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint record.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) error {
+	scimEndpointCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimEndpoint)
+	_, err := scimEndpointCollection.RemoveDocument(ctx, scimEndpoint.Key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+// Filters on _key, not _id: every real caller holds the bare id
+// AsAPIScimEndpoint exposes, never the full "collection/key" handle.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	var scimEndpoint *schemas.ScimEndpoint
+	query := fmt.Sprintf("FOR d in %s FILTER d._key == @id LIMIT 1 RETURN d", schemas.Collections.ScimEndpoint)
+	bindVars := map[string]interface{}{
+		"id": id,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if scimEndpoint == nil {
+				return nil, fmt.Errorf("scim endpoint not found")
+			}
+			break
+		}
+		s := &schemas.ScimEndpoint{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		scimEndpoint = s
+	}
+	return scimEndpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches the SCIM endpoint for an organization.
+// OrgID is unique: one SCIM endpoint per org.
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	var scimEndpoint *schemas.ScimEndpoint
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id LIMIT 1 RETURN d", schemas.Collections.ScimEndpoint)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if scimEndpoint == nil {
+				return nil, fmt.Errorf("scim endpoint not found")
+			}
+			break
+		}
+		s := &schemas.ScimEndpoint{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		scimEndpoint = s
+	}
+	return scimEndpoint, nil
+}

--- a/internal/storage/db/arangodb/user.go
+++ b/internal/storage/db/arangodb/user.go
@@ -153,6 +153,36 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.U
 	return user, nil
 }
 
+// GetUserByExternalID to get user information from database using the
+// org-namespaced external id. external_id is stored as "<orgID>:<externalID>"
+// so the same IdP external id can map to distinct users across organizations.
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	var user *schemas.User
+	query := fmt.Sprintf("FOR d in %s FILTER d.external_id == @extid RETURN d", schemas.Collections.User)
+	bindVars := map[string]interface{}{
+		"extid": orgID + ":" + externalID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if user == nil {
+				return nil, fmt.Errorf("user not found")
+			}
+			break
+		}
+		u := &schemas.User{}
+		if _, err := readDocument(ctx, cursor, u); err != nil {
+			return nil, err
+		}
+		user = u
+	}
+	return user, nil
+}
+
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, error) {
 	var user *schemas.User

--- a/internal/storage/db/cassandradb/org_membership.go
+++ b/internal/storage/db/cassandradb/org_membership.go
@@ -15,6 +15,17 @@ import (
 
 const orgMembershipColumns = "id, org_id, user_id, roles, created_at, updated_at"
 
+// orgMembershipPK derives the membership's primary key deterministically from
+// (org_id, user_id). ScyllaDB secondary indexes are materialized-view backed
+// and update ASYNCHRONOUSLY, so a lookup by the org_id/user_id index right after
+// an insert can miss the just-written row (the multi-member add-then-get race).
+// Keying the base table on a deterministic id lets GetOrgMembership read by
+// primary key — synchronous, index-free, and race-free — while (org_id,user_id)
+// uniqueness falls out for free (the same pair always maps to the same key).
+func orgMembershipPK(orgID, userID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(orgID+":"+userID)).String()
+}
+
 // scanOrgMembership maps the orgMembershipColumns projection onto a struct.
 func scanOrgMembership(scan func(...interface{}) error, membership *schemas.OrgMembership) error {
 	return scan(&membership.ID, &membership.OrgID, &membership.UserID, &membership.Roles, &membership.CreatedAt, &membership.UpdatedAt)
@@ -25,9 +36,10 @@ func scanOrgMembership(scan func(...interface{}) error, membership *schemas.OrgM
 // check-then-insert mirroring AddTrustedIssuer's pre-check.
 // ponytail: inherent TOCTOU race — closes the sequential case only.
 func (p *provider) AddOrgMembership(ctx context.Context, membership *schemas.OrgMembership) (*schemas.OrgMembership, error) {
-	if membership.ID == "" {
-		membership.ID = uuid.New().String()
-	}
+	// Deterministic PK from (org_id, user_id) so the row is readable by primary
+	// key immediately after insert — see orgMembershipPK. Overrides any incoming
+	// id; the id is opaque and no caller depends on a specific value.
+	membership.ID = orgMembershipPK(membership.OrgID, membership.UserID)
 	membership.Key = membership.ID
 	now := time.Now().Unix()
 	membership.CreatedAt = now
@@ -84,8 +96,11 @@ func (p *provider) DeleteOrgMembership(ctx context.Context, membership *schemas.
 // GetOrgMembership fetches the membership for a (orgID, userID) pair.
 func (p *provider) GetOrgMembership(ctx context.Context, orgID, userID string) (*schemas.OrgMembership, error) {
 	var membership schemas.OrgMembership
-	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND user_id = ? LIMIT 1 ALLOW FILTERING", orgMembershipColumns, KeySpace+"."+schemas.Collections.OrgMembership)
-	if err := scanOrgMembership(p.db.Query(query, orgID, userID).Consistency(gocql.One).Scan, &membership); err != nil {
+	// Read by the deterministic primary key (base table) — NOT the async org_id/
+	// user_id secondary index — so a membership is visible immediately after it
+	// is written (fixes the ScyllaDB add-then-get race).
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ?", orgMembershipColumns, KeySpace+"."+schemas.Collections.OrgMembership)
+	if err := scanOrgMembership(p.db.Query(query, orgMembershipPK(orgID, userID)).Consistency(gocql.One).Scan, &membership); err != nil {
 		return nil, err
 	}
 	return &membership, nil

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -159,7 +159,7 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		return nil, err
 	}
 
-	userCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, email text, email_verified_at bigint, password text, signup_methods text, given_name text, family_name text, middle_name text, nickname text, gender text, birthdate text, phone_number text, phone_number_verified_at bigint, picture text, roles text, updated_at bigint, created_at bigint, revoked_timestamp bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.User)
+	userCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, email text, email_verified_at bigint, password text, signup_methods text, given_name text, family_name text, middle_name text, nickname text, gender text, birthdate text, phone_number text, phone_number_verified_at bigint, picture text, roles text, updated_at bigint, created_at bigint, revoked_timestamp bigint, external_id text, is_active boolean, PRIMARY KEY (id))", KeySpace, schemas.Collections.User)
 	err = session.Query(userCollectionQuery).Exec()
 	if err != nil {
 		return nil, err
@@ -181,6 +181,25 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	if err != nil {
 		deps.Log.Debug().Err(err).Msg("Failed to alter table as is_multi_factor_auth_enabled column exists")
 		// continue
+	}
+	// add external_id and is_active on users table (SCIM provisioning)
+	userExternalIDAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD external_id text`, KeySpace, schemas.Collections.User)
+	err = session.Query(userExternalIDAlterQuery).Exec()
+	if err != nil {
+		deps.Log.Debug().Err(err).Msg("Failed to alter table as external_id column exists")
+		// continue
+	}
+	userIsActiveAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD is_active boolean`, KeySpace, schemas.Collections.User)
+	err = session.Query(userIsActiveAlterQuery).Exec()
+	if err != nil {
+		deps.Log.Debug().Err(err).Msg("Failed to alter table as is_active column exists")
+		// continue
+	}
+	// external_id is looked up by GetUserByExternalID (SCIM), needs an index
+	userExternalIDIndexQuery := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_user_external_id ON %s.%s (external_id)", KeySpace, schemas.Collections.User)
+	err = session.Query(userExternalIDIndexQuery).Exec()
+	if err != nil {
+		return nil, err
 	}
 
 	// token is reserved keyword in cassandra, hence we need to use jwt_token
@@ -447,6 +466,19 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Organization, "name", 30*time.Second)
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "org_id", 30*time.Second)
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "user_id", 30*time.Second)
+
+	// ScimEndpoint table and index
+	scimEndpointCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, token_hash text, enabled boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.ScimEndpoint)
+	if err = session.Query(scimEndpointCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	scimEndpointOrgIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_scim_endpoint_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.ScimEndpoint)
+	if err = session.Query(scimEndpointOrgIndex).Exec(); err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for org_id (used by
+	// GetScimEndpointByOrgID and the uniqueness guard) to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.ScimEndpoint, "org_id", 30*time.Second)
 
 	return &provider{
 		config:       cfg,

--- a/internal/storage/db/cassandradb/scim_endpoint.go
+++ b/internal/storage/db/cassandradb/scim_endpoint.go
@@ -1,0 +1,101 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const scimEndpointColumns = "id, org_id, token_hash, enabled, created_at, updated_at"
+
+// scanScimEndpoint maps the scimEndpointColumns projection onto a struct.
+func scanScimEndpoint(scan func(...interface{}) error, endpoint *schemas.ScimEndpoint) error {
+	return scan(&endpoint.ID, &endpoint.OrgID, &endpoint.TokenHash, &endpoint.Enabled, &endpoint.CreatedAt, &endpoint.UpdatedAt)
+}
+
+// AddScimEndpoint creates a new SCIM endpoint. OrgID is unique — one endpoint
+// per org. Cassandra has no cross-attribute unique constraint, so guard with a
+// check-then-insert mirroring AddOrganization's name pre-check.
+// ponytail: inherent TOCTOU race — closes the sequential case only.
+func (p *provider) AddScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.ID == "" {
+		endpoint.ID = uuid.New().String()
+	}
+	endpoint.Key = endpoint.ID
+	now := time.Now().Unix()
+	endpoint.CreatedAt = now
+	endpoint.UpdatedAt = now
+	if existing, _ := p.GetScimEndpointByOrgID(ctx, endpoint.OrgID); existing != nil {
+		return nil, fmt.Errorf("scim endpoint for org_id %s already exists", endpoint.OrgID)
+	}
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.ScimEndpoint, scimEndpointColumns)
+	err := p.db.Query(insertQuery, endpoint.ID, endpoint.OrgID, endpoint.TokenHash, endpoint.Enabled, endpoint.CreatedAt, endpoint.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	endpoint.UpdatedAt = time.Now().Unix()
+	endpointMap := buildCQLColumnMap(endpoint)
+	updateFields := ""
+	var updateValues []interface{}
+	for key, value := range endpointMap {
+		if key == "id" || key == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", key)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", key)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, endpoint.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.ScimEndpoint, updateFields)
+	if err := p.db.Query(query, updateValues...).Exec(); err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint record.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.ScimEndpoint)
+	return p.db.Query(query, endpoint.ID).Exec()
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	var endpoint schemas.ScimEndpoint
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", scimEndpointColumns, KeySpace+"."+schemas.Collections.ScimEndpoint)
+	if err := scanScimEndpoint(p.db.Query(query, id).Consistency(gocql.One).Scan, &endpoint); err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches a SCIM endpoint by its unique org ID.
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	var endpoint schemas.ScimEndpoint
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? LIMIT 1 ALLOW FILTERING", scimEndpointColumns, KeySpace+"."+schemas.Collections.ScimEndpoint)
+	if err := scanScimEndpoint(p.db.Query(query, orgID).Consistency(gocql.One).Scan, &endpoint); err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}

--- a/internal/storage/db/cassandradb/user.go
+++ b/internal/storage/db/cassandradb/user.go
@@ -162,7 +162,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) 
 	// there is no offset in cassandra
 	// so we fetch till limit + offset
 	// and return the results from offset to limit
-	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s LIMIT %d", KeySpace+"."+schemas.Collections.User,
+	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, external_id, is_active, created_at, updated_at FROM %s LIMIT %d", KeySpace+"."+schemas.Collections.User,
 		pagination.Limit+pagination.Offset)
 	scanner := p.db.Query(query).Iter().Scanner()
 	counter := int64(0)
@@ -172,7 +172,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) 
 			err := scanner.Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods,
 				&user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber,
 				&user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled,
-				&user.AppData, &user.CreatedAt, &user.UpdatedAt)
+				&user.AppData, &user.ExternalID, &user.IsActive, &user.CreatedAt, &user.UpdatedAt)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -186,8 +186,8 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) 
 // GetUserByEmail to get user information from database using email address
 func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.User, error) {
 	var user schemas.User
-	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s WHERE email = ? LIMIT 1 ALLOW FILTERING", KeySpace+"."+schemas.Collections.User)
-	err := p.db.Query(query, email).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.CreatedAt, &user.UpdatedAt)
+	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, external_id, is_active, created_at, updated_at FROM %s WHERE email = ? LIMIT 1 ALLOW FILTERING", KeySpace+"."+schemas.Collections.User)
+	err := p.db.Query(query, email).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.ExternalID, &user.IsActive, &user.CreatedAt, &user.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +197,8 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.U
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, error) {
 	var user schemas.User
-	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s WHERE id = ? LIMIT 1", KeySpace+"."+schemas.Collections.User)
-	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.CreatedAt, &user.UpdatedAt)
+	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, external_id, is_active, created_at, updated_at FROM %s WHERE id = ? LIMIT 1", KeySpace+"."+schemas.Collections.User)
+	err := p.db.Query(query, id).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.ExternalID, &user.IsActive, &user.CreatedAt, &user.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -275,8 +275,20 @@ func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{},
 // GetUserByPhoneNumber to get user information from database using phone number
 func (p *provider) GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (*schemas.User, error) {
 	var user schemas.User
-	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s WHERE phone_number = ? LIMIT 1 ALLOW FILTERING", KeySpace+"."+schemas.Collections.User)
-	err := p.db.Query(query, phoneNumber).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.CreatedAt, &user.UpdatedAt)
+	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, external_id, is_active, created_at, updated_at FROM %s WHERE phone_number = ? LIMIT 1 ALLOW FILTERING", KeySpace+"."+schemas.Collections.User)
+	err := p.db.Query(query, phoneNumber).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.ExternalID, &user.IsActive, &user.CreatedAt, &user.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// GetUserByExternalID fetches an IdP-provisioned user by its org-namespaced
+// external ID. The lookup key is the composite "<orgID>:<externalID>".
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	var user schemas.User
+	query := fmt.Sprintf("SELECT id, email, email_verified_at, password, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, roles, revoked_timestamp, is_multi_factor_auth_enabled, app_data, external_id, is_active, created_at, updated_at FROM %s WHERE external_id = ? LIMIT 1 ALLOW FILTERING", KeySpace+"."+schemas.Collections.User)
+	err := p.db.Query(query, orgID+":"+externalID).Consistency(gocql.One).Scan(&user.ID, &user.Email, &user.EmailVerifiedAt, &user.Password, &user.SignupMethods, &user.GivenName, &user.FamilyName, &user.MiddleName, &user.Nickname, &user.Birthdate, &user.PhoneNumber, &user.PhoneNumberVerifiedAt, &user.Picture, &user.Roles, &user.RevokedTimestamp, &user.IsMultiFactorAuthEnabled, &user.AppData, &user.ExternalID, &user.IsActive, &user.CreatedAt, &user.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/couchbase/org_membership.go
+++ b/internal/storage/db/couchbase/org_membership.go
@@ -13,7 +13,10 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const orgMembershipColumns = "_id, org_id, user_id, roles, created_at, updated_at"
+// roles is a N1QL reserved word — it MUST be backticked in every statement
+// that names it (SELECT projection here; the UPDATE SET clause is quoted by
+// GetSetFields).
+const orgMembershipColumns = "_id, org_id, user_id, `roles`, created_at, updated_at"
 
 // AddOrgMembership creates a new membership. (org_id, user_id) is unique;
 // Couchbase has no compound unique constraint, so guard with a

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -305,5 +305,9 @@ func getIndex(scopeName string) map[string][]string {
 	orgMembershipIndex2 := fmt.Sprintf("CREATE INDEX OrgMembershipUserIdIndex ON %s.%s(user_id)", scopeName, schemas.Collections.OrgMembership)
 	indices[schemas.Collections.OrgMembership] = []string{orgMembershipIndex1, orgMembershipIndex2}
 
+	// ScimEndpoint index
+	scimEndpointIndex1 := fmt.Sprintf("CREATE INDEX ScimEndpointOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.ScimEndpoint)
+	indices[schemas.Collections.ScimEndpoint] = []string{scimEndpointIndex1}
+
 	return indices
 }

--- a/internal/storage/db/couchbase/scim_endpoint.go
+++ b/internal/storage/db/couchbase/scim_endpoint.go
@@ -1,0 +1,129 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const scimEndpointColumns = "_id, org_id, token_hash, enabled, created_at, updated_at"
+
+// AddScimEndpoint creates a new SCIM endpoint. org_id is unique — one endpoint
+// per org; Couchbase has no cross-attribute unique constraint, so guard with a
+// check-then-insert on org_id (closes the sequential case).
+func (p *provider) AddScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.ID == "" {
+		endpoint.ID = uuid.New().String()
+	}
+	endpoint.Key = endpoint.ID
+	now := time.Now().Unix()
+	endpoint.CreatedAt = now
+	endpoint.UpdatedAt = now
+	if existing, _ := p.GetScimEndpointByOrgID(ctx, endpoint.OrgID); existing != nil {
+		return nil, fmt.Errorf("scim endpoint for org_id %s already exists", endpoint.OrgID)
+	}
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.ScimEndpoint).Insert(endpoint.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record (token rotation, enable).
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	endpoint.UpdatedAt = time.Now().Unix()
+	endpointMap, err := structToDocument(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(endpointMap)
+	params["_id"] = endpoint.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.ScimEndpoint, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint record.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.ScimEndpoint).Remove(endpoint.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	params := make(map[string]interface{}, 1)
+	params["_id"] = id
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, scimEndpointColumns, p.scopeName, schemas.Collections.ScimEndpoint)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	endpoint := &schemas.ScimEndpoint{}
+	if err := decodeDocument(raw, endpoint); err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches an org's SCIM endpoint (org_id is unique).
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	params := make(map[string]interface{}, 1)
+	params["org_id"] = orgID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id LIMIT 1`, scimEndpointColumns, p.scopeName, schemas.Collections.ScimEndpoint)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	endpoint := &schemas.ScimEndpoint{}
+	if err := decodeDocument(raw, endpoint); err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}

--- a/internal/storage/db/couchbase/shared.go
+++ b/internal/storage/db/couchbase/shared.go
@@ -126,8 +126,11 @@ func GetSetFields(webhookMap map[string]interface{}) (string, map[string]interfa
 		if key == "_key" {
 			continue
 		}
+		// Backtick the column identifier so N1QL reserved words (e.g. `roles`)
+		// are always legal in the SET clause. The bind-param name ($key) is not
+		// an identifier and needs no quoting.
 		if value == nil {
-			updateFields += fmt.Sprintf("%s=$%s,", key, key)
+			updateFields += fmt.Sprintf("`%s`=$%s,", key, key)
 			// Bind an actual nil so the gocb N1QL driver serializes it to JSON
 			// null (a real N1QL NULL). Binding the string "null" here would
 			// persist the 4-char literal instead of clearing the field.
@@ -136,11 +139,11 @@ func GetSetFields(webhookMap map[string]interface{}) (string, map[string]interfa
 		}
 		valueType := reflect.TypeOf(value)
 		if valueType.Name() == "string" {
-			updateFields += fmt.Sprintf("%s = $%s, ", key, key)
+			updateFields += fmt.Sprintf("`%s` = $%s, ", key, key)
 			params[key] = value.(string)
 
 		} else {
-			updateFields += fmt.Sprintf("%s = $%s, ", key, key)
+			updateFields += fmt.Sprintf("`%s` = $%s, ", key, key)
 			params[key] = value
 		}
 	}

--- a/internal/storage/db/couchbase/user.go
+++ b/internal/storage/db/couchbase/user.go
@@ -89,7 +89,7 @@ func (p *provider) DeleteUser(ctx context.Context, user *schemas.User) error {
 func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) ([]*schemas.User, *model.Pagination, error) {
 	users := []*schemas.User{}
 	paginationClone := pagination
-	userQuery := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s ORDER BY id OFFSET $1 LIMIT $2", p.scopeName, schemas.Collections.User)
+	userQuery := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, is_active, external_id, created_at, updated_at FROM %s.%s ORDER BY id OFFSET $1 LIMIT $2", p.scopeName, schemas.Collections.User)
 	queryResult, err := p.db.Query(userQuery, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -122,7 +122,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination) 
 
 // GetUserByEmail to get user information from database using email address
 func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.User, error) {
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE email = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, is_active, external_id, created_at, updated_at FROM %s.%s WHERE email = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -146,7 +146,7 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.U
 // org-namespaced external ID. external_id is stored as "<orgID>:<externalID>"
 // so IdP identifiers never collide across organizations.
 func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE external_id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, is_active, external_id, created_at, updated_at FROM %s.%s WHERE external_id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -168,7 +168,7 @@ func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID st
 
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, error) {
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE _id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, is_active, external_id, created_at, updated_at FROM %s.%s WHERE _id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,
@@ -224,7 +224,7 @@ func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{},
 
 // GetUserByPhoneNumber to get user information from database using phone number
 func (p *provider) GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (*schemas.User, error) {
-	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE phone_number = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, is_active, external_id, created_at, updated_at FROM %s.%s WHERE phone_number = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
 		Context:              ctx,

--- a/internal/storage/db/couchbase/user.go
+++ b/internal/storage/db/couchbase/user.go
@@ -142,6 +142,30 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.U
 	return user, nil
 }
 
+// GetUserByExternalID to get user information from database using the
+// org-namespaced external ID. external_id is stored as "<orgID>:<externalID>"
+// so IdP identifiers never collide across organizations.
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE external_id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
+		Context:              ctx,
+		PositionalParameters: []interface{}{orgID + ":" + externalID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	user := &schemas.User{}
+	if err := decodeDocument(raw, user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, error) {
 	query := fmt.Sprintf("SELECT _id, email, email_verified_at, `password`, signup_methods, given_name, family_name, middle_name, nickname, birthdate, phone_number, phone_number_verified_at, picture, `roles`, revoked_timestamp, is_multi_factor_auth_enabled, app_data, created_at, updated_at FROM %s.%s WHERE _id = $1 LIMIT 1", p.scopeName, schemas.Collections.User)

--- a/internal/storage/db/dynamodb/scim_endpoint.go
+++ b/internal/storage/db/dynamodb/scim_endpoint.go
@@ -1,0 +1,84 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimEndpoint creates a new SCIM endpoint record. OrgID is unique (one
+// endpoint per org); DynamoDB has no cross-attribute unique constraint, so
+// guard with a check-then-insert on the org_id GSI (closes the sequential case).
+func (p *provider) AddScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.ID == "" {
+		endpoint.ID = uuid.New().String()
+	}
+	endpoint.Key = endpoint.ID
+	now := time.Now().Unix()
+	endpoint.CreatedAt = now
+	endpoint.UpdatedAt = now
+	if existing, _ := p.GetScimEndpointByOrgID(ctx, endpoint.OrgID); existing != nil {
+		return nil, fmt.Errorf("scim endpoint for org_id %s already exists", endpoint.OrgID)
+	}
+	if err := p.putItem(ctx, schemas.Collections.ScimEndpoint, endpoint); err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — UpdateItem applies a partial SET/REMOVE merge, so a partial struct
+// blanks untouched columns to their zero values.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	endpoint.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.ScimEndpoint, "id", endpoint.ID, endpoint); err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint record.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error {
+	if endpoint == nil {
+		return nil
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.ScimEndpoint, "id", endpoint.ID)
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	var endpoint schemas.ScimEndpoint
+	err := p.getItemByHash(ctx, schemas.Collections.ScimEndpoint, "id", id, &endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if endpoint.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &endpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches an org's SCIM endpoint via the org_id GSI.
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimEndpoint, "org_id", "org_id", orgID, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var endpoint schemas.ScimEndpoint
+	if err := unmarshalItem(items[0], &endpoint); err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -60,8 +60,12 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			attr: []types.AttributeDefinition{
 				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
 				{AttributeName: aws.String("email"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("external_id"), AttributeType: types.ScalarAttributeTypeS},
 			},
-			gsi: []types.GlobalSecondaryIndex{gsi("email", "email")},
+			gsi: []types.GlobalSecondaryIndex{
+				gsi("email", "email"),
+				gsi("external_id", "external_id"),
+			},
 		},
 		{
 			name: schemas.Collections.Session,
@@ -216,6 +220,15 @@ func (p *provider) ensureTables(ctx context.Context) error {
 				gsi("org_id", "org_id"),
 				gsi("user_id", "user_id"),
 			},
+		},
+		{
+			name: schemas.Collections.ScimEndpoint,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
 		},
 	}
 

--- a/internal/storage/db/dynamodb/user.go
+++ b/internal/storage/db/dynamodb/user.go
@@ -208,6 +208,26 @@ func (p *provider) GetUserByEmail(ctx context.Context, email string) (*schemas.U
 	return &u, nil
 }
 
+// GetUserByExternalID fetches an IdP-provisioned user by its org-namespaced
+// external id via the external_id GSI. The lookup key is composed as
+// "<orgID>:<externalID>" so one org's SCIM/SSO connection can never resolve
+// another org's user by external id (design §4.4 H6).
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	items, err := p.queryEq(ctx, schemas.Collections.User, "external_id", "external_id", orgID+":"+externalID, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no record found")
+	}
+	var u schemas.User
+	if err := unmarshalItem(items[0], &u); err != nil {
+		return nil, err
+	}
+	normalizeUserOptionalPtrs(&u)
+	return &u, nil
+}
+
 // GetUserByID to get user information from database using user ID
 func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, error) {
 	var user schemas.User

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -254,6 +254,16 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// ScimEndpoint collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.ScimEndpoint, options.CreateCollection())
+	scimEndpointCollection := mongodb.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	_, _ = scimEndpointCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.M{"org_id": 1},
+			Options: options.Index().SetUnique(true),
+		},
+	}, options.CreateIndexes())
+
 	return &provider{
 		config:       config,
 		dependencies: deps,

--- a/internal/storage/db/mongodb/scim_endpoint.go
+++ b/internal/storage/db/mongodb/scim_endpoint.go
@@ -1,0 +1,81 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimEndpoint creates a new SCIM endpoint record. The unique index on
+// org_id rejects a second endpoint for the same organization at the database
+// layer.
+func (p *provider) AddScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if scimEndpoint.ID == "" {
+		scimEndpoint.ID = uuid.New().String()
+	}
+	scimEndpoint.Key = scimEndpoint.ID
+	now := time.Now().Unix()
+	scimEndpoint.CreatedAt = now
+	scimEndpoint.UpdatedAt = now
+	scimEndpointCollection := p.db.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	_, err := scimEndpointCollection.InsertOne(ctx, scimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	return scimEndpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — the $set write replaces every column and will blank zero-value
+// fields on a partial struct.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if scimEndpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	scimEndpoint.UpdatedAt = time.Now().Unix()
+	scimEndpointCollection := p.db.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	_, err := scimEndpointCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": scimEndpoint.ID}}, bson.M{"$set": scimEndpoint}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return scimEndpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint record.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, scimEndpoint *schemas.ScimEndpoint) error {
+	scimEndpointCollection := p.db.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	_, err := scimEndpointCollection.DeleteOne(ctx, bson.M{"_id": scimEndpoint.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	var scimEndpoint *schemas.ScimEndpoint
+	scimEndpointCollection := p.db.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	err := scimEndpointCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&scimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	return scimEndpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches the SCIM endpoint for an organization.
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	var scimEndpoint *schemas.ScimEndpoint
+	scimEndpointCollection := p.db.Collection(schemas.Collections.ScimEndpoint, options.Collection())
+	err := scimEndpointCollection.FindOne(ctx, bson.M{"org_id": orgID}).Decode(&scimEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	return scimEndpoint, nil
+}

--- a/internal/storage/db/mongodb/user.go
+++ b/internal/storage/db/mongodb/user.go
@@ -128,6 +128,19 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, e
 	return user, nil
 }
 
+// GetUserByExternalID to get user information from database using the
+// org-namespaced external ID. external_id is stored as "<orgID>:<externalID>"
+// so a SCIM externalId is only ever matched within its own organization.
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	var user *schemas.User
+	userCollection := p.db.Collection(schemas.Collections.User, options.Collection())
+	err := userCollection.FindOne(ctx, bson.M{"external_id": orgID + ":" + externalID}).Decode(&user)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
 // UpdateUsers to update multiple users, with parameters of user IDs slice
 // If ids set to nil / empty all the users will be updated
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.ScimEndpoint{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/sql/scim_endpoint.go
+++ b/internal/storage/db/sql/scim_endpoint.go
@@ -1,0 +1,68 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimEndpoint creates a new SCIM endpoint record.
+func (p *provider) AddScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.ID == "" {
+		endpoint.ID = uuid.New().String()
+	}
+	endpoint.Key = endpoint.ID
+	now := time.Now().Unix()
+	endpoint.CreatedAt = now
+	endpoint.UpdatedAt = now
+	res := p.db.Create(endpoint)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return endpoint, nil
+}
+
+// UpdateScimEndpoint updates a SCIM endpoint record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — Save writes every column and will blank zero-value fields on a
+// partial struct.
+func (p *provider) UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error) {
+	if endpoint.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimEndpoint: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	endpoint.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(endpoint)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return endpoint, nil
+}
+
+// DeleteScimEndpoint removes a SCIM endpoint.
+func (p *provider) DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error {
+	return p.db.Delete(endpoint).Error
+}
+
+// GetScimEndpointByID fetches a SCIM endpoint by primary key.
+func (p *provider) GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error) {
+	var endpoint schemas.ScimEndpoint
+	res := p.db.Where("id = ?", id).First(&endpoint)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &endpoint, nil
+}
+
+// GetScimEndpointByOrgID fetches a SCIM endpoint by its unique org ID.
+func (p *provider) GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error) {
+	var endpoint schemas.ScimEndpoint
+	res := p.db.Where("org_id = ?", orgID).First(&endpoint)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &endpoint, nil
+}

--- a/internal/storage/db/sql/user.go
+++ b/internal/storage/db/sql/user.go
@@ -147,6 +147,17 @@ func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{},
 	return nil
 }
 
+// GetUserByExternalID fetches an IdP-provisioned user by its org-namespaced
+// external ID. The lookup key is the composite "<orgID>:<externalID>".
+func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error) {
+	var user *schemas.User
+	result := p.db.Where("external_id = ?", orgID+":"+externalID).First(&user)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return user, nil
+}
+
 // GetUserByPhoneNumber to get user information from database using phone number
 func (p *provider) GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (*schemas.User, error) {
 	var user *schemas.User

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -43,6 +43,12 @@ type Provider interface {
 	GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (*schemas.User, error)
 	// GetUserByID to get user information from database using user ID
 	GetUserByID(ctx context.Context, id string) (*schemas.User, error)
+	// GetUserByExternalID fetches an IdP-provisioned user by its org-namespaced
+	// external id. The lookup key is composed as "<orgID>:<externalID>" so one
+	// org's SCIM/SSO connection can never resolve another org's user by external
+	// id (design §4.4 H6). Provisioning stores User.ExternalID in the same
+	// namespaced form.
+	GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error)
 	// UpdateUsers to update multiple users, identified by the ids slice.
 	// If ids is nil / empty NO update is performed: global updates are disabled,
 	// so implementations return an error (SQL: gorm.ErrMissingWhereClause) rather
@@ -249,6 +255,23 @@ type Provider interface {
 	ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
 	// ListOrgMembershipsByUser returns paginated memberships held by a user.
 	ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
+
+	// ScimEndpoint methods (per-org inbound SCIM 2.0 connection credential).
+
+	// AddScimEndpoint creates a new SCIM endpoint. OrgID is unique — one
+	// endpoint per org.
+	AddScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error)
+	// GetScimEndpointByID fetches an endpoint by primary key (the id embedded in
+	// the presented bearer token).
+	GetScimEndpointByID(ctx context.Context, id string) (*schemas.ScimEndpoint, error)
+	// GetScimEndpointByOrgID fetches an org's endpoint (admin surface, uniqueness
+	// pre-check).
+	GetScimEndpointByOrgID(ctx context.Context, orgID string) (*schemas.ScimEndpoint, error)
+	// UpdateScimEndpoint updates an existing endpoint (token rotation, enable).
+	// Callers MUST load-then-mutate — Save writes every column.
+	UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error)
+	// DeleteScimEndpoint removes an endpoint.
+	DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error
 }
 
 // New creates a new database provider based on the configuration

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"os"
 	"strings"
@@ -193,6 +194,14 @@ func TestStorageProvider(t *testing.T) {
 
 			t.Run("Org Membership Operations", func(t *testing.T) {
 				testOrgMembershipOperations(t, ctx, provider)
+			})
+
+			t.Run("SCIM Endpoint Operations", func(t *testing.T) {
+				testScimEndpointOperations(t, ctx, provider)
+			})
+
+			t.Run("User SCIM Fields", func(t *testing.T) {
+				testUserScimFields(t, ctx, provider)
 			})
 
 			if isSQLTestDB(dbType) {
@@ -1638,4 +1647,102 @@ func testOrgMembershipOperations(t *testing.T, ctx context.Context, provider Pro
 
 	require.NoError(t, provider.DeleteOrganization(ctx, orgA))
 	require.NoError(t, provider.DeleteOrganization(ctx, orgB))
+}
+
+// testScimEndpointOperations exercises ScimEndpoint CRUD including that the
+// bcrypt token hash round-trips (a json:"-" secret must persist) and never
+// serializes out, and that the org lookup resolves the same row.
+func testScimEndpointOperations(t *testing.T, ctx context.Context, provider Provider) {
+	org, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "scim-org-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgID := org.AsAPIOrganization().ID
+
+	const tokenHash = "$2a$12$abcdefghijklmnopqrstuvSCIMhashvaluethatmustroundtrip.xyz"
+	created, err := provider.AddScimEndpoint(ctx, &schemas.ScimEndpoint{
+		OrgID:     orgID,
+		TokenHash: tokenHash,
+		Enabled:   true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	endpointID := created.ID
+	require.NotEmpty(t, endpointID)
+
+	// Lookup by id (the token-embedded key) must resolve the row and its hash.
+	byID, err := provider.GetScimEndpointByID(ctx, endpointID)
+	require.NoError(t, err)
+	assert.Equal(t, orgID, byID.OrgID)
+	assert.Equal(t, tokenHash, byID.TokenHash, "bcrypt token hash must round-trip")
+	assert.True(t, byID.Enabled)
+
+	// Lookup by org (admin surface) must resolve the same endpoint.
+	byOrg, err := provider.GetScimEndpointByOrgID(ctx, orgID)
+	require.NoError(t, err)
+	assert.Equal(t, endpointID, byOrg.ID)
+
+	// The secret must never serialize out (json:"-").
+	blob, err := json.Marshal(byID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(blob), tokenHash, "token hash must not appear in JSON")
+
+	// Rotate: update the hash (load-then-mutate) and confirm it persists.
+	const rotated = "$2a$12$ROTATEDhashvaluethatmustalsoroundtrip.abcdefghijklmnop"
+	byID.TokenHash = rotated
+	_, err = provider.UpdateScimEndpoint(ctx, byID)
+	require.NoError(t, err)
+	afterRotate, err := provider.GetScimEndpointByID(ctx, endpointID)
+	require.NoError(t, err)
+	assert.Equal(t, rotated, afterRotate.TokenHash, "rotated hash must persist")
+
+	// Delete.
+	require.NoError(t, provider.DeleteScimEndpoint(ctx, afterRotate))
+	_, err = provider.GetScimEndpointByID(ctx, endpointID)
+	assert.Error(t, err, "endpoint should be gone after delete")
+
+	require.NoError(t, provider.DeleteOrganization(ctx, org))
+}
+
+// testUserScimFields verifies the additive User fields (ExternalID, IsActive)
+// persist and that GetUserByExternalID resolves by the org-namespaced key.
+func testUserScimFields(t *testing.T, ctx context.Context, provider Provider) {
+	orgID := uuid.New().String()
+	email := "scim-user-" + uuid.New().String() + "@example.com"
+	nsExt := orgID + ":okta-" + uuid.New().String()
+
+	created, err := provider.AddUser(ctx, &schemas.User{
+		ID:            uuid.New().String(),
+		Email:         &email,
+		SignupMethods: "scim",
+		ExternalID:    &nsExt,
+		IsActive:      true,
+	})
+	require.NoError(t, err)
+
+	// Additive fields round-trip.
+	fetched, err := provider.GetUserByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.ExternalID)
+	assert.Equal(t, nsExt, *fetched.ExternalID)
+	assert.True(t, fetched.IsActive, "IsActive must persist as true")
+
+	// GetUserByExternalID resolves by the org-namespaced (orgID, rawExternalID).
+	rawExt := nsExt[len(orgID)+1:]
+	byExt, err := provider.GetUserByExternalID(ctx, orgID, rawExt)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, byExt.ID, "GetUserByExternalID must resolve the org-scoped user")
+
+	// A different org must NOT resolve the same external id (H6 at the data layer).
+	_, err = provider.GetUserByExternalID(ctx, "other-org", rawExt)
+	assert.Error(t, err, "external id is namespaced per org — another org must not resolve it")
+
+	// Deactivate: IsActive=false persists.
+	fetched.IsActive = false
+	_, err = provider.UpdateUser(ctx, fetched)
+	require.NoError(t, err)
+	afterDeactivate, err := provider.GetUserByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.False(t, afterDeactivate.IsActive, "IsActive=false must persist")
 }

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -1668,7 +1668,10 @@ func testScimEndpointOperations(t *testing.T, ctx context.Context, provider Prov
 	})
 	require.NoError(t, err)
 	require.NotNil(t, created)
-	endpointID := created.ID
+	// Use the API-facing id (bare key). ArangoDB returns created.ID as the full
+	// "collection/key" handle; the runtime by-id lookup (GetScimEndpointByID) is
+	// keyed on the bare id the token carries, exactly as AsAPIScimEndpoint exposes.
+	endpointID := created.AsAPIScimEndpoint().ID
 	require.NotEmpty(t, endpointID)
 
 	// Lookup by id (the token-embedded key) must resolve the row and its hash.
@@ -1681,7 +1684,7 @@ func testScimEndpointOperations(t *testing.T, ctx context.Context, provider Prov
 	// Lookup by org (admin surface) must resolve the same endpoint.
 	byOrg, err := provider.GetScimEndpointByOrgID(ctx, orgID)
 	require.NoError(t, err)
-	assert.Equal(t, endpointID, byOrg.ID)
+	assert.Equal(t, endpointID, byOrg.AsAPIScimEndpoint().ID)
 
 	// The secret must never serialize out (json:"-").
 	blob, err := json.Marshal(byID)

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -20,6 +20,7 @@ type CollectionList struct {
 	TrustedIssuer          string
 	Organization           string
 	OrgMembership          string
+	ScimEndpoint           string
 }
 
 var (
@@ -45,5 +46,6 @@ var (
 		TrustedIssuer:          Prefix + "trusted_issuers",
 		Organization:           Prefix + "organizations",
 		OrgMembership:          Prefix + "org_memberships",
+		ScimEndpoint:           Prefix + "scim_endpoints",
 	}
 )

--- a/internal/storage/schemas/scim_endpoint.go
+++ b/internal/storage/schemas/scim_endpoint.go
@@ -1,0 +1,64 @@
+package schemas
+
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// ScimEndpoint is the per-organization inbound SCIM 2.0 connection credential.
+// A customer's IdP (Okta, Entra, …) authenticates to /scim/v2/ with a bearer
+// token; the org it may provision is derived ONLY from the matched endpoint
+// (design §4.4 H6 — never from the URL or payload).
+//
+// Authentication:
+//   - The presented bearer token is "<endpointID>.<hexSecret>". The endpointID
+//     selects this row; the secret is verified (constant-time bcrypt) against
+//     TokenHash. The plaintext is revealed ONCE at create and ONCE at rotate.
+//
+// One endpoint per org: OrgID is unique.
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type ScimEndpoint struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID is the organization this SCIM endpoint provisions into. Unique:
+	// one SCIM endpoint per org.
+	OrgID string `gorm:"uniqueIndex" json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" index:"org_id,hash"`
+
+	// TokenHash is the bcrypt hash of the endpoint's bearer-token secret.
+	// json:"-" keeps it out of any json.Marshal (structured logging, webhook
+	// payloads, error dumps), matching User.Password / Client.ClientSecret.
+	TokenHash string `json:"-" bson:"token_hash" cql:"token_hash" dynamo:"token_hash"`
+
+	// Enabled gates whether the endpoint accepts requests. Disabling it stops
+	// provisioning without deleting the row (rotate/re-enable later).
+	//
+	// GORM NOTE: gorm:"default:true" means Create with Enabled=false persists as
+	// true (Go zero-value triggers the column default). The service layer always
+	// sets Enabled explicitly and uses Save when creating a disabled endpoint.
+	Enabled bool `gorm:"default:true" json:"enabled" bson:"enabled" cql:"enabled" dynamo:"enabled"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPIScimEndpoint converts the storage record into the GraphQL model. The
+// token secret is never included — it is revealed only at create/rotate.
+func (s *ScimEndpoint) AsAPIScimEndpoint() *model.ScimEndpoint {
+	id := s.ID
+	if strings.Contains(id, Collections.ScimEndpoint+"/") {
+		id = strings.TrimPrefix(id, Collections.ScimEndpoint+"/")
+	}
+	return &model.ScimEndpoint{
+		ID:        id,
+		OrgID:     s.OrgID,
+		Enabled:   s.Enabled,
+		CreatedAt: refs.NewInt64Ref(s.CreatedAt),
+		UpdatedAt: refs.NewInt64Ref(s.UpdatedAt),
+	}
+}

--- a/internal/storage/schemas/user.go
+++ b/internal/storage/schemas/user.go
@@ -37,6 +37,20 @@ type User struct {
 	UpdatedAt                int64   `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
 	CreatedAt                int64   `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	AppData                  *string `json:"app_data" bson:"app_data" cql:"app_data" dynamo:"app_data"`
+
+	// ExternalID is the stable key an external IdP (SCIM/SSO) assigns to this
+	// user. It is nullable — only IdP-provisioned users carry one. For SCIM it
+	// is namespaced per org as "<orgID>:<idpExternalId>" (see
+	// Provider.GetUserByExternalID) so one org's IdP can never resolve another
+	// org's user by external id (design §4.4 H6).
+	ExternalID *string `gorm:"index" json:"external_id" bson:"external_id" cql:"external_id" dynamo:"external_id" index:"external_id,hash"`
+
+	// IsActive controls whether the user is provisioned/active. SCIM
+	// deprovisioning (active:false / DELETE) sets this false and revokes the
+	// user's sessions. Existing rows default to true (gorm column default);
+	// the service layer always sets it explicitly so the GORM zero-value
+	// default:true quirk never silently re-activates a deprovisioned user.
+	IsActive bool `gorm:"default:true" json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active"`
 }
 
 func (user *User) AsAPIUser() *model.User {


### PR DESCRIPTION
## Summary

A per-organization **inbound SCIM 2.0 server** for user provisioning/deprovisioning (users only) — a customer's IdP (Okta/Entra) can auto-provision and deprovision users into one org via a connection-scoped bearer token. Group→role mapping is deferred (needs the FGA engine).

## SCIM feature

- **Schema**: `User.ExternalID` + `User.IsActive`; new `ScimEndpoint` (per-org, bcrypt-hashed bearer token) across all 6 providers.
- **Endpoints** (`/scim/v2/…`, own router group, SCIM error schema, CSRF-exempt, bearer-only): Users CRUD + `active:false` PATCH/DELETE→deactivate, `userName eq` filter + dedup, `/ServiceProviderConfig` `/Schemas` `/ResourceTypes`.
- **Admin**: `_`-prefixed GraphQL to create/rotate/delete an org's SCIM endpoint (one-time token reveal).

## Security (per design §4.4; security-reviewed)

- **H6 cross-org isolation** — org derived ONLY from the bearer token, never the URL/body; every by-id op re-checks org membership; externalId dedup is org-scoped (composite `<orgID>:<externalID>` key across all 6 providers). Verified: Org A's token cannot read/mutate an Org B user.
- **Deprovision revokes sessions** — `active:false`/DELETE stamps `RevokedTimestamp` + synchronously drops sessions + refresh tokens.
- **Bearer token** — 256-bit crypto/rand, bcrypt-12 at rest (`json:"-"`), constant-time compare, dummy-compare on unknown id, one-time reveal.

## Pre-existing bugs this PR also fixes (all surfaced by `test-all-db` + the security review — SQLite-only CI never hit them)

1. **Couchbase deprovision was a silent no-op** — the couchbase user SELECT omitted the new `is_active`/`external_id` columns, so `IsActive` always read `false` and the revoke path early-returned. **Fixed** (added to all couchbase user projections). Would have let a deprovisioned user keep working on couchbase.
2. **App-wide Redis session revocation was a no-op** — `DeleteAllUserSessions` scanned `"<userID>:*"` but keys are `<loginMethod>:<userID>:<…>`, so the glob never matched. `revoke`, admin session-revoke, and SCIM deprovision all silently failed on Redis, and refresh tokens renewed indefinitely. **Fixed** (colon-bounded `*:<userID>:*` scan) + defense-in-depth: the refresh grant now rejects a user with `RevokedTimestamp != nil`, and introspection is now revocation-aware for first-party tokens.
3. **Cassandra/ScyllaDB org-membership async-index race** — `GetOrgMembership` read via an async secondary index and missed just-inserted members (silent duplicate memberships). **Fixed** at the root: memberships key on a deterministic `(org,user)` UUID and read by primary key (synchronous), making duplicate-rejection atomic.

## Testing

- **`make test-all-db` green across all 7 databases** (independently re-run); `TEST_DBS=sqlite` storage/service/handlers/memory_store/integration green; H1 validated against real Redis (`TEST_ENABLE_REDIS=1`).
- Security review: the two blocking findings (couchbase no-op, Redis no-op) are fixed; H6 isolation and deprovision-revocation verified.
- `go build`/`vet`/`gofmt`/`make lint-go` clean; no codegen drift.

## Deferred (ponytail-noted)

SCIM Groups→org-namespaced FGA roles (needs FGA engine + org-admin model), ETag/versioning, pagination cursors. Cross-org email-existence 409 documented as accepted risk (global email uniqueness; leaks existence only).
