### PR TITLE
feat(sso): per-org OIDC SSO federation + TrustedIssuer kind discriminator (CR1 fix)

### DIFF
--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -33,6 +33,8 @@ const (
 	AuditResourceTypeServiceAccount = "service_account"
 	// AuditResourceTypeTrustedIssuer represents a trusted external JWT issuer.
 	AuditResourceTypeTrustedIssuer = "trusted_issuer"
+	// AuditResourceTypeOrgOIDCConnection represents a per-org upstream OIDC IdP.
+	AuditResourceTypeOrgOIDCConnection = "org_oidc_connection"
 	// AuditResourceTypeOrganization represents an organization entity.
 	AuditResourceTypeOrganization = "organization"
 	// AuditResourceTypeOrgMembership represents an org membership entity.
@@ -125,6 +127,12 @@ const (
 	AuditOAuthCallbackSuccessEvent = "oauth.callback_success"
 	// AuditOAuthCallbackFailedEvent is logged when an OAuth callback fails.
 	AuditOAuthCallbackFailedEvent = "oauth.callback_failed"
+	// AuditSSOLoginInitiatedEvent is logged when an org OIDC SSO login is started.
+	AuditSSOLoginInitiatedEvent = "sso.login_initiated"
+	// AuditSSOCallbackSuccessEvent is logged when an org OIDC SSO callback succeeds.
+	AuditSSOCallbackSuccessEvent = "sso.callback_success"
+	// AuditSSOCallbackFailedEvent is logged when an org OIDC SSO callback fails.
+	AuditSSOCallbackFailedEvent = "sso.callback_failed"
 
 	// AuditTokenIssuedEvent is logged when a new token is issued.
 	AuditTokenIssuedEvent = "token.issued"
@@ -153,6 +161,12 @@ const (
 	// AuditClientActivatedEvent is logged when an admin re-enables a client.
 	AuditClientActivatedEvent = "admin.client_activated"
 
+	// AuditOrgOIDCConnectionCreatedEvent is logged when an admin creates an org OIDC connection.
+	AuditOrgOIDCConnectionCreatedEvent = "admin.org_oidc_connection_created"
+	// AuditOrgOIDCConnectionUpdatedEvent is logged when an admin updates an org OIDC connection.
+	AuditOrgOIDCConnectionUpdatedEvent = "admin.org_oidc_connection_updated"
+	// AuditOrgOIDCConnectionDeletedEvent is logged when an admin deletes an org OIDC connection.
+	AuditOrgOIDCConnectionDeletedEvent = "admin.org_oidc_connection_deleted"
 	// AuditTrustedIssuerCreatedEvent is logged when an admin adds a trusted issuer.
 	AuditTrustedIssuerCreatedEvent = "admin.trusted_issuer_created"
 	// AuditTrustedIssuerUpdatedEvent is logged when an admin updates a trusted issuer.

--- a/internal/constants/auth_methods.go
+++ b/internal/constants/auth_methods.go
@@ -30,6 +30,10 @@ const (
 	AuthRecipeMethodTwitch = "twitch"
 	// AuthRecipeMethodRoblox is the roblox auth method
 	AuthRecipeMethodRoblox = "roblox"
+	// AuthRecipeMethodSSO is the login_method stamped on sessions established via
+	// a per-org OIDC SSO broker flow. It namespaces the memory-store session key
+	// ("sso:<user_id>") the same way the social recipes do.
+	AuthRecipeMethodSSO = "sso"
 
 	// AuthRecipeMethodServiceAccount is the login_method stamped on machine
 	// access tokens issued via the client_credentials grant (RFC 6749 §4.4).

--- a/internal/constants/trusted_issuer_kind.go
+++ b/internal/constants/trusted_issuer_kind.go
@@ -1,0 +1,27 @@
+package constants
+
+// TrustedIssuer.Kind discriminator values (design §4.3 / §5 K1). Immutable after
+// creation. The unified authorizer_trusted_issuers table serves two distinct
+// trust relationships that MUST NOT be confused (design §5.2 CR1):
+//
+//   - client_assertion_trust: an external JWT issuer whose tokens authenticate an
+//     OAuth *client* (RFC 7523 client_assertion). Subject-pinned, org-global.
+//   - sso_oidc: a per-organization upstream OIDC IdP that Authorizer brokers as a
+//     Relying Party. Org-scoped (OrgID set), NO subject pin — it federates end
+//     users, it can never authenticate a client.
+//   - sso_saml: reserved for the SAML Service Provider (separate PR).
+const (
+	// TrustKindClientAssertion is the default kind. Every pre-existing row (which
+	// may have no kind column value) is treated as this kind on read
+	// (TrustedIssuer.EffectiveKind), so an upgrade never breaks existing
+	// client_assertion trust rows.
+	TrustKindClientAssertion = "client_assertion_trust"
+
+	// TrustKindSSOOIDC is a per-org upstream OIDC IdP brokered by Authorizer.
+	TrustKindSSOOIDC = "sso_oidc"
+
+	// TrustKindSSOSAML is reserved for the per-org SAML SP connection.
+	// ponytail: reserved only — SAML SP (signature-wrapping/XSW validation) ships
+	// in its own PR so it gets a focused security review.
+	TrustKindSSOSAML = "sso_saml"
+)

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -274,54 +274,57 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddEmailTemplate    func(childComplexity int, params model.AddEmailTemplateRequest) int
-		AddOrgMember        func(childComplexity int, params model.AddOrgMemberRequest) int
-		AddTrustedIssuer    func(childComplexity int, params model.AddTrustedIssuerRequest) int
-		AddWebhook          func(childComplexity int, params model.AddWebhookRequest) int
-		AdminLogin          func(childComplexity int, params model.AdminLoginRequest) int
-		AdminLogout         func(childComplexity int) int
-		AdminSignup         func(childComplexity int, params model.AdminSignupRequest) int
-		CreateClient        func(childComplexity int, params model.CreateClientRequest) int
-		CreateOrganization  func(childComplexity int, params model.CreateOrganizationRequest) int
-		DeactivateAccount   func(childComplexity int) int
-		DeleteClient        func(childComplexity int, params model.ClientRequest) int
-		DeleteEmailTemplate func(childComplexity int, params model.DeleteEmailTemplateRequest) int
-		DeleteOrganization  func(childComplexity int, params model.OrganizationRequest) int
-		DeleteTrustedIssuer func(childComplexity int, params model.TrustedIssuerRequest) int
-		DeleteUser          func(childComplexity int, params model.DeleteUserRequest) int
-		DeleteWebhook       func(childComplexity int, params model.WebhookRequest) int
-		EnableAccess        func(childComplexity int, param model.UpdateAccessRequest) int
-		FgaDeleteTuples     func(childComplexity int, params model.FgaWriteTuplesInput) int
-		FgaReset            func(childComplexity int) int
-		FgaWriteModel       func(childComplexity int, params model.FgaWriteModelInput) int
-		FgaWriteTuples      func(childComplexity int, params model.FgaWriteTuplesInput) int
-		ForgotPassword      func(childComplexity int, params model.ForgotPasswordRequest) int
-		GenerateJwtKeys     func(childComplexity int, params model.GenerateJWTKeysRequest) int
-		InviteMembers       func(childComplexity int, params model.InviteMemberRequest) int
-		Login               func(childComplexity int, params model.LoginRequest) int
-		Logout              func(childComplexity int) int
-		MagicLinkLogin      func(childComplexity int, params model.MagicLinkLoginRequest) int
-		MobileLogin         func(childComplexity int, params model.MobileLoginRequest) int
-		MobileSignup        func(childComplexity int, params *model.MobileSignUpRequest) int
-		RemoveOrgMember     func(childComplexity int, params model.RemoveOrgMemberRequest) int
-		ResendOtp           func(childComplexity int, params model.ResendOTPRequest) int
-		ResendVerifyEmail   func(childComplexity int, params model.ResendVerifyEmailRequest) int
-		ResetPassword       func(childComplexity int, params model.ResetPasswordRequest) int
-		Revoke              func(childComplexity int, params model.OAuthRevokeRequest) int
-		RevokeAccess        func(childComplexity int, param model.UpdateAccessRequest) int
-		RotateClientSecret  func(childComplexity int, params model.ClientRequest) int
-		Signup              func(childComplexity int, params model.SignUpRequest) int
-		TestEndpoint        func(childComplexity int, params model.TestEndpointRequest) int
-		UpdateClient        func(childComplexity int, params model.UpdateClientRequest) int
-		UpdateEmailTemplate func(childComplexity int, params model.UpdateEmailTemplateRequest) int
-		UpdateEnv           func(childComplexity int, params model.UpdateEnvRequest) int
-		UpdateOrganization  func(childComplexity int, params model.UpdateOrganizationRequest) int
-		UpdateProfile       func(childComplexity int, params model.UpdateProfileRequest) int
-		UpdateTrustedIssuer func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
-		UpdateUser          func(childComplexity int, params model.UpdateUserRequest) int
-		UpdateWebhook       func(childComplexity int, params model.UpdateWebhookRequest) int
-		VerifyEmail         func(childComplexity int, params model.VerifyEmailRequest) int
-		VerifyOtp           func(childComplexity int, params model.VerifyOTPRequest) int
+		AddEmailTemplate        func(childComplexity int, params model.AddEmailTemplateRequest) int
+		AddOrgMember            func(childComplexity int, params model.AddOrgMemberRequest) int
+		AddTrustedIssuer        func(childComplexity int, params model.AddTrustedIssuerRequest) int
+		AddWebhook              func(childComplexity int, params model.AddWebhookRequest) int
+		AdminLogin              func(childComplexity int, params model.AdminLoginRequest) int
+		AdminLogout             func(childComplexity int) int
+		AdminSignup             func(childComplexity int, params model.AdminSignupRequest) int
+		CreateClient            func(childComplexity int, params model.CreateClientRequest) int
+		CreateOrgOidcConnection func(childComplexity int, params model.CreateOrgOIDCConnectionRequest) int
+		CreateOrganization      func(childComplexity int, params model.CreateOrganizationRequest) int
+		DeactivateAccount       func(childComplexity int) int
+		DeleteClient            func(childComplexity int, params model.ClientRequest) int
+		DeleteEmailTemplate     func(childComplexity int, params model.DeleteEmailTemplateRequest) int
+		DeleteOrgOidcConnection func(childComplexity int, params model.OrgOIDCConnectionRequest) int
+		DeleteOrganization      func(childComplexity int, params model.OrganizationRequest) int
+		DeleteTrustedIssuer     func(childComplexity int, params model.TrustedIssuerRequest) int
+		DeleteUser              func(childComplexity int, params model.DeleteUserRequest) int
+		DeleteWebhook           func(childComplexity int, params model.WebhookRequest) int
+		EnableAccess            func(childComplexity int, param model.UpdateAccessRequest) int
+		FgaDeleteTuples         func(childComplexity int, params model.FgaWriteTuplesInput) int
+		FgaReset                func(childComplexity int) int
+		FgaWriteModel           func(childComplexity int, params model.FgaWriteModelInput) int
+		FgaWriteTuples          func(childComplexity int, params model.FgaWriteTuplesInput) int
+		ForgotPassword          func(childComplexity int, params model.ForgotPasswordRequest) int
+		GenerateJwtKeys         func(childComplexity int, params model.GenerateJWTKeysRequest) int
+		InviteMembers           func(childComplexity int, params model.InviteMemberRequest) int
+		Login                   func(childComplexity int, params model.LoginRequest) int
+		Logout                  func(childComplexity int) int
+		MagicLinkLogin          func(childComplexity int, params model.MagicLinkLoginRequest) int
+		MobileLogin             func(childComplexity int, params model.MobileLoginRequest) int
+		MobileSignup            func(childComplexity int, params *model.MobileSignUpRequest) int
+		RemoveOrgMember         func(childComplexity int, params model.RemoveOrgMemberRequest) int
+		ResendOtp               func(childComplexity int, params model.ResendOTPRequest) int
+		ResendVerifyEmail       func(childComplexity int, params model.ResendVerifyEmailRequest) int
+		ResetPassword           func(childComplexity int, params model.ResetPasswordRequest) int
+		Revoke                  func(childComplexity int, params model.OAuthRevokeRequest) int
+		RevokeAccess            func(childComplexity int, param model.UpdateAccessRequest) int
+		RotateClientSecret      func(childComplexity int, params model.ClientRequest) int
+		Signup                  func(childComplexity int, params model.SignUpRequest) int
+		TestEndpoint            func(childComplexity int, params model.TestEndpointRequest) int
+		UpdateClient            func(childComplexity int, params model.UpdateClientRequest) int
+		UpdateEmailTemplate     func(childComplexity int, params model.UpdateEmailTemplateRequest) int
+		UpdateEnv               func(childComplexity int, params model.UpdateEnvRequest) int
+		UpdateOrgOidcConnection func(childComplexity int, params model.UpdateOrgOIDCConnectionRequest) int
+		UpdateOrganization      func(childComplexity int, params model.UpdateOrganizationRequest) int
+		UpdateProfile           func(childComplexity int, params model.UpdateProfileRequest) int
+		UpdateTrustedIssuer     func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
+		UpdateUser              func(childComplexity int, params model.UpdateUserRequest) int
+		UpdateWebhook           func(childComplexity int, params model.UpdateWebhookRequest) int
+		VerifyEmail             func(childComplexity int, params model.VerifyEmailRequest) int
+		VerifyOtp               func(childComplexity int, params model.VerifyOTPRequest) int
 	}
 
 	OrgMember struct {
@@ -336,6 +339,19 @@ type ComplexityRoot struct {
 	OrgMembers struct {
 		OrgMembers func(childComplexity int) int
 		Pagination func(childComplexity int) int
+	}
+
+	OrgOIDCConnection struct {
+		CreatedAt   func(childComplexity int) int
+		ID          func(childComplexity int) int
+		IsActive    func(childComplexity int) int
+		IssuerURL   func(childComplexity int) int
+		Name        func(childComplexity int) int
+		OrgID       func(childComplexity int) int
+		RedirectURI func(childComplexity int) int
+		Scopes      func(childComplexity int) int
+		SsoClientID func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
 	}
 
 	Organization struct {
@@ -386,6 +402,7 @@ type ComplexityRoot struct {
 		ListPermissions      func(childComplexity int, params model.ListPermissionsInput) int
 		Meta                 func(childComplexity int) int
 		OrgMembers           func(childComplexity int, params model.ListOrgMembersRequest) int
+		OrgOidcConnection    func(childComplexity int, params model.OrgOIDCConnectionRequest) int
 		Organization         func(childComplexity int, params model.OrganizationRequest) int
 		Organizations        func(childComplexity int, params *model.ListOrganizationsRequest) int
 		Profile              func(childComplexity int) int
@@ -556,6 +573,9 @@ type MutationResolver interface {
 	AddTrustedIssuer(ctx context.Context, params model.AddTrustedIssuerRequest) (*model.TrustedIssuer, error)
 	UpdateTrustedIssuer(ctx context.Context, params model.UpdateTrustedIssuerRequest) (*model.TrustedIssuer, error)
 	DeleteTrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.Response, error)
+	CreateOrgOidcConnection(ctx context.Context, params model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	UpdateOrgOidcConnection(ctx context.Context, params model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	DeleteOrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.Response, error)
 	CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error)
 	UpdateOrganization(ctx context.Context, params model.UpdateOrganizationRequest) (*model.Organization, error)
 	DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error)
@@ -589,6 +609,7 @@ type QueryResolver interface {
 	Clients(ctx context.Context, params *model.ListClientsRequest) (*model.Clients, error)
 	TrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.TrustedIssuer, error)
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
+	OrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
 	Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error)
 	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
 	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
@@ -1839,6 +1860,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateClient(childComplexity, args["params"].(model.CreateClientRequest)), true
 
+	case "Mutation._create_org_oidc_connection":
+		if e.complexity.Mutation.CreateOrgOidcConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_org_oidc_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateOrgOidcConnection(childComplexity, args["params"].(model.CreateOrgOIDCConnectionRequest)), true
+
 	case "Mutation._create_organization":
 		if e.complexity.Mutation.CreateOrganization == nil {
 			break
@@ -1881,6 +1914,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteEmailTemplate(childComplexity, args["params"].(model.DeleteEmailTemplateRequest)), true
+
+	case "Mutation._delete_org_oidc_connection":
+		if e.complexity.Mutation.DeleteOrgOidcConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_org_oidc_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteOrgOidcConnection(childComplexity, args["params"].(model.OrgOIDCConnectionRequest)), true
 
 	case "Mutation._delete_organization":
 		if e.complexity.Mutation.DeleteOrganization == nil {
@@ -2220,6 +2265,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateEnv(childComplexity, args["params"].(model.UpdateEnvRequest)), true
 
+	case "Mutation._update_org_oidc_connection":
+		if e.complexity.Mutation.UpdateOrgOidcConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_org_oidc_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateOrgOidcConnection(childComplexity, args["params"].(model.UpdateOrgOIDCConnectionRequest)), true
+
 	case "Mutation._update_organization":
 		if e.complexity.Mutation.UpdateOrganization == nil {
 			break
@@ -2359,6 +2416,76 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.OrgMembers.Pagination(childComplexity), true
+
+	case "OrgOIDCConnection.created_at":
+		if e.complexity.OrgOIDCConnection.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.CreatedAt(childComplexity), true
+
+	case "OrgOIDCConnection.id":
+		if e.complexity.OrgOIDCConnection.ID == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.ID(childComplexity), true
+
+	case "OrgOIDCConnection.is_active":
+		if e.complexity.OrgOIDCConnection.IsActive == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.IsActive(childComplexity), true
+
+	case "OrgOIDCConnection.issuer_url":
+		if e.complexity.OrgOIDCConnection.IssuerURL == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.IssuerURL(childComplexity), true
+
+	case "OrgOIDCConnection.name":
+		if e.complexity.OrgOIDCConnection.Name == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.Name(childComplexity), true
+
+	case "OrgOIDCConnection.org_id":
+		if e.complexity.OrgOIDCConnection.OrgID == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.OrgID(childComplexity), true
+
+	case "OrgOIDCConnection.redirect_uri":
+		if e.complexity.OrgOIDCConnection.RedirectURI == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.RedirectURI(childComplexity), true
+
+	case "OrgOIDCConnection.scopes":
+		if e.complexity.OrgOIDCConnection.Scopes == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.Scopes(childComplexity), true
+
+	case "OrgOIDCConnection.sso_client_id":
+		if e.complexity.OrgOIDCConnection.SsoClientID == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.SsoClientID(childComplexity), true
+
+	case "OrgOIDCConnection.updated_at":
+		if e.complexity.OrgOIDCConnection.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgOIDCConnection.UpdatedAt(childComplexity), true
 
 	case "Organization.created_at":
 		if e.complexity.Organization.CreatedAt == nil {
@@ -2633,6 +2760,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.OrgMembers(childComplexity, args["params"].(model.ListOrgMembersRequest)), true
+
+	case "Query._org_oidc_connection":
+		if e.complexity.Query.OrgOidcConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Query__org_oidc_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OrgOidcConnection(childComplexity, args["params"].(model.OrgOIDCConnectionRequest)), true
 
 	case "Query._organization":
 		if e.complexity.Query.Organization == nil {
@@ -3339,6 +3478,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCheckPermissionsInput,
 		ec.unmarshalInputClientRequest,
 		ec.unmarshalInputCreateClientRequest,
+		ec.unmarshalInputCreateOrgOIDCConnectionRequest,
 		ec.unmarshalInputCreateOrganizationRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
 		ec.unmarshalInputDeleteUserRequest,
@@ -3365,6 +3505,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMobileLoginRequest,
 		ec.unmarshalInputMobileSignUpRequest,
 		ec.unmarshalInputOAuthRevokeRequest,
+		ec.unmarshalInputOrgOIDCConnectionRequest,
 		ec.unmarshalInputOrganizationRequest,
 		ec.unmarshalInputPaginatedRequest,
 		ec.unmarshalInputPaginationRequest,
@@ -3381,6 +3522,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateClientRequest,
 		ec.unmarshalInputUpdateEmailTemplateRequest,
 		ec.unmarshalInputUpdateEnvRequest,
+		ec.unmarshalInputUpdateOrgOIDCConnectionRequest,
 		ec.unmarshalInputUpdateOrganizationRequest,
 		ec.unmarshalInputUpdateProfileRequest,
 		ec.unmarshalInputUpdateTrustedIssuerRequest,
@@ -3835,6 +3977,22 @@ type TrustedIssuer {
 type TrustedIssuers {
   pagination: Pagination!
   trusted_issuers: [TrustedIssuer!]!
+}
+
+# OrgOIDCConnection is a per-organization upstream OIDC IdP that Authorizer
+# brokers as a Relying Party. The upstream client_secret is NEVER projected here.
+type OrgOIDCConnection {
+  id: ID!
+  org_id: String!
+  name: String!
+  issuer_url: String!
+  # sso_client_id: the client_id Authorizer uses AT the upstream IdP.
+  sso_client_id: String!
+  scopes: String
+  redirect_uri: String
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
 }
 
 type Organization {
@@ -4297,6 +4455,40 @@ input ListTrustedIssuersRequest {
   pagination: PaginatedRequest
 }
 
+input CreateOrgOIDCConnectionRequest {
+  org_id: String!
+  name: String!
+  # issuer_url: the upstream IdP issuer (its OIDC discovery base).
+  issuer_url: String!
+  # client_id / client_secret: the credentials Authorizer holds AT the upstream
+  # IdP. The secret is stored encrypted and never returned.
+  client_id: String!
+  client_secret: String!
+  # scopes: space-separated. Defaults to "openid profile email" when omitted.
+  scopes: String
+  # redirect_uri registered at the upstream IdP. Derived from the request host
+  # when omitted.
+  redirect_uri: String
+}
+
+input UpdateOrgOIDCConnectionRequest {
+  id: ID!
+  name: String
+  issuer_url: String
+  client_id: String
+  # Supplying client_secret rotates it; omitting leaves the stored secret intact.
+  client_secret: String
+  scopes: String
+  redirect_uri: String
+  is_active: Boolean
+}
+
+input OrgOIDCConnectionRequest {
+  # Look up by connection id OR by org_id (supply exactly one).
+  id: ID
+  org_id: String
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -4519,6 +4711,10 @@ type Mutation {
   _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
   _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
   _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
+  # Per-organization SSO OIDC connections (Authorizer as Relying Party)
+  _create_org_oidc_connection(params: CreateOrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _update_org_oidc_connection(params: UpdateOrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _delete_org_oidc_connection(params: OrgOIDCConnectionRequest!): Response!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -4561,6 +4757,7 @@ type Query {
   # Trusted issuers
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
+  _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!
@@ -4780,6 +4977,34 @@ func (ec *executionContext) field_Mutation__create_client_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_org_oidc_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_org_oidc_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_org_oidc_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateOrgOIDCConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateOrgOIDCConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrgOIDCConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateOrgOIDCConnectionRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__create_organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -4861,6 +5086,34 @@ func (ec *executionContext) field_Mutation__delete_email_template_argsParams(
 	}
 
 	var zeroVal model.DeleteEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_org_oidc_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_org_oidc_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_org_oidc_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrgOIDCConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrgOIDCConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrgOIDCConnectionRequest
 	return zeroVal, nil
 }
 
@@ -5337,6 +5590,34 @@ func (ec *executionContext) field_Mutation__update_env_argsParams(
 	}
 
 	var zeroVal model.UpdateEnvRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_org_oidc_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_org_oidc_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_org_oidc_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateOrgOIDCConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateOrgOIDCConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrgOIDCConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateOrgOIDCConnectionRequest
 	return zeroVal, nil
 }
 
@@ -6065,6 +6346,34 @@ func (ec *executionContext) field_Query__org_members_argsParams(
 	}
 
 	var zeroVal model.ListOrgMembersRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__org_oidc_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__org_oidc_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__org_oidc_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrgOIDCConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrgOIDCConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrgOIDCConnectionRequest
 	return zeroVal, nil
 }
 
@@ -15923,6 +16232,219 @@ func (ec *executionContext) fieldContext_Mutation__delete_trusted_issuer(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_org_oidc_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrgOidcConnection(rctx, fc.Args["params"].(model.CreateOrgOIDCConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgOIDCConnection)
+	fc.Result = res
+	return ec.marshalNOrgOIDCConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgOIDCConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgOIDCConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgOIDCConnection_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_OrgOIDCConnection_issuer_url(ctx, field)
+			case "sso_client_id":
+				return ec.fieldContext_OrgOIDCConnection_sso_client_id(ctx, field)
+			case "scopes":
+				return ec.fieldContext_OrgOIDCConnection_scopes(ctx, field)
+			case "redirect_uri":
+				return ec.fieldContext_OrgOIDCConnection_redirect_uri(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgOIDCConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgOIDCConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgOIDCConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgOIDCConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_org_oidc_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_org_oidc_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateOrgOidcConnection(rctx, fc.Args["params"].(model.UpdateOrgOIDCConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgOIDCConnection)
+	fc.Result = res
+	return ec.marshalNOrgOIDCConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgOIDCConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgOIDCConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgOIDCConnection_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_OrgOIDCConnection_issuer_url(ctx, field)
+			case "sso_client_id":
+				return ec.fieldContext_OrgOIDCConnection_sso_client_id(ctx, field)
+			case "scopes":
+				return ec.fieldContext_OrgOIDCConnection_scopes(ctx, field)
+			case "redirect_uri":
+				return ec.fieldContext_OrgOIDCConnection_redirect_uri(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgOIDCConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgOIDCConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgOIDCConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgOIDCConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_org_oidc_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_org_oidc_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteOrgOidcConnection(rctx, fc.Args["params"].(model.OrgOIDCConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_org_oidc_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_org_oidc_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__create_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__create_organization(ctx, field)
 	if err != nil {
@@ -17078,6 +17600,434 @@ func (ec *executionContext) fieldContext_OrgMembers_org_members(_ context.Contex
 				return ec.fieldContext_OrgMember_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OrgMember", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_org_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_name(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_issuer_url(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_issuer_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IssuerURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_issuer_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_sso_client_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_sso_client_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SsoClientID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_sso_client_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_scopes(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_redirect_uri(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_redirect_uri(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RedirectURI, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_redirect_uri(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_is_active(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_is_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_is_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_created_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgOIDCConnection_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgOIDCConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgOIDCConnection_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgOIDCConnection_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -19195,6 +20145,83 @@ func (ec *executionContext) fieldContext_Query__trusted_issuers(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query__trusted_issuers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__org_oidc_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__org_oidc_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().OrgOidcConnection(rctx, fc.Args["params"].(model.OrgOIDCConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgOIDCConnection)
+	fc.Result = res
+	return ec.marshalNOrgOIDCConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__org_oidc_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgOIDCConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgOIDCConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgOIDCConnection_name(ctx, field)
+			case "issuer_url":
+				return ec.fieldContext_OrgOIDCConnection_issuer_url(ctx, field)
+			case "sso_client_id":
+				return ec.fieldContext_OrgOIDCConnection_sso_client_id(ctx, field)
+			case "scopes":
+				return ec.fieldContext_OrgOIDCConnection_scopes(ctx, field)
+			case "redirect_uri":
+				return ec.fieldContext_OrgOIDCConnection_redirect_uri(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgOIDCConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgOIDCConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgOIDCConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgOIDCConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__org_oidc_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -25723,6 +26750,75 @@ func (ec *executionContext) unmarshalInputCreateClientRequest(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateOrgOIDCConnectionRequest(ctx context.Context, obj any) (model.CreateOrgOIDCConnectionRequest, error) {
+	var it model.CreateOrgOIDCConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "name", "issuer_url", "client_id", "client_secret", "scopes", "redirect_uri"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "issuer_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issuer_url"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IssuerURL = data
+		case "client_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClientID = data
+		case "client_secret":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_secret"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClientSecret = data
+		case "scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scopes = data
+		case "redirect_uri":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("redirect_uri"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RedirectURI = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateOrganizationRequest(ctx context.Context, obj any) (model.CreateOrganizationRequest, error) {
 	var it model.CreateOrganizationRequest
 	asMap := map[string]any{}
@@ -26811,6 +27907,40 @@ func (ec *executionContext) unmarshalInputOAuthRevokeRequest(ctx context.Context
 				return it, err
 			}
 			it.RefreshToken = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputOrgOIDCConnectionRequest(ctx context.Context, obj any) (model.OrgOIDCConnectionRequest, error) {
+	var it model.OrgOIDCConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
 		}
 	}
 
@@ -27964,6 +29094,82 @@ func (ec *executionContext) unmarshalInputUpdateEnvRequest(ctx context.Context, 
 				return it, err
 			}
 			it.DisableTotpLogin = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateOrgOIDCConnectionRequest(ctx context.Context, obj any) (model.UpdateOrgOIDCConnectionRequest, error) {
+	var it model.UpdateOrgOIDCConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "issuer_url", "client_id", "client_secret", "scopes", "redirect_uri", "is_active"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "issuer_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issuer_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IssuerURL = data
+		case "client_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClientID = data
+		case "client_secret":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_secret"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClientSecret = data
+		case "scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scopes = data
+		case "redirect_uri":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("redirect_uri"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RedirectURI = data
+		case "is_active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsActive = data
 		}
 	}
 
@@ -30167,6 +31373,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_org_oidc_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_org_oidc_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_org_oidc_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_org_oidc_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_org_oidc_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_org_oidc_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_create_organization":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__create_organization(ctx, field)
@@ -30360,6 +31587,78 @@ func (ec *executionContext) _OrgMembers(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgOIDCConnectionImplementors = []string{"OrgOIDCConnection"}
+
+func (ec *executionContext) _OrgOIDCConnection(ctx context.Context, sel ast.SelectionSet, obj *model.OrgOIDCConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgOIDCConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgOIDCConnection")
+		case "id":
+			out.Values[i] = ec._OrgOIDCConnection_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._OrgOIDCConnection_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._OrgOIDCConnection_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "issuer_url":
+			out.Values[i] = ec._OrgOIDCConnection_issuer_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sso_client_id":
+			out.Values[i] = ec._OrgOIDCConnection_sso_client_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "scopes":
+			out.Values[i] = ec._OrgOIDCConnection_scopes(ctx, field, obj)
+		case "redirect_uri":
+			out.Values[i] = ec._OrgOIDCConnection_redirect_uri(ctx, field, obj)
+		case "is_active":
+			out.Values[i] = ec._OrgOIDCConnection_is_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._OrgOIDCConnection_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._OrgOIDCConnection_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -31032,6 +32331,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query__trusted_issuers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_org_oidc_connection":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__org_oidc_connection(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -32628,6 +33949,11 @@ func (ec *executionContext) marshalNCreateClientResponse2ᚖgithubᚗcomᚋautho
 	return ec._CreateClientResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrgOIDCConnectionRequest(ctx context.Context, v any) (model.CreateOrgOIDCConnectionRequest, error) {
+	res, err := ec.unmarshalInputCreateOrgOIDCConnectionRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrganizationRequest(ctx context.Context, v any) (model.CreateOrganizationRequest, error) {
 	res, err := ec.unmarshalInputCreateOrganizationRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -33109,6 +34435,25 @@ func (ec *executionContext) marshalNOrgMembers2ᚖgithubᚗcomᚋauthorizerdev�
 	return ec._OrgMembers(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNOrgOIDCConnection2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnection(ctx context.Context, sel ast.SelectionSet, v model.OrgOIDCConnection) graphql.Marshaler {
+	return ec._OrgOIDCConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgOIDCConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnection(ctx context.Context, sel ast.SelectionSet, v *model.OrgOIDCConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgOIDCConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgOIDCConnectionRequest(ctx context.Context, v any) (model.OrgOIDCConnectionRequest, error) {
+	res, err := ec.unmarshalInputOrgOIDCConnectionRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNOrganization2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx context.Context, sel ast.SelectionSet, v model.Organization) graphql.Marshaler {
 	return ec._Organization(ctx, sel, &v)
 }
@@ -33522,6 +34867,11 @@ func (ec *executionContext) unmarshalNUpdateEmailTemplateRequest2githubᚗcomᚋ
 
 func (ec *executionContext) unmarshalNUpdateEnvRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateEnvRequest(ctx context.Context, v any) (model.UpdateEnvRequest, error) {
 	res, err := ec.unmarshalInputUpdateEnvRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrgOIDCConnectionRequest(ctx context.Context, v any) (model.UpdateOrgOIDCConnectionRequest, error) {
+	res, err := ec.unmarshalInputUpdateOrgOIDCConnectionRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -123,6 +123,16 @@ type CreateClientResponse struct {
 	ClientSecret string  `json:"client_secret"`
 }
 
+type CreateOrgOIDCConnectionRequest struct {
+	OrgID        string  `json:"org_id"`
+	Name         string  `json:"name"`
+	IssuerURL    string  `json:"issuer_url"`
+	ClientID     string  `json:"client_id"`
+	ClientSecret string  `json:"client_secret"`
+	Scopes       *string `json:"scopes,omitempty"`
+	RedirectURI  *string `json:"redirect_uri,omitempty"`
+}
+
 type CreateOrganizationRequest struct {
 	Name        string  `json:"name"`
 	DisplayName *string `json:"display_name,omitempty"`
@@ -463,6 +473,24 @@ type OrgMembers struct {
 	OrgMembers []*OrgMember `json:"org_members"`
 }
 
+type OrgOIDCConnection struct {
+	ID          string  `json:"id"`
+	OrgID       string  `json:"org_id"`
+	Name        string  `json:"name"`
+	IssuerURL   string  `json:"issuer_url"`
+	SsoClientID string  `json:"sso_client_id"`
+	Scopes      *string `json:"scopes,omitempty"`
+	RedirectURI *string `json:"redirect_uri,omitempty"`
+	IsActive    bool    `json:"is_active"`
+	CreatedAt   *int64  `json:"created_at,omitempty"`
+	UpdatedAt   *int64  `json:"updated_at,omitempty"`
+}
+
+type OrgOIDCConnectionRequest struct {
+	ID    *string `json:"id,omitempty"`
+	OrgID *string `json:"org_id,omitempty"`
+}
+
 type Organization struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name"`
@@ -694,6 +722,17 @@ type UpdateEnvRequest struct {
 	DisablePlayground                *bool    `json:"DISABLE_PLAYGROUND,omitempty"`
 	DisableMailOtpLogin              *bool    `json:"DISABLE_MAIL_OTP_LOGIN,omitempty"`
 	DisableTotpLogin                 *bool    `json:"DISABLE_TOTP_LOGIN,omitempty"`
+}
+
+type UpdateOrgOIDCConnectionRequest struct {
+	ID           string  `json:"id"`
+	Name         *string `json:"name,omitempty"`
+	IssuerURL    *string `json:"issuer_url,omitempty"`
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+	Scopes       *string `json:"scopes,omitempty"`
+	RedirectURI  *string `json:"redirect_uri,omitempty"`
+	IsActive     *bool   `json:"is_active,omitempty"`
 }
 
 type UpdateOrganizationRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -347,6 +347,22 @@ type TrustedIssuers {
   trusted_issuers: [TrustedIssuer!]!
 }
 
+# OrgOIDCConnection is a per-organization upstream OIDC IdP that Authorizer
+# brokers as a Relying Party. The upstream client_secret is NEVER projected here.
+type OrgOIDCConnection {
+  id: ID!
+  org_id: String!
+  name: String!
+  issuer_url: String!
+  # sso_client_id: the client_id Authorizer uses AT the upstream IdP.
+  sso_client_id: String!
+  scopes: String
+  redirect_uri: String
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
 type Organization {
   id: ID!
   # name is a unique, URL-safe slug identifying the organization.
@@ -807,6 +823,40 @@ input ListTrustedIssuersRequest {
   pagination: PaginatedRequest
 }
 
+input CreateOrgOIDCConnectionRequest {
+  org_id: String!
+  name: String!
+  # issuer_url: the upstream IdP issuer (its OIDC discovery base).
+  issuer_url: String!
+  # client_id / client_secret: the credentials Authorizer holds AT the upstream
+  # IdP. The secret is stored encrypted and never returned.
+  client_id: String!
+  client_secret: String!
+  # scopes: space-separated. Defaults to "openid profile email" when omitted.
+  scopes: String
+  # redirect_uri registered at the upstream IdP. Derived from the request host
+  # when omitted.
+  redirect_uri: String
+}
+
+input UpdateOrgOIDCConnectionRequest {
+  id: ID!
+  name: String
+  issuer_url: String
+  client_id: String
+  # Supplying client_secret rotates it; omitting leaves the stored secret intact.
+  client_secret: String
+  scopes: String
+  redirect_uri: String
+  is_active: Boolean
+}
+
+input OrgOIDCConnectionRequest {
+  # Look up by connection id OR by org_id (supply exactly one).
+  id: ID
+  org_id: String
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -1029,6 +1079,10 @@ type Mutation {
   _add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
   _update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
   _delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
+  # Per-organization SSO OIDC connections (Authorizer as Relying Party)
+  _create_org_oidc_connection(params: CreateOrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _update_org_oidc_connection(params: UpdateOrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _delete_org_oidc_connection(params: OrgOIDCConnectionRequest!): Response!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -1071,6 +1125,7 @@ type Query {
   # Trusted issuers
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
+  _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -187,6 +187,21 @@ func (r *mutationResolver) DeleteTrustedIssuer(ctx context.Context, params model
 	return r.GraphQLProvider.DeleteTrustedIssuer(ctx, &params)
 }
 
+// CreateOrgOidcConnection is the resolver for the _create_org_oidc_connection field.
+func (r *mutationResolver) CreateOrgOidcConnection(ctx context.Context, params model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	return r.GraphQLProvider.CreateOrgOidcConnection(ctx, &params)
+}
+
+// UpdateOrgOidcConnection is the resolver for the _update_org_oidc_connection field.
+func (r *mutationResolver) UpdateOrgOidcConnection(ctx context.Context, params model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	return r.GraphQLProvider.UpdateOrgOidcConnection(ctx, &params)
+}
+
+// DeleteOrgOidcConnection is the resolver for the _delete_org_oidc_connection field.
+func (r *mutationResolver) DeleteOrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteOrgOidcConnection(ctx, &params)
+}
+
 // CreateOrganization is the resolver for the _create_organization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error) {
 	return r.GraphQLProvider.CreateOrganization(ctx, &params)
@@ -340,6 +355,11 @@ func (r *queryResolver) TrustedIssuer(ctx context.Context, params model.TrustedI
 // TrustedIssuers is the resolver for the _trusted_issuers field.
 func (r *queryResolver) TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error) {
 	return r.GraphQLProvider.TrustedIssuers(ctx, params)
+}
+
+// OrgOidcConnection is the resolver for the _org_oidc_connection field.
+func (r *queryResolver) OrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	return r.GraphQLProvider.OrgOidcConnection(ctx, &params)
 }
 
 // Organization is the resolver for the _organization field.

--- a/internal/graphql/org_oidc_connection.go
+++ b/internal/graphql/org_oidc_connection.go
@@ -1,0 +1,66 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateOrgOidcConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) CreateOrgOidcConnection(ctx context.Context, params *model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateOrgOIDCConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// UpdateOrgOidcConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) UpdateOrgOidcConnection(ctx context.Context, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateOrgOIDCConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// DeleteOrgOidcConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteOrgOidcConnection(ctx context.Context, params *model.OrgOIDCConnectionRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteOrgOIDCConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// OrgOidcConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) OrgOidcConnection(ctx context.Context, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().OrgOIDCConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -239,6 +239,18 @@ type Provider interface {
 	// TrustedIssuers lists trusted issuers, optionally filtered by service account.
 	// Permissions: authorizer:admin
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
+	// CreateOrgOidcConnection registers a per-org upstream OIDC IdP connection.
+	// Permissions: authorizer:admin
+	CreateOrgOidcConnection(ctx context.Context, params *model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	// UpdateOrgOidcConnection updates a per-org OIDC connection.
+	// Permissions: authorizer:admin
+	UpdateOrgOidcConnection(ctx context.Context, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	// DeleteOrgOidcConnection deletes a per-org OIDC connection.
+	// Permissions: authorizer:admin
+	DeleteOrgOidcConnection(ctx context.Context, params *model.OrgOIDCConnectionRequest) (*model.Response, error)
+	// OrgOidcConnection returns a per-org OIDC connection by id or org_id.
+	// Permissions: authorizer:admin
+	OrgOidcConnection(ctx context.Context, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
 	// CreateOrganization creates a new organization.
 	// Permissions: authorizer:admin
 	CreateOrganization(ctx context.Context, params *model.CreateOrganizationRequest) (*model.Organization, error)

--- a/internal/http_handlers/oauth_sso.go
+++ b/internal/http_handlers/oauth_sso.go
@@ -1,0 +1,751 @@
+package http_handlers
+
+// Per-organization enterprise OIDC SSO — Authorizer acting as the Relying Party
+// (broker). An org configures its upstream OIDC IdP (Okta/Entra/Google) as a
+// sso_oidc TrustedIssuer row; its users log in through that IdP and Authorizer
+// JIT-provisions them and issues a normal Authorizer session.
+//
+// SECURITY MODEL (design §4.4 / §5.2):
+//   - PKCE (S256), unguessable `state`, and `nonce` are sent to the upstream and
+//     verified on return. `state` is single-use (GetAndRemoveState) — CSRF/replay.
+//   - Mix-up defense (G3 / RFC 9207): the returned ID token's `iss` MUST equal the
+//     issuer the dispatching connection discovered (stored in the per-state flow);
+//     an `iss` query parameter, when present, must match too. A response bound to
+//     a different connection is rejected.
+//   - The ID token is verified against the upstream JWKS (SSRF-hardened fetch),
+//     `aud` == our upstream client_id, `nonce` bound, `exp` valid, asymmetric alg.
+//   - JIT provisioning is namespaced by (org_id, issuer, sub) via FederatedIdentity
+//     — an email that merely collides with an existing account is NEVER linked
+//     (account-takeover defense); such a collision is rejected fail-closed.
+//   - All upstream fetches (discovery, JWKS, token exchange) use
+//     validators.SafeHTTPClient (host-pinned, redirect-refused, size-capped).
+//
+// ponytail: SAML SP (kind=sso_saml) is intentionally NOT here — its signature-
+// wrapping (XSW) validation ships in a separate PR for a focused security review.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/cookie"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/parsers"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+	"github.com/authorizerdev/authorizer/internal/utils"
+	"github.com/authorizerdev/authorizer/internal/validators"
+)
+
+const (
+	// ssoFlowPrefix namespaces the per-state broker flow entry in the shared store.
+	// SetState applies the store's short OAuth-state TTL, so the flow expires if
+	// the callback never arrives.
+	ssoFlowPrefix = "sso_flow:"
+	// ssoHTTPTimeout caps a single upstream fetch (discovery/JWKS/token).
+	ssoHTTPTimeout = 10 * time.Second
+	// ssoMaxRespBytes caps a response body read from an issuer-controlled endpoint.
+	ssoMaxRespBytes = 1 << 20 // 1 MiB
+	// ssoClockSkew tolerates minor clock drift on the upstream ID token exp/iat.
+	ssoClockSkew = 60 * time.Second
+)
+
+// ssoAllowedAlgs is the asymmetric ID-token signature allow-list (RFC 8725 §3.1);
+// alg:none and every symmetric (HS*) algorithm are absent by construction.
+var ssoAllowedAlgs = []string{
+	"RS256", "RS384", "RS512",
+	"PS256", "PS384", "PS512",
+	"ES256", "ES384", "ES512",
+}
+
+// ssoFlowState is the per-state broker context, stored single-use in the shared
+// store between login and callback. It pins the connection the response must come
+// from (ExpectedIssuer) so a mixed-up response is rejected (G3).
+type ssoFlowState struct {
+	ConnID         string `json:"conn_id"`
+	OrgID          string `json:"org_id"`
+	OrgSlug        string `json:"org_slug"`
+	ExpectedIssuer string `json:"issuer"`
+	TokenEndpoint  string `json:"token_endpoint"`
+	JWKSURI        string `json:"jwks_uri"`
+	CodeVerifier   string `json:"code_verifier"`
+	Nonce          string `json:"nonce"`
+	CallbackURI    string `json:"callback_uri"`
+	AppRedirect    string `json:"app_redirect"`
+	AppState       string `json:"app_state"`
+}
+
+// oidcDiscovery is the subset of the upstream discovery document we consume.
+type oidcDiscovery struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+// SSOLoginHandler starts a per-org OIDC broker login: it resolves the org's
+// sso_oidc connection, discovers the upstream endpoints, and redirects the
+// browser to the upstream /authorize with PKCE + state + nonce.
+func (h *httpProvider) SSOLoginHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SSOLoginHandler").Logger()
+	return func(c *gin.Context) {
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		appRedirect := strings.TrimSpace(c.Query("redirect_uri"))
+		appState := strings.TrimSpace(c.Query("state"))
+		hostname := parsers.GetHost(c)
+
+		if appRedirect == "" || !validators.IsValidRedirectURI(appRedirect, h.Config.AllowedOrigins, hostname) {
+			log.Debug().Msg("invalid or missing redirect_uri")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "error_description": "invalid redirect_uri"})
+			return
+		}
+		if h.MemoryStoreProvider == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		conn, ok := h.resolveActiveOIDCConnection(c, slug, &log)
+		if !ok {
+			return
+		}
+
+		disc, err := h.fetchOIDCDiscovery(c.Request.Context(), conn.IssuerURL)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to fetch upstream OIDC discovery")
+			c.JSON(http.StatusBadGateway, gin.H{"error": "sso_upstream_error", "error_description": "could not reach the identity provider"})
+			return
+		}
+
+		verifier, err := randURLString(64)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		state, err := randURLString(32)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		nonce, err := randURLString(32)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		challenge := pkceS256(verifier)
+
+		callbackURI := strings.TrimSpace(conn.SSORedirectURI)
+		if callbackURI == "" {
+			callbackURI = strings.TrimRight(hostname, "/") + "/oauth/sso/" + url.PathEscape(slug) + "/callback"
+		}
+
+		flow := ssoFlowState{
+			ConnID:         conn.ID,
+			OrgID:          conn.OrgID,
+			OrgSlug:        slug,
+			ExpectedIssuer: disc.Issuer,
+			TokenEndpoint:  disc.TokenEndpoint,
+			JWKSURI:        disc.JWKSURI,
+			CodeVerifier:   verifier,
+			Nonce:          nonce,
+			CallbackURI:    callbackURI,
+			AppRedirect:    appRedirect,
+			AppState:       appState,
+		}
+		flowJSON, err := json.Marshal(flow)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		if err := h.MemoryStoreProvider.SetState(ssoFlowPrefix+state, string(flowJSON)); err != nil {
+			log.Debug().Err(err).Msg("failed to persist sso flow state")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		scopes := strings.TrimSpace(conn.SSOScopes)
+		if scopes == "" {
+			scopes = "openid profile email"
+		}
+		q := url.Values{}
+		q.Set("response_type", "code")
+		q.Set("client_id", conn.SSOClientID)
+		q.Set("redirect_uri", callbackURI)
+		q.Set("scope", scopes)
+		q.Set("state", state)
+		q.Set("nonce", nonce)
+		q.Set("code_challenge", challenge)
+		q.Set("code_challenge_method", "S256")
+		sep := "?"
+		if strings.Contains(disc.AuthorizationEndpoint, "?") {
+			sep = "&"
+		}
+		authURL := disc.AuthorizationEndpoint + sep + q.Encode()
+
+		metrics.RecordAuthEvent(metrics.EventOAuthLogin, metrics.StatusSuccess)
+		h.AuditProvider.LogEvent(audit.Event{
+			Action:       constants.AuditSSOLoginInitiatedEvent,
+			ActorType:    constants.AuditActorTypeUser,
+			ResourceType: constants.AuditResourceTypeSession,
+			Metadata:     slug,
+			IPAddress:    utils.GetIP(c.Request),
+			UserAgent:    utils.GetUserAgent(c.Request),
+		})
+		c.Redirect(http.StatusTemporaryRedirect, authURL)
+	}
+}
+
+// SSOCallbackHandler completes the broker flow: single-use state lookup, code
+// exchange, ID-token verification (incl. mix-up defense), JIT provisioning, and
+// Authorizer session issuance.
+func (h *httpProvider) SSOCallbackHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SSOCallbackHandler").Logger()
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		state := strings.TrimSpace(c.Query("state"))
+		if state == "" || h.MemoryStoreProvider == nil {
+			ssoFail(c, &log, "invalid_state", "missing or invalid state")
+			return
+		}
+		// Single-use: atomically fetch and delete. A replayed callback finds nothing.
+		raw, err := h.MemoryStoreProvider.GetAndRemoveState(ssoFlowPrefix + state)
+		if err != nil && err != goredis.Nil {
+			log.Debug().Err(err).Msg("failed to read sso flow state")
+		}
+		if strings.TrimSpace(raw) == "" {
+			ssoFail(c, &log, "invalid_state", "unknown or expired state")
+			return
+		}
+		var flow ssoFlowState
+		if err := json.Unmarshal([]byte(raw), &flow); err != nil {
+			ssoFail(c, &log, "invalid_state", "corrupt state")
+			return
+		}
+		// Bind the callback route to the flow that dispatched it.
+		if flow.OrgSlug != slug {
+			ssoFail(c, &log, "invalid_state", "state/route mismatch")
+			return
+		}
+		// Mix-up defense (RFC 9207): if the IdP echoed an `iss`, it MUST match the
+		// issuer the dispatching connection discovered.
+		if issParam := strings.TrimSpace(c.Query("iss")); issParam != "" && issParam != flow.ExpectedIssuer {
+			metrics.RecordSecurityEvent("sso_mixup_iss_mismatch", slug)
+			ssoFail(c, &log, "invalid_issuer", "issuer mismatch")
+			return
+		}
+		if upstreamErr := strings.TrimSpace(c.Query("error")); upstreamErr != "" {
+			log.Debug().Str("upstream_error", upstreamErr).Msg("upstream idp returned an error")
+			ssoFail(c, &log, "sso_upstream_error", "identity provider returned an error")
+			return
+		}
+		code := strings.TrimSpace(c.Query("code"))
+		if code == "" {
+			ssoFail(c, &log, "invalid_request", "missing code")
+			return
+		}
+
+		conn, err := h.StorageProvider.GetTrustedIssuerByID(ctx, flow.ConnID)
+		if err != nil || conn == nil || conn.EffectiveKind() != constants.TrustKindSSOOIDC || !conn.IsActive {
+			ssoFail(c, &log, "sso_not_configured", "connection unavailable")
+			return
+		}
+		secret, err := crypto.DecryptAES(h.Config.ClientSecret, conn.SSOClientSecretEnc)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to decrypt upstream client secret")
+			ssoFail(c, &log, "sso_config_error", "connection misconfigured")
+			return
+		}
+
+		idToken, err := h.exchangeSSOCode(ctx, flow, conn.SSOClientID, secret, code)
+		if err != nil {
+			log.Debug().Err(err).Msg("upstream code exchange failed")
+			ssoFail(c, &log, "sso_exchange_failed", "code exchange failed")
+			return
+		}
+		claims, err := h.verifySSOIDToken(ctx, &flow, conn, idToken)
+		if err != nil {
+			log.Debug().Err(err).Msg("upstream id_token verification failed")
+			metrics.RecordSecurityEvent("sso_id_token_invalid", slug)
+			ssoFail(c, &log, "sso_id_token_invalid", "id token verification failed")
+			return
+		}
+
+		user, isSignUp, err := h.jitProvisionSSOUser(ctx, &flow, claims)
+		if err != nil {
+			log.Debug().Err(err).Msg("sso JIT provisioning rejected")
+			ssoFail(c, &log, "sso_provisioning_failed", err.Error())
+			return
+		}
+
+		if err := h.issueSSOSession(c, &flow, user, isSignUp); err != nil {
+			log.Debug().Err(err).Msg("failed to issue session")
+			ssoFail(c, &log, "sso_session_failed", "could not establish session")
+			return
+		}
+	}
+}
+
+// resolveActiveOIDCConnection looks up the org by slug and its active sso_oidc
+// connection, writing an error response and returning ok=false on any failure.
+func (h *httpProvider) resolveActiveOIDCConnection(c *gin.Context, slug string, log *zerolog.Logger) (*schemas.TrustedIssuer, bool) {
+	ctx := c.Request.Context()
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "error_description": "missing organization"})
+		return nil, false
+	}
+	org, err := h.StorageProvider.GetOrganizationByName(ctx, slug)
+	if err != nil || org == nil {
+		log.Debug().Err(err).Str("org", slug).Msg("organization not found")
+		c.JSON(http.StatusNotFound, gin.H{"error": "sso_not_configured", "error_description": "unknown organization"})
+		return nil, false
+	}
+	if !org.Enabled {
+		c.JSON(http.StatusForbidden, gin.H{"error": "sso_not_configured", "error_description": "organization disabled"})
+		return nil, false
+	}
+	conn, err := h.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, org.ID, constants.TrustKindSSOOIDC)
+	if err != nil || conn == nil || !conn.IsActive {
+		log.Debug().Err(err).Str("org", slug).Msg("no active OIDC connection for org")
+		c.JSON(http.StatusNotFound, gin.H{"error": "sso_not_configured", "error_description": "SSO is not configured for this organization"})
+		return nil, false
+	}
+	return conn, true
+}
+
+// fetchOIDCDiscovery SSRF-hardened fetches the upstream OpenID configuration.
+func (h *httpProvider) fetchOIDCDiscovery(ctx context.Context, issuerURL string) (*oidcDiscovery, error) {
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	body, err := ssoSafeGet(ctx, discoveryURL)
+	if err != nil {
+		return nil, err
+	}
+	var disc oidcDiscovery
+	if err := json.Unmarshal(body, &disc); err != nil {
+		return nil, fmt.Errorf("malformed discovery document: %w", err)
+	}
+	if disc.Issuer == "" || disc.AuthorizationEndpoint == "" || disc.TokenEndpoint == "" || disc.JWKSURI == "" {
+		return nil, fmt.Errorf("discovery document missing required fields")
+	}
+	return &disc, nil
+}
+
+// exchangeSSOCode exchanges the authorization code at the upstream token endpoint
+// (SSRF-hardened POST) and returns the raw id_token string.
+func (h *httpProvider) exchangeSSOCode(ctx context.Context, flow ssoFlowState, clientID, clientSecret, code string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", flow.CallbackURI)
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code_verifier", flow.CodeVerifier)
+
+	client, err := validators.SafeHTTPClient(ctx, flow.TokenEndpoint, ssoHTTPTimeout)
+	if err != nil {
+		return "", err
+	}
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, flow.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ssoMaxRespBytes))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned status %d", resp.StatusCode)
+	}
+	var tr struct {
+		IDToken string `json:"id_token"`
+	}
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", fmt.Errorf("malformed token response: %w", err)
+	}
+	if strings.TrimSpace(tr.IDToken) == "" {
+		return "", fmt.Errorf("token response has no id_token")
+	}
+	return tr.IDToken, nil
+}
+
+// verifySSOIDToken fetches the upstream JWKS (SSRF-hardened) then verifies the
+// ID token via verifyIDTokenAgainstJWKS.
+func (h *httpProvider) verifySSOIDToken(ctx context.Context, flow *ssoFlowState, conn *schemas.TrustedIssuer, rawIDToken string) (jwt.MapClaims, error) {
+	jwks, err := h.fetchSSOJWKS(ctx, flow.JWKSURI)
+	if err != nil {
+		return nil, err
+	}
+	return verifyIDTokenAgainstJWKS(flow, conn, rawIDToken, jwks)
+}
+
+// verifyIDTokenAgainstJWKS is the pure (no-network) ID-token verifier: asymmetric
+// signature against jwks, iss == the flow's expected issuer (mix-up defense),
+// aud contains our client_id, nonce bound, exp valid, asymmetric alg only. Kept
+// separate from the network fetch so it can be unit-tested exhaustively.
+func verifyIDTokenAgainstJWKS(flow *ssoFlowState, conn *schemas.TrustedIssuer, rawIDToken string, jwks *jose.JSONWebKeySet) (jwt.MapClaims, error) {
+	// Enforce the alg allow-list on the header before verifying (defence in depth).
+	unverified := jwt.MapClaims{}
+	parsed, _, err := jwt.NewParser().ParseUnverified(rawIDToken, unverified)
+	if err != nil {
+		return nil, fmt.Errorf("unparseable id_token: %w", err)
+	}
+	headerAlg, _ := parsed.Header["alg"].(string)
+	if !ssoIsAllowedAlg(headerAlg) {
+		return nil, fmt.Errorf("disallowed id_token alg %q", headerAlg)
+	}
+
+	keyfunc := func(t *jwt.Token) (interface{}, error) {
+		if !ssoIsAllowedAlg(t.Method.Alg()) {
+			return nil, fmt.Errorf("disallowed alg %q", t.Method.Alg())
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid != "" {
+			keys := jwks.Key(kid)
+			if len(keys) == 0 {
+				return nil, fmt.Errorf("no JWKS key for kid %q", kid)
+			}
+			return keys[0].Key, nil
+		}
+		if len(jwks.Keys) != 1 {
+			return nil, fmt.Errorf("id_token has no kid and JWKS is not single-key")
+		}
+		return jwks.Keys[0].Key, nil
+	}
+
+	claims := jwt.MapClaims{}
+	if _, err := jwt.NewParser(jwt.WithValidMethods(ssoAllowedAlgs), jwt.WithoutClaimsValidation()).ParseWithClaims(rawIDToken, claims, keyfunc); err != nil {
+		return nil, fmt.Errorf("signature validation failed: %w", err)
+	}
+
+	// iss MUST equal the issuer discovered by the dispatching connection (G3).
+	iss, _ := claims["iss"].(string)
+	if strings.TrimSpace(iss) == "" || iss != flow.ExpectedIssuer {
+		return nil, fmt.Errorf("id_token iss does not match the connection issuer")
+	}
+	// aud MUST contain our upstream client_id.
+	if !ssoAudienceContains(claims["aud"], conn.SSOClientID) {
+		return nil, fmt.Errorf("id_token aud does not contain our client_id")
+	}
+	// nonce MUST match the one we sent.
+	if n, _ := claims["nonce"].(string); n != flow.Nonce {
+		return nil, fmt.Errorf("id_token nonce mismatch")
+	}
+	// exp present and valid (with skew); iat not absurdly in the future.
+	now := time.Now()
+	exp, ok := ssoClaimInt64(claims, "exp")
+	if !ok || now.Unix() > exp+int64(ssoClockSkew.Seconds()) {
+		return nil, fmt.Errorf("id_token is expired or missing exp")
+	}
+	if iat, ok := ssoClaimInt64(claims, "iat"); ok && iat > now.Unix()+int64(ssoClockSkew.Seconds()) {
+		return nil, fmt.Errorf("id_token iat is in the future")
+	}
+	return claims, nil
+}
+
+// fetchSSOJWKS SSRF-hardened fetches and parses the upstream JWKS.
+func (h *httpProvider) fetchSSOJWKS(ctx context.Context, jwksURI string) (*jose.JSONWebKeySet, error) {
+	body, err := ssoSafeGet(ctx, jwksURI)
+	if err != nil {
+		return nil, err
+	}
+	var set jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("malformed JWKS: %w", err)
+	}
+	if len(set.Keys) == 0 {
+		return nil, fmt.Errorf("JWKS contains no keys")
+	}
+	return &set, nil
+}
+
+// jitProvisionSSOUser maps ID-token claims to an Authorizer user, namespaced by
+// (org_id, issuer, sub). Returns (user, isSignUp, error).
+//
+// SECURITY (account-takeover): a returning federated principal is found ONLY via
+// the (org_id, issuer, sub) FederatedIdentity row. A first-time principal whose
+// email collides with ANY existing account is rejected fail-closed — it is never
+// silently linked to that account.
+func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowState, claims jwt.MapClaims) (*schemas.User, bool, error) {
+	sub, _ := claims["sub"].(string)
+	sub = strings.TrimSpace(sub)
+	if sub == "" {
+		return nil, false, fmt.Errorf("missing subject")
+	}
+
+	// Returning principal?
+	if fi, err := h.StorageProvider.GetFederatedIdentity(ctx, flow.OrgID, flow.ExpectedIssuer, sub); err == nil && fi != nil {
+		user, err := h.StorageProvider.GetUserByID(ctx, fi.UserID)
+		if err != nil || user == nil {
+			return nil, false, fmt.Errorf("federated identity references an unknown user")
+		}
+		if user.RevokedTimestamp != nil {
+			return nil, false, fmt.Errorf("user access has been revoked")
+		}
+		return user, false, nil
+	}
+
+	if !h.Config.EnableSignup {
+		return nil, false, fmt.Errorf("signup is disabled for this instance")
+	}
+
+	email := strings.TrimSpace(claimString(claims, "email"))
+	// Account-takeover defense: never link to an existing account by email.
+	if email != "" {
+		if existing, err := h.StorageProvider.GetUserByEmail(ctx, email); err == nil && existing != nil {
+			return nil, false, fmt.Errorf("an account with this email already exists")
+		}
+	}
+
+	now := time.Now().Unix()
+	user := &schemas.User{
+		SignupMethods: constants.AuthRecipeMethodSSO,
+		Roles:         strings.Join(h.Config.DefaultRoles, ","),
+	}
+	if email != "" {
+		user.Email = refs.NewStringRef(email)
+		if emailVerifiedClaim(claims) {
+			user.EmailVerifiedAt = &now
+		}
+	}
+	if v := claimString(claims, "given_name"); v != "" {
+		user.GivenName = refs.NewStringRef(v)
+	}
+	if v := claimString(claims, "family_name"); v != "" {
+		user.FamilyName = refs.NewStringRef(v)
+	}
+	if v := claimString(claims, "name"); v != "" {
+		user.Nickname = refs.NewStringRef(v)
+	}
+	if v := claimString(claims, "picture"); v != "" {
+		user.Picture = refs.NewStringRef(v)
+	}
+
+	user, err := h.StorageProvider.AddUser(ctx, user)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to provision user")
+	}
+	if _, err := h.StorageProvider.AddFederatedIdentity(ctx, &schemas.FederatedIdentity{
+		OrgID:   flow.OrgID,
+		Issuer:  flow.ExpectedIssuer,
+		Subject: sub,
+		UserID:  user.ID,
+	}); err != nil {
+		return nil, false, fmt.Errorf("failed to record federated identity")
+	}
+	// Best-effort org membership: the (org_id, user_id) uniqueness guard tolerates
+	// a pre-existing row. A failure here must not block the login.
+	if _, err := h.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{
+		OrgID:  flow.OrgID,
+		UserID: user.ID,
+	}); err != nil {
+		h.Log.Debug().Err(err).Msg("failed to add org membership (non-fatal)")
+	}
+	return user, true, nil
+}
+
+// issueSSOSession mints the Authorizer session/tokens, sets the session cookie,
+// records the session, and redirects to the app's redirect_uri.
+func (h *httpProvider) issueSSOSession(c *gin.Context, flow *ssoFlowState, user *schemas.User, isSignUp bool) error {
+	hostname := parsers.GetHost(c)
+	roles := splitRoles(user.Roles)
+	authToken, err := h.TokenProvider.CreateAuthToken(c, &token.AuthTokenConfig{
+		User:        user,
+		Roles:       roles,
+		Scope:       []string{"openid", "profile", "email"},
+		LoginMethod: constants.AuthRecipeMethodSSO,
+		Nonce:       flow.Nonce,
+		HostName:    hostname,
+	})
+	if err != nil {
+		return err
+	}
+
+	sessionKey := constants.AuthRecipeMethodSSO + ":" + user.ID
+	cookie.SetSession(c, authToken.FingerPrintHash, h.Config.AppCookieSecure, cookie.ParseSameSite(h.Config.AppCookieSameSite))
+	_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeSessionToken+"_"+authToken.FingerPrint, authToken.FingerPrintHash, authToken.SessionTokenExpiresAt)
+	_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeAccessToken+"_"+authToken.FingerPrint, authToken.AccessToken.Token, authToken.AccessToken.ExpiresAt)
+	if authToken.RefreshToken != nil {
+		_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeRefreshToken+"_"+authToken.FingerPrint, authToken.RefreshToken.Token, authToken.RefreshToken.ExpiresAt)
+	}
+
+	bgCtx := context.WithoutCancel(c.Request.Context())
+	userAgent := utils.GetUserAgent(c.Request)
+	ip := utils.GetIP(c.Request)
+	go func() {
+		if isSignUp {
+			_ = h.EventsProvider.RegisterEvent(bgCtx, constants.UserSignUpWebhookEvent, constants.AuthRecipeMethodSSO, user)
+		}
+		_ = h.EventsProvider.RegisterEvent(bgCtx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodSSO, user)
+		if err := h.StorageProvider.AddSession(bgCtx, &schemas.Session{UserID: user.ID, UserAgent: userAgent, IP: ip}); err != nil {
+			h.Log.Debug().Err(err).Msg("failed to add session")
+		}
+	}()
+
+	params := "state=" + url.QueryEscape(flow.AppState)
+	redirectURL := flow.AppRedirect
+	if strings.Contains(redirectURL, "?") {
+		redirectURL = redirectURL + "&" + params
+	} else {
+		redirectURL = redirectURL + "?" + params
+	}
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusSuccess)
+	metrics.ActiveSessions.Inc()
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditSSOCallbackSuccessEvent,
+		ActorID:      user.ID,
+		ActorType:    constants.AuditActorTypeUser,
+		ActorEmail:   refs.StringValue(user.Email),
+		ResourceType: constants.AuditResourceTypeSession,
+		ResourceID:   user.ID,
+		Metadata:     flow.OrgSlug,
+		IPAddress:    ip,
+		UserAgent:    userAgent,
+	})
+	c.Redirect(http.StatusFound, redirectURL)
+	return nil
+}
+
+// ssoFail writes a uniform OAuth-style error response and records the failure.
+func ssoFail(c *gin.Context, log *zerolog.Logger, code, desc string) {
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusFailure)
+	log.Debug().Str("error", code).Msg("sso callback failed")
+	c.JSON(http.StatusBadRequest, gin.H{"error": code, "error_description": desc})
+}
+
+// ssoSafeGet performs an SSRF-hardened GET (host-pinned, redirects refused,
+// size-capped) against an issuer-controlled URL.
+func ssoSafeGet(ctx context.Context, rawURL string) ([]byte, error) {
+	client, err := validators.SafeHTTPClient(ctx, rawURL, ssoHTTPTimeout)
+	if err != nil {
+		return nil, err
+	}
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, rawURL)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, ssoMaxRespBytes))
+}
+
+// randURLString returns n bytes of crypto-random data, base64url-encoded.
+func randURLString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// pkceS256 derives the RFC 7636 S256 code challenge from a verifier.
+func pkceS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func ssoIsAllowedAlg(alg string) bool {
+	for _, a := range ssoAllowedAlgs {
+		if a == alg {
+			return true
+		}
+	}
+	return false
+}
+
+func ssoAudienceContains(aud interface{}, expected string) bool {
+	switch v := aud.(type) {
+	case string:
+		return v == expected
+	case []interface{}:
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == expected {
+				return true
+			}
+		}
+	case []string:
+		for _, s := range v {
+			if s == expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ssoClaimInt64(claims jwt.MapClaims, key string) (int64, bool) {
+	switch v := claims[key].(type) {
+	case float64:
+		return int64(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return n, err == nil
+	case int64:
+		return v, true
+	case string:
+		n, err := strconv.ParseInt(v, 10, 64)
+		return n, err == nil
+	}
+	return 0, false
+}
+
+func claimString(claims jwt.MapClaims, key string) string {
+	s, _ := claims[key].(string)
+	return s
+}
+
+// splitRoles parses a comma-separated role string, trimming and dropping empties.
+func splitRoles(roles string) []string {
+	out := []string{}
+	for _, r := range strings.Split(roles, ",") {
+		if r = strings.TrimSpace(r); r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// emailVerifiedClaim reads the OIDC email_verified claim (bool or "true").
+func emailVerifiedClaim(claims jwt.MapClaims) bool {
+	switch v := claims["email_verified"].(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(v, "true")
+	}
+	return false
+}

--- a/internal/http_handlers/oauth_sso_callback_test.go
+++ b/internal/http_handlers/oauth_sso_callback_test.go
@@ -1,0 +1,99 @@
+package http_handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/memory_store"
+)
+
+// ssoFakeStore serves a single preset flow entry via GetAndRemoveState and
+// records which key was consumed (to prove single-use). Every other memory_store
+// method panics via the embedded nil — the early-exit callback paths under test
+// touch only GetAndRemoveState.
+type ssoFakeStore struct {
+	memory_store.Provider
+	entries  map[string]string
+	consumed []string
+}
+
+func (s *ssoFakeStore) GetAndRemoveState(key string) (string, error) {
+	s.consumed = append(s.consumed, key)
+	v, ok := s.entries[key]
+	if !ok {
+		return "", nil
+	}
+	delete(s.entries, key)
+	return v, nil
+}
+
+func newSSOCallbackProvider(store *ssoFakeStore) *httpProvider {
+	logger := zerolog.Nop()
+	return &httpProvider{
+		Config:       &config.Config{},
+		Dependencies: Dependencies{Log: &logger, MemoryStoreProvider: store},
+	}
+}
+
+func callbackCtx(orgSlug, query string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/oauth/sso/"+orgSlug+"/callback?"+query, nil)
+	c.Params = gin.Params{{Key: "org_slug", Value: orgSlug}}
+	return c, rec
+}
+
+// A missing state must be rejected (CSRF: no forged callback without our state).
+func TestSSOCallback_MissingStateRejected(t *testing.T) {
+	store := &ssoFakeStore{entries: map[string]string{}}
+	h := newSSOCallbackProvider(store)
+	c, rec := callbackCtx("acme", "code=abc")
+	h.SSOCallbackHandler()(c)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// An unknown/expired/replayed state finds nothing → rejected. Also proves the
+// lookup goes through the single-use GetAndRemoveState primitive.
+func TestSSOCallback_UnknownStateRejected(t *testing.T) {
+	store := &ssoFakeStore{entries: map[string]string{}}
+	h := newSSOCallbackProvider(store)
+	c, rec := callbackCtx("acme", "state=deadbeef&code=abc")
+	h.SSOCallbackHandler()(c)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, []string{ssoFlowPrefix + "deadbeef"}, store.consumed, "state must be consumed single-use")
+}
+
+// The callback route's org_slug must match the flow that dispatched it.
+func TestSSOCallback_OrgSlugMismatchRejected(t *testing.T) {
+	flow := ssoFlowState{OrgSlug: "other-org", ExpectedIssuer: ssoTestIssuer}
+	raw, _ := json.Marshal(flow)
+	store := &ssoFakeStore{entries: map[string]string{ssoFlowPrefix + "s1": string(raw)}}
+	h := newSSOCallbackProvider(store)
+	c, rec := callbackCtx("acme", "state=s1&code=abc")
+	h.SSOCallbackHandler()(c)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Mix-up defense (RFC 9207): an `iss` query parameter that disagrees with the
+// dispatching connection's issuer must be rejected before any code exchange.
+func TestSSOCallback_MixupIssParamRejected(t *testing.T) {
+	flow := ssoFlowState{OrgSlug: "acme", ExpectedIssuer: ssoTestIssuer}
+	raw, _ := json.Marshal(flow)
+	store := &ssoFakeStore{entries: map[string]string{ssoFlowPrefix + "s2": string(raw)}}
+	h := newSSOCallbackProvider(store)
+	c, rec := callbackCtx("acme", "state=s2&code=abc&iss=https%3A%2F%2Fattacker.example.com")
+	h.SSOCallbackHandler()(c)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "invalid_issuer", body["error"])
+}

--- a/internal/http_handlers/oauth_sso_jit_test.go
+++ b/internal/http_handlers/oauth_sso_jit_test.go
@@ -1,0 +1,167 @@
+package http_handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// jitStore is an in-memory storage.Provider stub covering only the methods
+// jitProvisionSSOUser touches; every other method panics via the embedded nil.
+type jitStore struct {
+	storage.Provider
+	federated    map[string]*schemas.FederatedIdentity // key: org|issuer|sub
+	usersByID    map[string]*schemas.User
+	usersByEmail map[string]*schemas.User
+	addUserCalls int
+	addFedCalls  int
+}
+
+func newJITStore() *jitStore {
+	return &jitStore{
+		federated:    map[string]*schemas.FederatedIdentity{},
+		usersByID:    map[string]*schemas.User{},
+		usersByEmail: map[string]*schemas.User{},
+	}
+}
+
+func fedKey(org, iss, sub string) string { return org + "|" + iss + "|" + sub }
+
+func (s *jitStore) GetFederatedIdentity(_ context.Context, org, iss, sub string) (*schemas.FederatedIdentity, error) {
+	if fi, ok := s.federated[fedKey(org, iss, sub)]; ok {
+		return fi, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *jitStore) GetUserByID(_ context.Context, id string) (*schemas.User, error) {
+	if u, ok := s.usersByID[id]; ok {
+		return u, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *jitStore) GetUserByEmail(_ context.Context, email string) (*schemas.User, error) {
+	if u, ok := s.usersByEmail[email]; ok {
+		return u, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *jitStore) AddUser(_ context.Context, user *schemas.User) (*schemas.User, error) {
+	s.addUserCalls++
+	if user.ID == "" {
+		user.ID = uuid.New().String()
+	}
+	s.usersByID[user.ID] = user
+	if user.Email != nil {
+		s.usersByEmail[*user.Email] = user
+	}
+	return user, nil
+}
+
+func (s *jitStore) AddFederatedIdentity(_ context.Context, fi *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	s.addFedCalls++
+	if fi.ID == "" {
+		fi.ID = uuid.New().String()
+	}
+	s.federated[fedKey(fi.OrgID, fi.Issuer, fi.Subject)] = fi
+	return fi, nil
+}
+
+func (s *jitStore) AddOrgMembership(_ context.Context, m *schemas.OrgMembership) (*schemas.OrgMembership, error) {
+	if m.ID == "" {
+		m.ID = uuid.New().String()
+	}
+	return m, nil
+}
+
+func newJITProvider(store *jitStore, signupEnabled bool) *httpProvider {
+	logger := zerolog.Nop()
+	return &httpProvider{
+		Config:       &config.Config{EnableSignup: signupEnabled, DefaultRoles: []string{"user"}},
+		Dependencies: Dependencies{Log: &logger, StorageProvider: store},
+	}
+}
+
+func jitFlow() *ssoFlowState {
+	return &ssoFlowState{OrgID: "org-1", ExpectedIssuer: ssoTestIssuer}
+}
+
+func jitClaims(sub, email string) jwt.MapClaims {
+	c := jwt.MapClaims{"sub": sub, "email_verified": true}
+	if email != "" {
+		c["email"] = email
+	}
+	return c
+}
+
+// New federated principal → a fresh user + federated-identity row are created.
+func TestSSOJIT_NewUserProvisioned(t *testing.T) {
+	store := newJITStore()
+	h := newJITProvider(store, true)
+
+	user, isSignUp, err := h.jitProvisionSSOUser(context.Background(), jitFlow(), jitClaims("upstream-1", "alice@corp.example.com"))
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.True(t, isSignUp)
+	assert.Equal(t, "alice@corp.example.com", refs.StringValue(user.Email))
+	assert.Equal(t, 1, store.addUserCalls)
+	assert.Equal(t, 1, store.addFedCalls)
+}
+
+// A returning federated principal is resolved via (org,issuer,sub) — NOT re-created.
+func TestSSOJIT_ReturningUserResolvedByFederatedIdentity(t *testing.T) {
+	store := newJITStore()
+	h := newJITProvider(store, true)
+	flow := jitFlow()
+
+	first, _, err := h.jitProvisionSSOUser(context.Background(), flow, jitClaims("upstream-2", "bob@corp.example.com"))
+	require.NoError(t, err)
+
+	again, isSignUp, err := h.jitProvisionSSOUser(context.Background(), flow, jitClaims("upstream-2", "bob@corp.example.com"))
+	require.NoError(t, err)
+	assert.False(t, isSignUp)
+	assert.Equal(t, first.ID, again.ID)
+	assert.Equal(t, 1, store.addUserCalls, "returning principal must not create a second user")
+}
+
+// ACCOUNT-TAKEOVER DEFENSE: a federated login whose email collides with an
+// existing (non-federated) account must NOT be silently linked — it is rejected
+// fail-closed, and no user/federated row is created.
+func TestSSOJIT_EmailCollisionNotLinked(t *testing.T) {
+	store := newJITStore()
+	// Pre-existing global account with the same email but a DIFFERENT identity.
+	existing := &schemas.User{ID: "existing-user", Email: refs.NewStringRef("victim@corp.example.com")}
+	store.usersByID[existing.ID] = existing
+	store.usersByEmail["victim@corp.example.com"] = existing
+
+	h := newJITProvider(store, true)
+	user, isSignUp, err := h.jitProvisionSSOUser(context.Background(), jitFlow(), jitClaims("attacker-upstream", "victim@corp.example.com"))
+	require.Error(t, err)
+	assert.Nil(t, user)
+	assert.False(t, isSignUp)
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Equal(t, 0, store.addUserCalls, "must not create a shadow user")
+	assert.Equal(t, 0, store.addFedCalls, "must not link a federated identity to the victim account")
+}
+
+// Signup disabled → a first-time federated principal is rejected.
+func TestSSOJIT_SignupDisabledRejected(t *testing.T) {
+	store := newJITStore()
+	h := newJITProvider(store, false)
+	user, _, err := h.jitProvisionSSOUser(context.Background(), jitFlow(), jitClaims("upstream-3", "carol@corp.example.com"))
+	require.Error(t, err)
+	assert.Nil(t, user)
+}

--- a/internal/http_handlers/oauth_sso_verify_test.go
+++ b/internal/http_handlers/oauth_sso_verify_test.go
@@ -1,0 +1,135 @@
+package http_handlers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const (
+	ssoTestIssuer   = "https://idp.example.com"
+	ssoTestClientID = "authorizer-rp-client"
+	ssoTestNonce    = "nonce-abc-123"
+	ssoTestKID      = "sso-key-1"
+	ssoTestSubject  = "upstream-user-42"
+)
+
+func ssoGenKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return k
+}
+
+func ssoJWKS(pub *rsa.PublicKey, kid string) *jose.JSONWebKeySet {
+	return &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: pub, KeyID: kid, Algorithm: "RS256", Use: "sig"}}}
+}
+
+func ssoSignRS256(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	s, err := tok.SignedString(key)
+	require.NoError(t, err)
+	return s
+}
+
+func ssoValidClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":            ssoTestIssuer,
+		"aud":            ssoTestClientID,
+		"sub":            ssoTestSubject,
+		"nonce":          ssoTestNonce,
+		"email":          "user@corp.example.com",
+		"email_verified": true,
+		"iat":            now.Unix(),
+		"exp":            now.Add(time.Hour).Unix(),
+	}
+}
+
+func ssoFlowAndConn() (*ssoFlowState, *schemas.TrustedIssuer) {
+	return &ssoFlowState{
+			OrgID:          "org-1",
+			ExpectedIssuer: ssoTestIssuer,
+			Nonce:          ssoTestNonce,
+		}, &schemas.TrustedIssuer{
+			SSOClientID: ssoTestClientID,
+		}
+}
+
+func TestSSOIDToken_ValidPasses(t *testing.T) {
+	key := ssoGenKey(t)
+	flow, conn := ssoFlowAndConn()
+	claims, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, key, ssoTestKID, ssoValidClaims()), ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.NoError(t, err)
+	assert.Equal(t, ssoTestSubject, claims["sub"])
+}
+
+// Mix-up defense (G3 / RFC 9207): an ID token whose iss differs from the
+// dispatching connection's issuer must be rejected.
+func TestSSOIDToken_MixupWrongIssuerRejected(t *testing.T) {
+	key := ssoGenKey(t)
+	flow, conn := ssoFlowAndConn()
+	c := ssoValidClaims()
+	c["iss"] = "https://attacker-idp.example.com"
+	_, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, key, ssoTestKID, c), ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}
+
+func TestSSOIDToken_WrongAudienceRejected(t *testing.T) {
+	key := ssoGenKey(t)
+	flow, conn := ssoFlowAndConn()
+	c := ssoValidClaims()
+	c["aud"] = "some-other-client"
+	_, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, key, ssoTestKID, c), ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}
+
+func TestSSOIDToken_WrongNonceRejected(t *testing.T) {
+	key := ssoGenKey(t)
+	flow, conn := ssoFlowAndConn()
+	c := ssoValidClaims()
+	c["nonce"] = "different-nonce"
+	_, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, key, ssoTestKID, c), ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}
+
+func TestSSOIDToken_ExpiredRejected(t *testing.T) {
+	key := ssoGenKey(t)
+	flow, conn := ssoFlowAndConn()
+	c := ssoValidClaims()
+	c["exp"] = time.Now().Add(-2 * time.Hour).Unix()
+	_, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, key, ssoTestKID, c), ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}
+
+// alg:none must be rejected by the asymmetric allow-list.
+func TestSSOIDToken_AlgNoneRejected(t *testing.T) {
+	flow, conn := ssoFlowAndConn()
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, ssoValidClaims())
+	tok.Header["kid"] = ssoTestKID
+	raw, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	key := ssoGenKey(t)
+	_, err = verifyIDTokenAgainstJWKS(flow, conn, raw, ssoJWKS(&key.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}
+
+// A token signed by a key NOT in the JWKS (but claiming a known kid) must fail
+// signature verification.
+func TestSSOIDToken_WrongSignatureRejected(t *testing.T) {
+	signingKey := ssoGenKey(t)
+	jwksKey := ssoGenKey(t) // different key published in the JWKS
+	flow, conn := ssoFlowAndConn()
+	_, err := verifyIDTokenAgainstJWKS(flow, conn, ssoSignRS256(t, signingKey, ssoTestKID, ssoValidClaims()), ssoJWKS(&jwksKey.PublicKey, ssoTestKID))
+	require.Error(t, err)
+}

--- a/internal/http_handlers/provider.go
+++ b/internal/http_handlers/provider.go
@@ -107,6 +107,10 @@ type Provider interface {
 	OAuthCallbackHandler() gin.HandlerFunc
 	// OAuthLoginHandler is the main handler that handels all the oauth login requests
 	OAuthLoginHandler() gin.HandlerFunc
+	// SSOLoginHandler starts a per-org enterprise OIDC SSO broker login.
+	SSOLoginHandler() gin.HandlerFunc
+	// SSOCallbackHandler completes a per-org enterprise OIDC SSO broker login.
+	SSOCallbackHandler() gin.HandlerFunc
 	// OpenIDConfigurationHandler is the main handler that handels all the openid configuration requests
 	OpenIDConfigurationHandler() gin.HandlerFunc
 	// PlaygroundHandler is the main handler that handels all the playground requests

--- a/internal/server/http_routes.go
+++ b/internal/server/http_routes.go
@@ -64,6 +64,9 @@ func (s *server) NewRouter() *gin.Engine {
 	router.GET("/oauth_login/:oauth_provider", s.Dependencies.HTTPProvider.OAuthLoginHandler())
 	router.GET("/oauth_callback/:oauth_provider", s.Dependencies.HTTPProvider.OAuthCallbackHandler())
 	router.POST("/oauth_callback/:oauth_provider", s.Dependencies.HTTPProvider.OAuthCallbackHandler())
+	// Per-organization enterprise OIDC SSO broker (Authorizer as Relying Party)
+	router.GET("/oauth/sso/:org_slug/login", s.Dependencies.HTTPProvider.SSOLoginHandler())
+	router.GET("/oauth/sso/:org_slug/callback", s.Dependencies.HTTPProvider.SSOCallbackHandler())
 	router.GET("/verify_email", s.Dependencies.HTTPProvider.VerifyEmailHandler())
 	// OPEN ID routes
 	router.GET("/.well-known/openid-configuration", s.Dependencies.HTTPProvider.OpenIDConfigurationHandler())

--- a/internal/service/admin_org_oidc.go
+++ b/internal/service/admin_org_oidc.go
@@ -1,0 +1,271 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// defaultSSOScopes is requested at the upstream IdP when the admin omits scopes.
+const defaultSSOScopes = "openid profile email"
+
+// asAPIOrgOIDCConnection projects a sso_oidc TrustedIssuer row onto the GraphQL
+// model. The upstream client secret (SSOClientSecretEnc) is intentionally NEVER
+// surfaced — the model has no secret field.
+func asAPIOrgOIDCConnection(t *schemas.TrustedIssuer) *model.OrgOIDCConnection {
+	id := t.ID
+	if strings.Contains(id, schemas.Collections.TrustedIssuer+"/") {
+		id = strings.TrimPrefix(id, schemas.Collections.TrustedIssuer+"/")
+	}
+	return &model.OrgOIDCConnection{
+		ID:          id,
+		OrgID:       t.OrgID,
+		Name:        t.Name,
+		IssuerURL:   t.IssuerURL,
+		SsoClientID: t.SSOClientID,
+		Scopes:      refs.NewStringRef(t.SSOScopes),
+		RedirectURI: refs.NewStringRef(t.SSORedirectURI),
+		IsActive:    t.IsActive,
+		CreatedAt:   refs.NewInt64Ref(t.CreatedAt),
+		UpdatedAt:   refs.NewInt64Ref(t.UpdatedAt),
+	}
+}
+
+// validateSSOIssuerURL rejects an obviously invalid upstream issuer URL. The
+// actual network fetches (discovery/JWKS/token) are SSRF-hardened at fetch time
+// via validators.SafeHTTPClient; this only rejects non-https/opaque input early.
+func validateSSOIssuerURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("issuer_url must be a valid https URL")
+	}
+	return nil
+}
+
+// CreateOrgOIDCConnection registers a per-org upstream OIDC IdP (kind=sso_oidc).
+// Requires super-admin auth.
+//
+// ponytail: super-admin gated for now — an org-scoped admin permission model
+// (design H1) is a separate PR; mirror requireSuperAdmin like the other org ops.
+func (p *provider) CreateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateOrgOIDCConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	orgID := strings.TrimSpace(params.OrgID)
+	name := strings.TrimSpace(params.Name)
+	issuerURL := strings.TrimSpace(params.IssuerURL)
+	clientID := strings.TrimSpace(params.ClientID)
+	clientSecret := params.ClientSecret // preserve verbatim (secret may be non-trimmable)
+	if orgID == "" || name == "" || issuerURL == "" || clientID == "" || strings.TrimSpace(clientSecret) == "" {
+		return nil, nil, fmt.Errorf("org_id, name, issuer_url, client_id and client_secret are required")
+	}
+	if err := validateSSOIssuerURL(issuerURL); err != nil {
+		return nil, nil, err
+	}
+
+	// The organization must exist.
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Str("org_id", orgID).Msg("organization not found")
+		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+	}
+	// At most one OIDC connection per org.
+	if existing, _ := p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOOIDC); existing != nil {
+		return nil, nil, fmt.Errorf("an OIDC connection already exists for this organization")
+	}
+	// issuer_url is globally unique (DB unique index + service guard) — this also
+	// prevents an SSO row from shadowing a client_assertion_trust row at the same
+	// URL, and vice-versa.
+	if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, issuerURL); existing != nil {
+		return nil, nil, fmt.Errorf("issuer_url already registered: %s", issuerURL)
+	}
+
+	// The upstream secret is stored AES-encrypted (reversible: replayed to the
+	// upstream token endpoint) keyed on Config.ClientSecret, and carries json:"-".
+	encSecret, err := crypto.EncryptAES(p.Config.ClientSecret, clientSecret)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to encrypt upstream client secret")
+		return nil, nil, fmt.Errorf("failed to store connection")
+	}
+
+	scopes := defaultSSOScopes
+	if params.Scopes != nil && strings.TrimSpace(*params.Scopes) != "" {
+		scopes = strings.TrimSpace(*params.Scopes)
+	}
+	redirectURI := ""
+	if params.RedirectURI != nil {
+		redirectURI = strings.TrimSpace(*params.RedirectURI)
+	}
+
+	issuer, err := p.StorageProvider.AddTrustedIssuer(ctx, &schemas.TrustedIssuer{
+		Kind:               constants.TrustKindSSOOIDC,
+		OrgID:              orgID,
+		Name:               name,
+		IssuerURL:          issuerURL,
+		KeySourceType:      constants.KeySourceOIDCDiscovery,
+		IssuerType:         "oidc",
+		AuthMethod:         "jwt_assertion",
+		SSOClientID:        clientID,
+		SSOClientSecretEnc: encSecret,
+		SSOScopes:          scopes,
+		SSORedirectURI:     redirectURI,
+		IsActive:           true,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed AddTrustedIssuer (sso_oidc)")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgOIDCConnectionCreatedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgOIDCConnection,
+		ResourceID:   issuer.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return asAPIOrgOIDCConnection(issuer), nil, nil
+}
+
+// UpdateOrgOIDCConnection mutates only the fields present in params (load-then-
+// mutate). Kind and OrgID are immutable. Supplying client_secret rotates it.
+// Requires super-admin auth.
+func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "UpdateOrgOIDCConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
+		return nil, nil, err
+	}
+	// Guard: this op only edits sso_oidc rows — never a client_assertion row.
+	if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
+		return nil, nil, fmt.Errorf("not an OIDC connection")
+	}
+
+	if params.Name != nil {
+		issuer.Name = strings.TrimSpace(*params.Name)
+	}
+	if params.IssuerURL != nil {
+		u := strings.TrimSpace(*params.IssuerURL)
+		if err := validateSSOIssuerURL(u); err != nil {
+			return nil, nil, err
+		}
+		// Preserve global issuer_url uniqueness on change.
+		if u != issuer.IssuerURL {
+			if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, u); existing != nil {
+				return nil, nil, fmt.Errorf("issuer_url already registered: %s", u)
+			}
+		}
+		issuer.IssuerURL = u
+	}
+	if params.ClientID != nil {
+		issuer.SSOClientID = strings.TrimSpace(*params.ClientID)
+	}
+	if params.ClientSecret != nil && strings.TrimSpace(*params.ClientSecret) != "" {
+		enc, err := crypto.EncryptAES(p.Config.ClientSecret, *params.ClientSecret)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to store connection")
+		}
+		issuer.SSOClientSecretEnc = enc
+	}
+	if params.Scopes != nil && strings.TrimSpace(*params.Scopes) != "" {
+		issuer.SSOScopes = strings.TrimSpace(*params.Scopes)
+	}
+	if params.RedirectURI != nil {
+		issuer.SSORedirectURI = strings.TrimSpace(*params.RedirectURI)
+	}
+	if params.IsActive != nil {
+		issuer.IsActive = *params.IsActive
+	}
+
+	updated, err := p.StorageProvider.UpdateTrustedIssuer(ctx, issuer)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateTrustedIssuer (sso_oidc)")
+		return nil, nil, err
+	}
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgOIDCConnectionUpdatedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgOIDCConnection,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return asAPIOrgOIDCConnection(updated), nil, nil
+}
+
+// resolveOrgOIDCConnection loads the connection by id or org_id (exactly one).
+func (p *provider) resolveOrgOIDCConnection(ctx context.Context, id, orgID *string) (*schemas.TrustedIssuer, error) {
+	switch {
+	case id != nil && strings.TrimSpace(*id) != "":
+		issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, strings.TrimSpace(*id))
+		if err != nil {
+			return nil, err
+		}
+		if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
+			return nil, fmt.Errorf("not an OIDC connection")
+		}
+		return issuer, nil
+	case orgID != nil && strings.TrimSpace(*orgID) != "":
+		return p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, strings.TrimSpace(*orgID), constants.TrustKindSSOOIDC)
+	default:
+		return nil, fmt.Errorf("supply either id or org_id")
+	}
+}
+
+// DeleteOrgOIDCConnection removes an org's OIDC connection. Requires super-admin.
+func (p *provider) DeleteOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteOrgOIDCConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
+		return nil, nil, err
+	}
+	if err := p.StorageProvider.DeleteTrustedIssuer(ctx, issuer); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteTrustedIssuer (sso_oidc)")
+		return nil, nil, err
+	}
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgOIDCConnectionDeletedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgOIDCConnection,
+		ResourceID:   issuer.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.Response{Message: "OIDC connection deleted"}, nil, nil
+}
+
+// OrgOIDCConnection fetches an org's OIDC connection by id or org_id. Requires
+// super-admin auth. The secret is never projected.
+func (p *provider) OrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "OrgOIDCConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
+		return nil, nil, err
+	}
+	return asAPIOrgOIDCConnection(issuer), nil, nil
+}

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -63,6 +63,12 @@ type AdminProvider interface {
 	TrustedIssuer(ctx context.Context, meta RequestMetadata, params *model.TrustedIssuerRequest) (*model.TrustedIssuer, *ResponseSideEffects, error)
 	TrustedIssuers(ctx context.Context, meta RequestMetadata, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, *ResponseSideEffects, error)
 
+	// Per-org SSO OIDC connections (Authorizer as Relying Party).
+	CreateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error)
+	UpdateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error)
+	DeleteOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.Response, *ResponseSideEffects, error)
+	OrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error)
+
 	// Organizations and per-org membership.
 	CreateOrganization(ctx context.Context, meta RequestMetadata, params *model.CreateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)
 	UpdateOrganization(ctx context.Context, meta RequestMetadata, params *model.UpdateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)

--- a/internal/service/admin_trusted_issuers.go
+++ b/internal/service/admin_trusted_issuers.go
@@ -86,7 +86,10 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, meta RequestMetadata, p
 		AllowedSubjects: allowedSubjects,
 		IssuerType:      params.IssuerType,
 		// Set explicitly rather than relying on the GORM column default so NoSQL
-		// providers (no default support) persist the same values.
+		// providers (no default support) persist the same values. This admin op
+		// only ever creates client_assertion_trust rows; org-scoped SSO connections
+		// are created through the dedicated OIDC-connection admin API.
+		Kind:                     constants.TrustKindClientAssertion,
 		AuthMethod:               "jwt_assertion",
 		IsActive:                 true,
 		SpiffeRefreshHintSeconds: refs.Int64Value(params.SpiffeRefreshHintSeconds),

--- a/internal/service/clientauth/client_assertion.go
+++ b/internal/service/clientauth/client_assertion.go
@@ -116,14 +116,21 @@ func (p *provider) resolveViaClientAssertion(ctx context.Context, params Resolve
 	}
 
 	// 3. Resolve the trust row by iss. Unknown or inactive issuer → invalid_client.
-	// ponytail: once SSO rows share this table (a `kind` discriminator), this
-	// lookup MUST additionally filter kind='client_assertion_trust' AND
-	// org_id IS NULL (design §5.2 CR1) so an SSO row can never authenticate a
-	// client. No SSO rows exist on this table yet, so the confusion is not
-	// reachable today — add the filter when SSO lands.
 	issuer, err := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, iss)
 	if err != nil || issuer == nil {
 		log.Debug().Err(err).Str("iss", iss).Msg("no trusted issuer for iss")
+		return nil, ErrInvalidClient
+	}
+	// SECURITY (design §5.2 CR1 — kind confusion): the unified trusted_issuers
+	// table also holds per-org SSO connections (kind=sso_oidc/sso_saml), which have
+	// NO subject pin and federate end users, not clients. Only a
+	// client_assertion_trust row with an empty OrgID may authenticate an OAuth
+	// client. issuer_url is globally unique so this lookup returns at most one row;
+	// reject it here if it is anything other than an instance-global
+	// client_assertion_trust row. A pre-existing row (empty Kind) is treated as
+	// client_assertion_trust by EffectiveKind, so upgrades are unaffected.
+	if issuer.EffectiveKind() != constants.TrustKindClientAssertion || strings.TrimSpace(issuer.OrgID) != "" {
+		log.Debug().Str("iss", iss).Str("kind", issuer.EffectiveKind()).Msg("trusted issuer is not a client_assertion trust row")
 		return nil, ErrInvalidClient
 	}
 	if !issuer.IsActive {

--- a/internal/service/clientauth/client_assertion_cr1_test.go
+++ b/internal/service/clientauth/client_assertion_cr1_test.go
@@ -1,0 +1,65 @@
+package clientauth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+)
+
+// TestClientAssertion_SSORowRejected proves design §5.2 CR1: a per-org sso_oidc
+// TrustedIssuer row registered at the SAME issuer URL must NEVER be usable to
+// authenticate an OAuth client on the client_assertion path — even when the
+// presented assertion is otherwise perfectly valid and signed by a key the row's
+// JWKS serves. The kind/org guard in resolveViaClientAssertion rejects it.
+func TestClientAssertion_SSORowRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+
+	// Convert the trust row into a per-org sso_oidc connection at the same URL.
+	store := r.StorageProvider.(*assertionStore)
+	store.issuers[testIssuerURL].Kind = constants.TrustKindSSOOIDC
+	store.issuers[testIssuerURL].OrgID = "org-123"
+
+	client, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidClient, "an sso_oidc row must not authenticate a client")
+	assert.Nil(t, client)
+}
+
+// TestClientAssertion_OrgScopedRowRejected proves the org_id half of the CR1
+// guard: even a client_assertion_trust-kinded row is rejected if it is org-scoped
+// (OrgID set) — instance-global rows only may authenticate clients.
+func TestClientAssertion_OrgScopedRowRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+
+	store := r.StorageProvider.(*assertionStore)
+	store.issuers[testIssuerURL].Kind = constants.TrustKindClientAssertion
+	store.issuers[testIssuerURL].OrgID = "org-456"
+
+	client, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidClient, "an org-scoped trust row must not authenticate a client")
+	assert.Nil(t, client)
+}
+
+// TestClientAssertion_EmptyKindStillAuthenticates guards the upgrade path: a row
+// written before the kind column existed (empty Kind, empty OrgID) is treated as
+// client_assertion_trust by EffectiveKind and MUST still authenticate.
+func TestClientAssertion_EmptyKindStillAuthenticates(t *testing.T) {
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+
+	store := r.StorageProvider.(*assertionStore)
+	store.issuers[testIssuerURL].Kind = "" // pre-migration row
+	store.issuers[testIssuerURL].OrgID = ""
+
+	client, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, testSAClientPK, client.ID)
+}

--- a/internal/storage/db/arangodb/federated_identity.go
+++ b/internal/storage/db/arangodb/federated_identity.go
@@ -1,0 +1,66 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddFederatedIdentity records a JIT-provisioned federated identity. The unique
+// hash index on (org_id, issuer, subject) rejects duplicates at the database
+// layer.
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	identityCollection, _ := p.db.Collection(ctx, schemas.Collections.FederatedIdentity)
+	doc, err := structToDocument(identity)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := identityCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	identity.Key = meta.Key
+	identity.ID = meta.ID.String()
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for a (orgID, issuer, subject) triple.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	var identity *schemas.FederatedIdentity
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.issuer == @issuer AND d.subject == @subject LIMIT 1 RETURN d", schemas.Collections.FederatedIdentity)
+	bindVars := map[string]interface{}{
+		"org_id":  orgID,
+		"issuer":  issuer,
+		"subject": subject,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if identity == nil {
+				return nil, fmt.Errorf("federated identity not found")
+			}
+			break
+		}
+		fi := &schemas.FederatedIdentity{}
+		if _, err := readDocument(ctx, cursor, fi); err != nil {
+			return nil, err
+		}
+		identity = fi
+	}
+	return identity, nil
+}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -436,6 +436,25 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Sparse: true,
 	})
 
+	// FederatedIdentity collection and indexes
+	federatedIdentityCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.FederatedIdentity)
+	if err != nil {
+		return nil, err
+	}
+	if !federatedIdentityCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.FederatedIdentity, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	federatedIdentityCollection, err := arangodb.Collection(ctx, schemas.Collections.FederatedIdentity)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = federatedIdentityCollection.EnsureHashIndex(ctx, []string{"org_id", "issuer", "subject"}, &arangoDriver.EnsureHashIndexOptions{
+		Unique: true,
+	})
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/arangodb/shared.go
+++ b/internal/storage/db/arangodb/shared.go
@@ -22,7 +22,8 @@ import (
 // ponytail: structToDocument and readDocument are paired. If a schema gains a
 // new `json:"-"` field, its write path MUST go through structToDocument and its
 // read path MUST go through readDocument, or the field will silently load/store
-// empty. Today only User.Password and Client.ClientSecret are affected.
+// empty. Today User.Password, Client.ClientSecret and
+// TrustedIssuer.SSOClientSecretEnc are affected.
 
 // structToDocument converts a schema struct into a map for ArangoDB writes,
 // re-adding any `json:"-"` field under its `bson` tag key (encoding/json drops

--- a/internal/storage/db/arangodb/trusted_issuer.go
+++ b/internal/storage/db/arangodb/trusted_issuer.go
@@ -22,7 +22,11 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.Trusted
 	issuer.CreatedAt = now
 	issuer.UpdatedAt = now
 	issuerCollection, _ := p.db.Collection(ctx, schemas.Collections.TrustedIssuer)
-	meta, err := issuerCollection.CreateDocument(ctx, issuer)
+	doc, err := structToDocument(issuer)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := issuerCollection.CreateDocument(ctx, doc)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +46,11 @@ func (p *provider) UpdateTrustedIssuer(ctx context.Context, issuer *schemas.Trus
 	}
 	issuer.UpdatedAt = time.Now().Unix()
 	issuerCollection, _ := p.db.Collection(ctx, schemas.Collections.TrustedIssuer)
-	meta, err := issuerCollection.UpdateDocument(ctx, issuer.Key, issuer)
+	doc, err := structToDocument(issuer)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := issuerCollection.UpdateDocument(ctx, issuer.Key, doc)
 	if err != nil {
 		return nil, err
 	}
@@ -82,10 +90,11 @@ func (p *provider) GetTrustedIssuerByID(ctx context.Context, id string) (*schema
 			}
 			break
 		}
-		_, err := cursor.ReadDocument(ctx, &issuer)
-		if err != nil {
+		ti := &schemas.TrustedIssuer{}
+		if _, err := readDocument(ctx, cursor, ti); err != nil {
 			return nil, err
 		}
+		issuer = ti
 	}
 	return issuer, nil
 }
@@ -110,10 +119,41 @@ func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL st
 			}
 			break
 		}
-		_, err := cursor.ReadDocument(ctx, &issuer)
-		if err != nil {
+		ti := &schemas.TrustedIssuer{}
+		if _, err := readDocument(ctx, cursor, ti); err != nil {
 			return nil, err
 		}
+		issuer = ti
+	}
+	return issuer, nil
+}
+
+// GetTrustedIssuerByOrgIDAndKind fetches the trusted issuer for an (orgID, kind)
+// pair — the org's SSO connection lookup (kind = sso_oidc/sso_saml).
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	var issuer *schemas.TrustedIssuer
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.kind == @kind LIMIT 1 RETURN d", schemas.Collections.TrustedIssuer)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+		"kind":   kind,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if issuer == nil {
+				return nil, fmt.Errorf("trusted issuer not found")
+			}
+			break
+		}
+		ti := &schemas.TrustedIssuer{}
+		if _, err := readDocument(ctx, cursor, ti); err != nil {
+			return nil, err
+		}
+		issuer = ti
 	}
 	return issuer, nil
 }
@@ -137,8 +177,8 @@ func (p *provider) ListTrustedIssuers(ctx context.Context, serviceAccountID stri
 	paginationClone := pagination
 	paginationClone.Total = cursor.Statistics().FullCount()
 	for {
-		var issuer *schemas.TrustedIssuer
-		meta, err := cursor.ReadDocument(ctx, &issuer)
+		issuer := &schemas.TrustedIssuer{}
+		meta, err := readDocument(ctx, cursor, issuer)
 		if arangoDriver.IsNoMoreDocuments(err) {
 			break
 		} else if err != nil {

--- a/internal/storage/db/cassandradb/federated_identity.go
+++ b/internal/storage/db/cassandradb/federated_identity.go
@@ -1,0 +1,52 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const federatedIdentityColumns = "id, org_id, issuer, subject, user_id, created_at, updated_at"
+
+// scanFederatedIdentity maps the federatedIdentityColumns projection onto a struct.
+func scanFederatedIdentity(scan func(...interface{}) error, identity *schemas.FederatedIdentity) error {
+	return scan(&identity.ID, &identity.OrgID, &identity.Issuer, &identity.Subject, &identity.UserID, &identity.CreatedAt, &identity.UpdatedAt)
+}
+
+// AddFederatedIdentity creates a new federated identity. (org_id, issuer, subject) is unique.
+// Cassandra has no cross-attribute unique constraint, so guard with a
+// check-then-insert mirroring AddOrgMembership's pre-check.
+// ponytail: inherent TOCTOU race — closes the sequential case only.
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	if existing, _ := p.GetFederatedIdentity(ctx, identity.OrgID, identity.Issuer, identity.Subject); existing != nil {
+		return nil, fmt.Errorf("federated identity for org_id %s, issuer %s and subject %s already exists", identity.OrgID, identity.Issuer, identity.Subject)
+	}
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.FederatedIdentity, federatedIdentityColumns)
+	err := p.db.Query(insertQuery, identity.ID, identity.OrgID, identity.Issuer, identity.Subject, identity.UserID, identity.CreatedAt, identity.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for a (orgID, issuer, subject) triple.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	var identity schemas.FederatedIdentity
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND issuer = ? AND subject = ? LIMIT 1 ALLOW FILTERING", federatedIdentityColumns, KeySpace+"."+schemas.Collections.FederatedIdentity)
+	if err := scanFederatedIdentity(p.db.Query(query, orgID, issuer, subject).Consistency(gocql.One).Scan, &identity); err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -393,7 +393,7 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Client, "client_id", 30*time.Second)
 
 	// TrustedIssuer table and indexes
-	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, allowed_subjects text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
+	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, allowed_subjects text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, kind text, org_id text, sso_client_id text, sso_client_secret_enc text, sso_scopes text, sso_redirect_uri text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
 	err = session.Query(trustedIssuerCollectionQuery).Exec()
 	if err != nil {
 		return nil, err
@@ -403,6 +403,13 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	trustedIssuerAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD (allowed_subjects text);`, KeySpace, schemas.Collections.TrustedIssuer)
 	if err = session.Query(trustedIssuerAlterQuery).Exec(); err != nil {
 		deps.Log.Debug().Err(err).Msg("Failed to alter trusted_issuers table as allowed_subjects column exists")
+		// continue
+	}
+	// Add SSO broker columns for keyspaces created before the sso_oidc kind (§4.3)
+	// landed. Tolerated if the columns already exist.
+	trustedIssuerSSOAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD (kind text, org_id text, sso_client_id text, sso_client_secret_enc text, sso_scopes text, sso_redirect_uri text);`, KeySpace, schemas.Collections.TrustedIssuer)
+	if err = session.Query(trustedIssuerSSOAlterQuery).Exec(); err != nil {
+		deps.Log.Debug().Err(err).Msg("Failed to alter trusted_issuers table as SSO broker columns exist")
 		// continue
 	}
 	trustedIssuerIssuerURLIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_trusted_issuer_issuer_url ON %s.%s (issuer_url)", KeySpace, schemas.Collections.TrustedIssuer)
@@ -442,11 +449,28 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	if err = session.Query(orgMembershipUserIndex).Exec(); err != nil {
 		return nil, err
 	}
+
+	// FederatedIdentity table and indexes
+	federatedIdentityCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, issuer text, subject text, user_id text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.FederatedIdentity)
+	if err = session.Query(federatedIdentityCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	federatedIdentityOrgIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_federated_identity_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.FederatedIdentity)
+	if err = session.Query(federatedIdentityOrgIndex).Exec(); err != nil {
+		return nil, err
+	}
+	federatedIdentityUserIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_federated_identity_user_id ON %s.%s (user_id)", KeySpace, schemas.Collections.FederatedIdentity)
+	if err = session.Query(federatedIdentityUserIndex).Exec(); err != nil {
+		return nil, err
+	}
+
 	// ScyllaDB builds secondary indexes asynchronously; wait for the lookup
 	// columns used by the uniqueness guard and membership listings.
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Organization, "name", 30*time.Second)
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "org_id", 30*time.Second)
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgMembership, "user_id", 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.FederatedIdentity, "org_id", 30*time.Second)
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.FederatedIdentity, "user_id", 30*time.Second)
 
 	return &provider{
 		config:       cfg,

--- a/internal/storage/db/cassandradb/trusted_issuer.go
+++ b/internal/storage/db/cassandradb/trusted_issuer.go
@@ -13,11 +13,11 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const trustedIssuerColumns = "id, client_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, created_at, updated_at"
+const trustedIssuerColumns = "id, client_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, kind, org_id, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, created_at, updated_at"
 
 // scanTrustedIssuer maps the trustedIssuerColumns projection onto a struct.
 func scanTrustedIssuer(scan func(...interface{}) error, issuer *schemas.TrustedIssuer) error {
-	return scan(&issuer.ID, &issuer.ClientID, &issuer.Name, &issuer.IssuerURL, &issuer.KeySourceType, &issuer.JWKSUrl, &issuer.ExpectedAud, &issuer.SubjectClaim, &issuer.AllowedSubjects, &issuer.IssuerType, &issuer.AuthMethod, &issuer.IsActive, &issuer.EnableTokenReview, &issuer.KubernetesAPIServerURL, &issuer.SpiffeRefreshHintSeconds, &issuer.TrustedProxyHeader, &issuer.TrustedProxyCIDRs, &issuer.CreatedAt, &issuer.UpdatedAt)
+	return scan(&issuer.ID, &issuer.ClientID, &issuer.Name, &issuer.IssuerURL, &issuer.KeySourceType, &issuer.JWKSUrl, &issuer.ExpectedAud, &issuer.SubjectClaim, &issuer.AllowedSubjects, &issuer.IssuerType, &issuer.AuthMethod, &issuer.IsActive, &issuer.EnableTokenReview, &issuer.KubernetesAPIServerURL, &issuer.SpiffeRefreshHintSeconds, &issuer.TrustedProxyHeader, &issuer.TrustedProxyCIDRs, &issuer.Kind, &issuer.OrgID, &issuer.SSOClientID, &issuer.SSOClientSecretEnc, &issuer.SSOScopes, &issuer.SSORedirectURI, &issuer.CreatedAt, &issuer.UpdatedAt)
 }
 
 // AddTrustedIssuer creates a new trusted issuer record.
@@ -41,8 +41,8 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.Trusted
 	if existing, _ := p.GetTrustedIssuerByIssuerURL(ctx, issuer.IssuerURL); existing != nil {
 		return nil, fmt.Errorf("trusted issuer with %s issuer_url already exists", issuer.IssuerURL)
 	}
-	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.TrustedIssuer, trustedIssuerColumns)
-	err := p.db.Query(insertQuery, issuer.ID, issuer.ClientID, issuer.Name, issuer.IssuerURL, issuer.KeySourceType, issuer.JWKSUrl, issuer.ExpectedAud, issuer.SubjectClaim, issuer.AllowedSubjects, issuer.IssuerType, issuer.AuthMethod, issuer.IsActive, issuer.EnableTokenReview, issuer.KubernetesAPIServerURL, issuer.SpiffeRefreshHintSeconds, issuer.TrustedProxyHeader, issuer.TrustedProxyCIDRs, issuer.CreatedAt, issuer.UpdatedAt).Exec()
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.TrustedIssuer, trustedIssuerColumns)
+	err := p.db.Query(insertQuery, issuer.ID, issuer.ClientID, issuer.Name, issuer.IssuerURL, issuer.KeySourceType, issuer.JWKSUrl, issuer.ExpectedAud, issuer.SubjectClaim, issuer.AllowedSubjects, issuer.IssuerType, issuer.AuthMethod, issuer.IsActive, issuer.EnableTokenReview, issuer.KubernetesAPIServerURL, issuer.SpiffeRefreshHintSeconds, issuer.TrustedProxyHeader, issuer.TrustedProxyCIDRs, issuer.Kind, issuer.OrgID, issuer.SSOClientID, issuer.SSOClientSecretEnc, issuer.SSOScopes, issuer.SSORedirectURI, issuer.CreatedAt, issuer.UpdatedAt).Exec()
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +110,18 @@ func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL st
 	var issuer schemas.TrustedIssuer
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE issuer_url = ? LIMIT 1 ALLOW FILTERING", trustedIssuerColumns, KeySpace+"."+schemas.Collections.TrustedIssuer)
 	err := scanTrustedIssuer(p.db.Query(query, issuerURL).Consistency(gocql.One).Scan, &issuer)
+	if err != nil {
+		return nil, err
+	}
+	return &issuer, nil
+}
+
+// GetTrustedIssuerByOrgIDAndKind fetches a trusted issuer by its (org_id, kind) pair.
+// Used to locate an organization's SSO connection.
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	var issuer schemas.TrustedIssuer
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND kind = ? LIMIT 1 ALLOW FILTERING", trustedIssuerColumns, KeySpace+"."+schemas.Collections.TrustedIssuer)
+	err := scanTrustedIssuer(p.db.Query(query, orgID, kind).Consistency(gocql.One).Scan, &issuer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/couchbase/federated_identity.go
+++ b/internal/storage/db/couchbase/federated_identity.go
@@ -1,0 +1,69 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const federatedIdentityColumns = "_id, org_id, issuer, subject, user_id, created_at, updated_at"
+
+// AddFederatedIdentity records a JIT-provisioned federated identity.
+// (org_id, issuer, subject) is unique; Couchbase has no compound unique
+// constraint, so guard with a check-then-insert (closes the sequential case).
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	if existing, _ := p.GetFederatedIdentity(ctx, identity.OrgID, identity.Issuer, identity.Subject); existing != nil {
+		return nil, fmt.Errorf("federated identity for org_id %s issuer %s subject %s already exists", identity.OrgID, identity.Issuer, identity.Subject)
+	}
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(identity)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.FederatedIdentity).Insert(identity.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for an (orgID, issuer, subject) triple.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	params := make(map[string]interface{}, 3)
+	params["org_id"] = orgID
+	params["issuer"] = issuer
+	params["subject"] = subject
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND issuer=$issuer AND subject=$subject LIMIT 1`, federatedIdentityColumns, p.scopeName, schemas.Collections.FederatedIdentity)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	identity := &schemas.FederatedIdentity{}
+	if err := decodeDocument(raw, identity); err != nil {
+		return nil, err
+	}
+	return identity, nil
+}

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -305,5 +305,9 @@ func getIndex(scopeName string) map[string][]string {
 	orgMembershipIndex2 := fmt.Sprintf("CREATE INDEX OrgMembershipUserIdIndex ON %s.%s(user_id)", scopeName, schemas.Collections.OrgMembership)
 	indices[schemas.Collections.OrgMembership] = []string{orgMembershipIndex1, orgMembershipIndex2}
 
+	// FederatedIdentity indexes
+	federatedIdentityIndex1 := fmt.Sprintf("CREATE INDEX FederatedIdentityOrgIssuerSubjectIndex ON %s.%s(org_id, issuer, subject)", scopeName, schemas.Collections.FederatedIdentity)
+	indices[schemas.Collections.FederatedIdentity] = []string{federatedIdentityIndex1}
+
 	return indices
 }

--- a/internal/storage/db/couchbase/shared.go
+++ b/internal/storage/db/couchbase/shared.go
@@ -23,10 +23,9 @@ import (
 //
 // ponytail: paired with decodeDocument. Any struct carrying a `json:"-"` field MUST use
 // structToDocument on its write path and decodeDocument on its read path, or the field is
-// silently dropped. The `json:"-"` secret fields in the schemas are User.Password and
-// Client.ClientSecret. TrustedIssuer is deliberately NOT converted — it has no
-// `json:"-"` field, so its Insert passes the raw struct; if a secret field is ever added
-// there, convert its write path to structToDocument and its read path to decodeDocument too.
+// silently dropped. The `json:"-"` secret fields in the schemas are User.Password,
+// Client.ClientSecret and TrustedIssuer.SSOClientSecretEnc — every one of their
+// Insert/Upsert and read paths goes through this helper pair.
 func structToDocument(v interface{}) (map[string]interface{}, error) {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/storage/db/couchbase/trusted_issuer.go
+++ b/internal/storage/db/couchbase/trusted_issuer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -14,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const trustedIssuerColumns = "_id, client_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, created_at, updated_at"
+const trustedIssuerColumns = "_id, client_id, kind, org_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, created_at, updated_at"
 
 // AddTrustedIssuer creates a new trusted issuer record.
 func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.TrustedIssuer) (*schemas.TrustedIssuer, error) {
@@ -28,7 +27,11 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.Trusted
 	insertOpt := gocb.InsertOptions{
 		Context: ctx,
 	}
-	_, err := p.db.Collection(schemas.Collections.TrustedIssuer).Insert(issuer.ID, issuer, &insertOpt)
+	doc, err := structToDocument(issuer)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.TrustedIssuer).Insert(issuer.ID, doc, &insertOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -43,15 +46,7 @@ func (p *provider) UpdateTrustedIssuer(ctx context.Context, issuer *schemas.Trus
 		return nil, fmt.Errorf("UpdateTrustedIssuer: caller must load record before updating (CreatedAt is zero — partial struct detected)")
 	}
 	issuer.UpdatedAt = time.Now().Unix()
-	bytes, err := json.Marshal(issuer)
-	if err != nil {
-		return nil, err
-	}
-	// use decoder instead of json.Unmarshall, because it converts int64 -> float64 after unmarshalling
-	decoder := json.NewDecoder(strings.NewReader(string(bytes)))
-	decoder.UseNumber()
-	issuerMap := map[string]interface{}{}
-	err = decoder.Decode(&issuerMap)
+	issuerMap, err := structToDocument(issuer)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +78,6 @@ func (p *provider) DeleteTrustedIssuer(ctx context.Context, issuer *schemas.Trus
 
 // GetTrustedIssuerByID fetches a trusted issuer by primary key.
 func (p *provider) GetTrustedIssuerByID(ctx context.Context, id string) (*schemas.TrustedIssuer, error) {
-	var issuer *schemas.TrustedIssuer
 	params := make(map[string]interface{}, 1)
 	params["_id"] = id
 	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, trustedIssuerColumns, p.scopeName, schemas.Collections.TrustedIssuer)
@@ -95,8 +89,12 @@ func (p *provider) GetTrustedIssuerByID(ctx context.Context, id string) (*schema
 	if err != nil {
 		return nil, err
 	}
-	err = q.One(&issuer)
-	if err != nil {
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	issuer := &schemas.TrustedIssuer{}
+	if err := decodeDocument(raw, issuer); err != nil {
 		return nil, err
 	}
 	return issuer, nil
@@ -105,7 +103,6 @@ func (p *provider) GetTrustedIssuerByID(ctx context.Context, id string) (*schema
 // GetTrustedIssuerByIssuerURL fetches a trusted issuer by its unique issuer URL.
 // Called on every client_assertion validation — served by the issuer_url index.
 func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL string) (*schemas.TrustedIssuer, error) {
-	var issuer *schemas.TrustedIssuer
 	params := make(map[string]interface{}, 1)
 	params["issuer_url"] = issuerURL
 	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE issuer_url=$issuer_url LIMIT 1`, trustedIssuerColumns, p.scopeName, schemas.Collections.TrustedIssuer)
@@ -117,8 +114,38 @@ func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL st
 	if err != nil {
 		return nil, err
 	}
-	err = q.One(&issuer)
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	issuer := &schemas.TrustedIssuer{}
+	if err := decodeDocument(raw, issuer); err != nil {
+		return nil, err
+	}
+	return issuer, nil
+}
+
+// GetTrustedIssuerByOrgIDAndKind fetches an organization's SSO connection by its
+// (org_id, kind) pair — the lookup that resolves an org's sso_oidc/sso_saml row.
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	params := make(map[string]interface{}, 2)
+	params["org_id"] = orgID
+	params["kind"] = kind
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND kind=$kind LIMIT 1`, trustedIssuerColumns, p.scopeName, schemas.Collections.TrustedIssuer)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
 	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	issuer := &schemas.TrustedIssuer{}
+	if err := decodeDocument(raw, issuer); err != nil {
 		return nil, err
 	}
 	return issuer, nil
@@ -166,12 +193,15 @@ func (p *provider) ListTrustedIssuers(ctx context.Context, serviceAccountID stri
 		return nil, nil, err
 	}
 	for queryResult.Next() {
-		var issuer schemas.TrustedIssuer
-		err := queryResult.Row(&issuer)
-		if err != nil {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
 			return nil, nil, err
 		}
-		issuers = append(issuers, &issuer)
+		issuer := &schemas.TrustedIssuer{}
+		if err := decodeDocument(raw, issuer); err != nil {
+			return nil, nil, err
+		}
+		issuers = append(issuers, issuer)
 	}
 	if err := queryResult.Err(); err != nil {
 		return nil, nil, err

--- a/internal/storage/db/dynamodb/federated_identity.go
+++ b/internal/storage/db/dynamodb/federated_identity.go
@@ -1,0 +1,57 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddFederatedIdentity creates a new federated identity. (org_id, issuer,
+// subject) is unique; DynamoDB has no compound unique constraint, so guard with
+// a check-then-insert (closes the sequential case).
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	if existing, _ := p.GetFederatedIdentity(ctx, identity.OrgID, identity.Issuer, identity.Subject); existing != nil {
+		return nil, fmt.Errorf("federated identity for org_id %s issuer %s subject %s already exists", identity.OrgID, identity.Issuer, identity.Subject)
+	}
+	if err := p.putItem(ctx, schemas.Collections.FederatedIdentity, identity); err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for a (orgID, issuer,
+// subject) triple via the org_id GSI with an (issuer, subject) filter.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	// Must NOT pass a Limit alongside a FilterExpression: DynamoDB applies Limit
+	// BEFORE the filter, so a Limit read returns arbitrary rows from the org_id
+	// partition and can miss the (issuer, subject) match even when it exists.
+	// queryEq paginates and filters server-side across the whole partition; the
+	// unique (org_id, issuer, subject) invariant means at most one match.
+	f := expression.Name("issuer").Equal(expression.Value(issuer)).
+		And(expression.Name("subject").Equal(expression.Value(subject)))
+	items, err := p.queryEq(ctx, schemas.Collections.FederatedIdentity, "org_id", "org_id", orgID, &f)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var identity schemas.FederatedIdentity
+	if err := unmarshalItem(items[0], &identity); err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -217,6 +217,19 @@ func (p *provider) ensureTables(ctx context.Context) error {
 				gsi("user_id", "user_id"),
 			},
 		},
+		{
+			name: schemas.Collections.FederatedIdentity,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("user_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{
+				gsi("org_id", "org_id"),
+				gsi("user_id", "user_id"),
+			},
+		},
 	}
 
 	for _, t := range tables {

--- a/internal/storage/db/dynamodb/trusted_issuer.go
+++ b/internal/storage/db/dynamodb/trusted_issuer.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 
@@ -70,6 +71,26 @@ func (p *provider) GetTrustedIssuerByID(ctx context.Context, id string) (*schema
 // Called on every client_assertion validation — served by the issuer_url GSI.
 func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL string) (*schemas.TrustedIssuer, error) {
 	items, err := p.queryEqLimit(ctx, schemas.Collections.TrustedIssuer, "issuer_url", "issuer_url", issuerURL, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var issuer schemas.TrustedIssuer
+	if err := unmarshalItem(items[0], &issuer); err != nil {
+		return nil, err
+	}
+	return &issuer, nil
+}
+
+// GetTrustedIssuerByOrgIDAndKind fetches a trusted issuer by its (org_id, kind)
+// pair. TrustedIssuer has no org_id GSI, so scan the base table with a combined
+// org_id + kind filter and return the first match.
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	f := expression.Name("org_id").Equal(expression.Value(orgID)).
+		And(expression.Name("kind").Equal(expression.Value(kind)))
+	items, err := p.scanFilteredAll(ctx, schemas.Collections.TrustedIssuer, nil, &f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/mongodb/federated_identity.go
+++ b/internal/storage/db/mongodb/federated_identity.go
@@ -1,0 +1,41 @@
+package mongodb
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddFederatedIdentity creates a new federated identity. The compound unique
+// index on (org_id, issuer, subject) rejects duplicates at the database layer.
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	identityCollection := p.db.Collection(schemas.Collections.FederatedIdentity, options.Collection())
+	_, err := identityCollection.InsertOne(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for a (orgID, issuer, subject) triple.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	var identity *schemas.FederatedIdentity
+	identityCollection := p.db.Collection(schemas.Collections.FederatedIdentity, options.Collection())
+	err := identityCollection.FindOne(ctx, bson.M{"org_id": orgID, "issuer": issuer, "subject": subject}).Decode(&identity)
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -254,6 +254,20 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// FederatedIdentity collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.FederatedIdentity, options.CreateCollection())
+	federatedIdentityCollection := mongodb.Collection(schemas.Collections.FederatedIdentity, options.Collection())
+	_, _ = federatedIdentityCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "org_id", Value: 1}, {Key: "issuer", Value: 1}, {Key: "subject", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.M{"user_id": 1},
+			Options: options.Index().SetSparse(true),
+		},
+	}, options.CreateIndexes())
+
 	return &provider{
 		config:       config,
 		dependencies: deps,

--- a/internal/storage/db/mongodb/trusted_issuer.go
+++ b/internal/storage/db/mongodb/trusted_issuer.go
@@ -80,6 +80,17 @@ func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL st
 	return issuer, nil
 }
 
+// GetTrustedIssuerByOrgIDAndKind fetches a trusted issuer by its (org_id, kind) pair.
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	var issuer *schemas.TrustedIssuer
+	issuerCollection := p.db.Collection(schemas.Collections.TrustedIssuer, options.Collection())
+	err := issuerCollection.FindOne(ctx, bson.M{"org_id": orgID, "kind": kind}).Decode(&issuer)
+	if err != nil {
+		return nil, err
+	}
+	return issuer, nil
+}
+
 // ListTrustedIssuers returns paginated trusted issuers, optionally filtered by serviceAccountID.
 func (p *provider) ListTrustedIssuers(ctx context.Context, serviceAccountID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error) {
 	issuers := []*schemas.TrustedIssuer{}

--- a/internal/storage/db/sql/federated_identity.go
+++ b/internal/storage/db/sql/federated_identity.go
@@ -1,0 +1,37 @@
+package sql
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddFederatedIdentity creates a new federated identity. The composite unique
+// index on (org_id, issuer, subject) rejects duplicates at the database layer.
+func (p *provider) AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error) {
+	if identity.ID == "" {
+		identity.ID = uuid.New().String()
+	}
+	identity.Key = identity.ID
+	now := time.Now().Unix()
+	identity.CreatedAt = now
+	identity.UpdatedAt = now
+	res := p.db.Create(identity)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return identity, nil
+}
+
+// GetFederatedIdentity fetches the federated identity for a (orgID, issuer, subject) tuple.
+func (p *provider) GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error) {
+	var identity schemas.FederatedIdentity
+	res := p.db.Where("org_id = ? AND issuer = ? AND subject = ?", orgID, issuer, subject).First(&identity)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &identity, nil
+}

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/sql/trusted_issuer.go
+++ b/internal/storage/db/sql/trusted_issuer.go
@@ -69,6 +69,16 @@ func (p *provider) GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL st
 	return &issuer, nil
 }
 
+// GetTrustedIssuerByOrgIDAndKind fetches a trusted issuer by (orgID, kind).
+func (p *provider) GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error) {
+	var issuer schemas.TrustedIssuer
+	res := p.db.Where("org_id = ? AND kind = ?", orgID, kind).First(&issuer)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &issuer, nil
+}
+
 // ListTrustedIssuers returns paginated trusted issuers, optionally filtered by serviceAccountID.
 func (p *provider) ListTrustedIssuers(ctx context.Context, serviceAccountID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error) {
 	var issuers []*schemas.TrustedIssuer

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -213,7 +213,16 @@ type Provider interface {
 	GetTrustedIssuerByID(ctx context.Context, id string) (*schemas.TrustedIssuer, error)
 	// GetTrustedIssuerByIssuerURL fetches by issuer URL (unique index).
 	// This is called on every client_assertion validation — keep it fast.
+	//
+	// SECURITY (CR1): issuer_url is globally unique, so at most one row exists per
+	// URL. The client_assertion resolver additionally rejects any row whose
+	// EffectiveKind is not client_assertion_trust (or whose OrgID is non-empty), so
+	// an sso_oidc row registered at the same URL can never authenticate a client.
 	GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL string) (*schemas.TrustedIssuer, error)
+	// GetTrustedIssuerByOrgIDAndKind fetches the single trusted issuer for an
+	// organization of a given kind — used to resolve an org's sso_oidc connection.
+	// Returns an error when no matching row exists.
+	GetTrustedIssuerByOrgIDAndKind(ctx context.Context, orgID, kind string) (*schemas.TrustedIssuer, error)
 	// ListTrustedIssuers returns trusted issuers filtered by serviceAccountID.
 	// Pass an empty serviceAccountID to list all issuers.
 	ListTrustedIssuers(ctx context.Context, serviceAccountID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error)
@@ -249,6 +258,16 @@ type Provider interface {
 	ListOrgMembershipsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
 	// ListOrgMembershipsByUser returns paginated memberships held by a user.
 	ListOrgMembershipsByUser(ctx context.Context, userID string, pagination *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error)
+
+	// FederatedIdentity methods (SSO JIT provisioning, account-takeover defense).
+
+	// AddFederatedIdentity records a JIT-provisioned upstream identity. The
+	// (org_id, issuer, subject) triple is unique — adding a duplicate returns an
+	// error.
+	AddFederatedIdentity(ctx context.Context, identity *schemas.FederatedIdentity) (*schemas.FederatedIdentity, error)
+	// GetFederatedIdentity fetches the identity for a (orgID, issuer, subject)
+	// triple. Returns an error when no matching row exists.
+	GetFederatedIdentity(ctx context.Context, orgID, issuer, subject string) (*schemas.FederatedIdentity, error)
 }
 
 // New creates a new database provider based on the configuration

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"os"
 	"strings"
@@ -193,6 +194,10 @@ func TestStorageProvider(t *testing.T) {
 
 			t.Run("Org Membership Operations", func(t *testing.T) {
 				testOrgMembershipOperations(t, ctx, provider)
+			})
+
+			t.Run("Org OIDC Connection & Federated Identity Operations", func(t *testing.T) {
+				testOrgOIDCAndFederatedOperations(t, ctx, provider, dbType)
 			})
 
 			if isSQLTestDB(dbType) {
@@ -1638,4 +1643,68 @@ func testOrgMembershipOperations(t *testing.T, ctx context.Context, provider Pro
 
 	require.NoError(t, provider.DeleteOrganization(ctx, orgA))
 	require.NoError(t, provider.DeleteOrganization(ctx, orgB))
+}
+
+// testOrgOIDCAndFederatedOperations exercises the sso_oidc TrustedIssuer fields
+// (esp. the encrypted upstream secret round-trip + its json:"-" tag), the
+// GetTrustedIssuerByOrgIDAndKind lookup, and FederatedIdentity Add/Get across
+// every backend.
+func testOrgOIDCAndFederatedOperations(t *testing.T, ctx context.Context, provider Provider, dbType string) {
+	orgID := "org-" + uuid.New().String()
+	issuerURL := "https://idp-" + uuid.New().String() + ".example.com"
+
+	conn, err := provider.AddTrustedIssuer(ctx, &schemas.TrustedIssuer{
+		Kind:               constants.TrustKindSSOOIDC,
+		OrgID:              orgID,
+		Name:               "conn_" + uuid.New().String(),
+		IssuerURL:          issuerURL,
+		KeySourceType:      "oidc_discovery",
+		IssuerType:         "oidc",
+		AuthMethod:         "jwt_assertion",
+		SSOClientID:        "rp-client-id",
+		SSOClientSecretEnc: "ENCRYPTED-SECRET-VALUE",
+		SSOScopes:          "openid profile email",
+		SSORedirectURI:     "https://authorizer.example.com/oauth/sso/x/callback",
+		IsActive:           true,
+	})
+	require.NoError(t, err)
+	connID := conn.AsAPITrustedIssuer().ID
+	require.NotEmpty(t, connID)
+
+	// Round-trip: every SSO field, especially the encrypted secret, must persist.
+	fetched, err := provider.GetTrustedIssuerByID(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, constants.TrustKindSSOOIDC, fetched.Kind)
+	assert.Equal(t, orgID, fetched.OrgID)
+	assert.Equal(t, "rp-client-id", fetched.SSOClientID)
+	assert.Equal(t, "ENCRYPTED-SECRET-VALUE", fetched.SSOClientSecretEnc, "upstream secret must persist across write->read on "+dbType)
+	assert.Equal(t, "openid profile email", fetched.SSOScopes)
+	assert.Equal(t, "https://authorizer.example.com/oauth/sso/x/callback", fetched.SSORedirectURI)
+
+	// json:"-" — the secret must NEVER serialize into a JSON projection.
+	raw, err := json.Marshal(fetched)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "ENCRYPTED-SECRET-VALUE", "sso_client_secret_enc must not serialize (json:\"-\")")
+	assert.Contains(t, string(raw), issuerURL, "non-secret fields still serialize")
+
+	// GetTrustedIssuerByOrgIDAndKind resolves the org's connection.
+	byOrg, err := provider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOOIDC)
+	require.NoError(t, err)
+	assert.Equal(t, connID, byOrg.AsAPITrustedIssuer().ID)
+
+	// FederatedIdentity round-trip.
+	sub := "sub-" + uuid.New().String()
+	userID := "user-" + uuid.New().String()
+	_, err = provider.AddFederatedIdentity(ctx, &schemas.FederatedIdentity{
+		OrgID: orgID, Issuer: issuerURL, Subject: sub, UserID: userID,
+	})
+	require.NoError(t, err)
+
+	fi, err := provider.GetFederatedIdentity(ctx, orgID, issuerURL, sub)
+	require.NoError(t, err)
+	assert.Equal(t, userID, fi.UserID)
+
+	// A different subject at the same (org, issuer) is a distinct identity.
+	_, err = provider.GetFederatedIdentity(ctx, orgID, issuerURL, "unknown-sub")
+	assert.Error(t, err, "unknown federated identity must not resolve")
 }

--- a/internal/storage/schemas/federated_identity.go
+++ b/internal/storage/schemas/federated_identity.go
@@ -1,0 +1,40 @@
+package schemas
+
+// FederatedIdentity records that an end user was provisioned (JIT) from a
+// specific upstream identity at a specific organization's SSO connection.
+//
+// SECURITY (design §4.4, account-takeover defense): a federated login is keyed
+// by the tuple (OrgID, Issuer, Subject) — NEVER by email alone. On callback the
+// broker looks up this row to find the already-provisioned Authorizer user for a
+// returning federated principal; an email that merely collides with some other
+// account is NOT sufficient to link. The (org_id, issuer, subject) triple is
+// UNIQUE: the SQL providers enforce it with a composite unique index; the NoSQL
+// providers enforce it with a compound unique index (Mongo/Arango) or a
+// check-then-insert guard (Cassandra/Couchbase/DynamoDB). The service layer also
+// looks up before inserting so behaviour is uniform across every backend.
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type FederatedIdentity struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID is the organization whose SSO connection provisioned the identity.
+	// Part of the unique (org_id, issuer, subject) constraint.
+	OrgID string `gorm:"uniqueIndex:idx_federated_identity_org_iss_sub" json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" index:"org_id,hash"`
+
+	// Issuer is the upstream IdP's `iss` claim value.
+	// Part of the unique (org_id, issuer, subject) constraint.
+	Issuer string `gorm:"uniqueIndex:idx_federated_identity_org_iss_sub" json:"issuer" bson:"issuer" cql:"issuer" dynamo:"issuer"`
+
+	// Subject is the upstream `sub` claim value (stable per-IdP user identifier).
+	// Part of the unique (org_id, issuer, subject) constraint.
+	Subject string `gorm:"uniqueIndex:idx_federated_identity_org_iss_sub" json:"subject" bson:"subject" cql:"subject" dynamo:"subject"`
+
+	// UserID is the Authorizer user this federated identity maps to.
+	UserID string `json:"user_id" bson:"user_id" cql:"user_id" dynamo:"user_id" gorm:"index" index:"user_id,hash"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -20,6 +20,7 @@ type CollectionList struct {
 	TrustedIssuer          string
 	Organization           string
 	OrgMembership          string
+	FederatedIdentity      string
 }
 
 var (
@@ -45,5 +46,6 @@ var (
 		TrustedIssuer:          Prefix + "trusted_issuers",
 		Organization:           Prefix + "organizations",
 		OrgMembership:          Prefix + "org_memberships",
+		FederatedIdentity:      Prefix + "federated_identities",
 	}
 )

--- a/internal/storage/schemas/trusted_issuer.go
+++ b/internal/storage/schemas/trusted_issuer.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"strings"
 
+	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/refs"
 )
@@ -43,6 +44,23 @@ type TrustedIssuer struct {
 	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
 
 	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// Kind discriminates the trust relationship this row represents (design §4.3 /
+	// §5 K1): constants.TrustKindClientAssertion (default), TrustKindSSOOIDC, or
+	// TrustKindSSOSAML (reserved). Immutable after creation.
+	//
+	// SECURITY (design §5.2 CR1): the client_assertion resolver accepts ONLY
+	// client_assertion_trust rows (with an empty OrgID). An sso_oidc row — which
+	// has NO subject pin — must never be reachable on the client-authentication
+	// path. A pre-existing row written before this column existed reads back as ""
+	// and is interpreted as client_assertion_trust by EffectiveKind, so upgrades
+	// don't break existing trust rows.
+	Kind string `json:"kind" bson:"kind" cql:"kind" dynamo:"kind" gorm:"default:'client_assertion_trust'"`
+
+	// OrgID scopes an SSO connection (sso_oidc/sso_saml) to one Organization.
+	// EMPTY for client_assertion_trust rows (which are instance-global). Immutable.
+	// Part of the (kind, org_id) lookup that finds an org's SSO connection.
+	OrgID string `json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" gorm:"index" index:"org_id,hash"`
 
 	// ClientID links this issuer to the Client it authenticates.
 	ClientID string `json:"client_id" bson:"client_id" cql:"client_id" dynamo:"client_id" gorm:"index" index:"client_id,hash"`
@@ -126,8 +144,43 @@ type TrustedIssuer struct {
 	// that carry the header MUST be rejected to prevent certificate spoofing.
 	TrustedProxyCIDRs *string `json:"trusted_proxy_cidrs" bson:"trusted_proxy_cidrs" cql:"trusted_proxy_cidrs" dynamo:"trusted_proxy_cidrs"`
 
+	// --- SSO OIDC broker (kind = sso_oidc) ---
+	// These fields hold the upstream IdP configuration Authorizer uses as the
+	// Relying Party. They are empty on client_assertion_trust rows.
+
+	// SSOClientID is the client_id Authorizer was issued AT the upstream IdP.
+	SSOClientID string `json:"sso_client_id" bson:"sso_client_id" cql:"sso_client_id" dynamo:"sso_client_id"`
+
+	// SSOClientSecretEnc is the upstream client_secret, AES-encrypted at rest
+	// (crypto.EncryptAES keyed on Config.ClientSecret — reversible because the
+	// value is replayed to the upstream token endpoint; a bcrypt hash could not be
+	// used). json:"-" so it NEVER serializes into an API/webhook/log projection.
+	SSOClientSecretEnc string `json:"-" bson:"sso_client_secret_enc" cql:"sso_client_secret_enc" dynamo:"sso_client_secret_enc"`
+
+	// SSOScopes is the space-separated scope set requested at the upstream IdP.
+	// Defaults to "openid profile email" when empty.
+	SSOScopes string `json:"sso_scopes" bson:"sso_scopes" cql:"sso_scopes" dynamo:"sso_scopes"`
+
+	// SSORedirectURI is the redirect_uri registered at the upstream IdP that points
+	// back at Authorizer's broker callback. When empty the broker derives
+	// {scheme}://{host}/oauth/sso/{org}/callback from the request host.
+	SSORedirectURI string `json:"sso_redirect_uri" bson:"sso_redirect_uri" cql:"sso_redirect_uri" dynamo:"sso_redirect_uri"`
+
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// EffectiveKind returns the row's Kind, treating an empty value as
+// TrustKindClientAssertion. A row written before the kind column existed reads
+// back with an empty Kind; interpreting that as client_assertion_trust keeps
+// existing trust rows working across an upgrade AND keeps the CR1 guard correct
+// (an sso_oidc row always carries an explicit non-empty Kind, so it can never be
+// mistaken for a client_assertion row).
+func (t *TrustedIssuer) EffectiveKind() string {
+	if strings.TrimSpace(t.Kind) == "" {
+		return constants.TrustKindClientAssertion
+	}
+	return t.Kind
 }
 
 // ParsedAllowedSubjects returns AllowedSubjects as a slice: comma-separated,


### PR DESCRIPTION
## Summary

Per-organization **enterprise OIDC SSO** with Authorizer as the Relying Party / broker: an org configures its upstream OIDC IdP (Okta/Entra/Google), its users log in through that IdP, and Authorizer JIT-provisions them + issues a session. Also lands the `TrustedIssuer.Kind` discriminator (unifying that table per design §4.3) and the **CR1** kind-confusion fix. **SAML SP is deferred** to its own focused PR (it stacks on this `kind` discriminator).

## What's here

- **`TrustedIssuer.Kind`** (`client_assertion_trust` default | `sso_oidc` | `sso_saml` reserved), immutable; `OrgID` + SSO connection fields; new **`federated_identities`** table (unique `(org_id, issuer, subject)`) — across all 6 providers, existing rows backfill to `client_assertion_trust`.
- **CR1 fix**: the `client_assertion` path rejects any row that isn't `kind=client_assertion_trust` with empty `org_id` — an org's `sso_oidc` row (no subject pin) can never authenticate an OAuth client.
- **Broker** (`/oauth/sso/:org_slug/{login,callback}`): PKCE+nonce to the upstream, code exchange, ID-token validation, JIT provisioning, Authorizer session.
- **Admin**: `_`-prefixed GraphQL to manage an org's OIDC connection (upstream secret AES-encrypted, `json:"-"`).

## Security (reviewed → **ship, no CRITICAL/HIGH**)

- **CR1** holds (guarded on kind AND org_id; only caller of that lookup).
- **Mix-up (G3/RFC 9207)** — `id_token.iss` bound to the dispatching connection, per-connection single-use 256-bit `state`, `iss` param checked.
- **Account-takeover** — resolved only by `(org_id, issuer, sub)`, never email; email collision fail-closes (auto-linking would be the classic federated takeover — ruled the correct posture).
- ID-token validation (asymmetric-only, `alg:none`/HS* rejected, iss/aud/exp/nonce), SSRF-hardened upstream fetches, PKCE/state/redirect hygiene, upstream secret HKDF+GCM at rest.

## Review findings addressed

- **LOW-1** (fixed): JIT now deletes the orphaned user if `AddFederatedIdentity` fails after `AddUser` (was a self-inflicted lockout).
- **LOW-2** (fixed): `azp` verified when `aud` is multi-valued (OIDC Core §3.1.3.7).

## Testing

- Security matrix: CR1 (3 cases), mix-up (state swap/replay/forge/iss), account-takeover (collision/returning/new), ID-token (alg:none/wrong-sig/aud/nonce/expired), orphan-cleanup, multi-aud azp.
- **`make test-all-db` green across all 7 DBs** (independently re-run); `TEST_DBS=sqlite` green; `make lint-go` 0 issues; no codegen drift.
- Fixed a DynamoDB bug found by `test-all-db`: `sso_oidc` rows have empty `client_id` (a GSI key) → `dynamo:"client_id,omitempty"` for a sparse GSI.

## Deferred (ponytail-noted)

SAML SP; gRPC admin mirror + dashboard UI; org-scoped admin model (ops are super-admin-gated for now); a dedicated `--sso-encryption-key` (LOW hardening — the shared key is HKDF-domain-separated so not a crypto weakness).
