### PR TITLE
feat(oauth): RFC 8693 token-exchange delegation (agentic on-behalf-of)

### DIFF
--- a/internal/http_handlers/openid_config.go
+++ b/internal/http_handlers/openid_config.go
@@ -30,7 +30,7 @@ func (h *httpProvider) OpenIDConfigurationHandler() gin.HandlerFunc {
 		// "implicit" corresponds to response_type=token / id_token / id_token token.
 		// "client_credentials" is the machine/service-account grant (RFC 6749 §4.4)
 		// served by the token endpoint via the client registry.
-		grantTypes := []string{"authorization_code", "refresh_token", "client_credentials", "implicit"}
+		grantTypes := []string{"authorization_code", "refresh_token", "client_credentials", "implicit", "urn:ietf:params:oauth:grant-type:token-exchange"}
 
 		// Back-channel logout is advertised only when the operator has
 		// configured a backchannel_logout_uri — avoids lying to RPs.

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -41,6 +41,15 @@ type RequestBody struct {
 	// credential — the secretless workload-identity path (K8s SA tokens etc.).
 	ClientAssertion     string `form:"client_assertion" json:"client_assertion"`
 	ClientAssertionType string `form:"client_assertion_type" json:"client_assertion_type"`
+	// RFC 8693 token-exchange parameters. SubjectToken carries the authority
+	// being exercised (the user's token); ActorToken carries the actor (the
+	// agent's token) — its presence selects the delegation profile. The `resource`
+	// parameter (RFC 8707) is read separately via PostFormArray so a repeated
+	// value can be rejected.
+	SubjectToken     string `form:"subject_token" json:"subject_token"`
+	SubjectTokenType string `form:"subject_token_type" json:"subject_token_type"`
+	ActorToken       string `form:"actor_token" json:"actor_token"`
+	ActorTokenType   string `form:"actor_token_type" json:"actor_token_type"`
 }
 
 // TokenHandler to handle /oauth/token requests
@@ -76,8 +85,9 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 		isRefreshTokenGrant := grantType == "refresh_token"
 		isAuthorizationCodeGrant := grantType == "authorization_code"
 		isClientCredentialsGrant := grantType == constants.GrantTypeClientCredentials
+		isTokenExchangeGrant := grantType == constants.GrantTypeTokenExchange
 
-		if !isRefreshTokenGrant && !isAuthorizationCodeGrant && !isClientCredentialsGrant {
+		if !isRefreshTokenGrant && !isAuthorizationCodeGrant && !isClientCredentialsGrant && !isTokenExchangeGrant {
 			log.Debug().Str("grant_type", grantType).Msg("Invalid grant type")
 			gc.JSON(http.StatusBadRequest, gin.H{
 				"error":             "unsupported_grant_type",
@@ -114,12 +124,13 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			// verifies a presented secret (PKCE gates a secret-less request);
 			// refresh_token ignores the secret and authenticates the client_id
 			// only — preserving the pre-registry behavior of each grant.
-			RequireSecret:         isClientCredentialsGrant,
+			RequireSecret:         isClientCredentialsGrant || isTokenExchangeGrant,
 			VerifyPresentedSecret: isAuthorizationCodeGrant,
-			// client_credentials is machine-only (design §4.1): the resolver rejects a
-			// non-service_account client before verifying the secret, so an interactive
-			// client_id cannot confirm a guessed secret on this grant.
-			RequireServiceAccountKind: isClientCredentialsGrant,
+			// client_credentials and token-exchange are machine-only: the calling
+			// client is the agent's service account (design §4.1 / §3). The resolver
+			// rejects a non-service_account client before verifying the secret, so an
+			// interactive client_id cannot confirm a guessed secret on these grants.
+			RequireServiceAccountKind: isClientCredentialsGrant || isTokenExchangeGrant,
 		})
 		if authErr != nil {
 			h.respondClientAuthError(gc, authErr, resolvedClient, isClientCredentialsGrant)
@@ -130,6 +141,14 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 		// already authenticated the service_account; issue its scoped token here.
 		if isClientCredentialsGrant {
 			h.handleClientCredentialsGrant(gc, resolvedClient, scopeParam)
+			return
+		}
+
+		// RFC 8693 token-exchange (delegation): the resolver has already
+		// authenticated the calling agent's service_account. Mint the delegated,
+		// attenuated, resource-bound token carrying the nested `act` chain.
+		if isTokenExchangeGrant {
+			h.handleTokenExchangeGrant(gc, resolvedClient, &reqBody, scopeParam)
 			return
 		}
 

--- a/internal/http_handlers/token_exchange.go
+++ b/internal/http_handlers/token_exchange.go
@@ -88,11 +88,25 @@ func (h *httpProvider) handleTokenExchangeGrant(gc *gin.Context, agent *schemas.
 		})
 		return
 	}
-	if _, err := h.validateExchangeToken(actorToken, hostname); err != nil {
+	actorClaims, err := h.validateExchangeToken(actorToken, hostname)
+	if err != nil {
 		log.Debug().Err(err).Msg("invalid actor_token")
 		gc.JSON(http.StatusBadRequest, gin.H{
 			"error":             "invalid_grant",
 			"error_description": "The actor_token is invalid or has expired",
+		})
+		return
+	}
+	// RFC 8693 §1.1: the actor_token represents the acting party. Bind it to the
+	// authenticated agent — a valid-but-unrelated token must not stand in as the
+	// actor. The agent's own machine token (client_credentials) carries
+	// sub = the service-account's surrogate ID (see token.go ServiceAccountID: sa.ID),
+	// so require the actor_token's subject to be this client.
+	if actorSub, _ := actorClaims["sub"].(string); actorSub != agent.ID {
+		log.Debug().Msg("actor_token does not belong to the authenticated client")
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_grant",
+			"error_description": "The actor_token must belong to the authenticated client",
 		})
 		return
 	}
@@ -107,11 +121,25 @@ func (h *httpProvider) handleTokenExchangeGrant(gc *gin.Context, agent *schemas.
 	}
 
 	// Fail-closed on a revoked authority source: a deprovisioned user (SCIM
-	// active:false / RevokedTimestamp) must never seed a fresh delegation. A sub
-	// that resolves to no user (e.g. a service-account authority) is left alone —
-	// this only demotes, mirroring the introspection revocation check.
+	// active:false / RevokedTimestamp) must never seed a fresh delegation.
+	// Distinguish a machine/service-account subject (a multi-hop agent chain, which
+	// has no user row) from a user subject by the token's login_method — NOT by a
+	// failed user lookup, so a transient DB error can't be silently treated as
+	// "not a user" and fail open past the revocation check.
 	onBehalfOfType := constants.AuditActorTypeUser
-	if user, uErr := h.StorageProvider.GetUserByID(gc, subject); uErr == nil && user != nil {
+	if lm, _ := subjectClaims["login_method"].(string); lm == constants.AuthRecipeMethodServiceAccount {
+		onBehalfOfType = "agent"
+	} else {
+		user, uErr := h.StorageProvider.GetUserByID(gc, subject)
+		if uErr != nil || user == nil {
+			// A user authority we cannot load must not seed a delegation (fail closed).
+			log.Debug().Err(uErr).Msg("subject user could not be verified")
+			gc.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_grant",
+				"error_description": "The subject could not be verified",
+			})
+			return
+		}
 		if user.RevokedTimestamp != nil {
 			gc.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_grant",
@@ -119,8 +147,6 @@ func (h *httpProvider) handleTokenExchangeGrant(gc *gin.Context, agent *schemas.
 			})
 			return
 		}
-	} else {
-		onBehalfOfType = "agent"
 	}
 
 	// Attenuation (DC2/H1), fail-closed: effective = subject_scope ∩ agent_ceiling

--- a/internal/http_handlers/token_exchange.go
+++ b/internal/http_handlers/token_exchange.go
@@ -1,0 +1,329 @@
+package http_handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/parsers"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// maxActChainDepth caps the RFC 8693 `act` delegation nesting (design H1). A
+// resulting chain deeper than this is rejected — an unbounded chain is both a
+// token-bloat and an audit-legibility risk, and real delegation is a few hops
+// (app > agent > sub-agent). Hard-coded rather than configurable: no operator
+// need to loosen it has surfaced; promote to config if one ever does.
+const maxActChainDepth = 4
+
+// handleTokenExchangeGrant implements the RFC 8693 token-exchange grant in the
+// DELEGATION-ONLY profile (design §3, DC1). The calling client (agent) has
+// already been authenticated by the clientauth resolver as an active
+// service_account; agent is that resolved client. It mints a short-lived,
+// resource-bound (RFC 8707), attenuated access token that carries the nested
+// `act` actor chain and whose `sub` is the subject_token's user. Impersonation
+// (a subject-only exchange) is intentionally rejected here — it is a separate,
+// admin-gated design.
+func (h *httpProvider) handleTokenExchangeGrant(gc *gin.Context, agent *schemas.Client, reqBody *RequestBody, scopeParam string) {
+	log := h.Log.With().Str("func", "handleTokenExchangeGrant").Logger()
+
+	subjectToken := strings.TrimSpace(reqBody.SubjectToken)
+	subjectTokenType := strings.TrimSpace(reqBody.SubjectTokenType)
+	actorToken := strings.TrimSpace(reqBody.ActorToken)
+	actorTokenType := strings.TrimSpace(reqBody.ActorTokenType)
+
+	// RFC 8693 §2.1: subject_token and subject_token_type are REQUIRED.
+	if subjectToken == "" || subjectTokenType == "" {
+		badTokenExchangeRequest(gc, "subject_token and subject_token_type are required")
+		return
+	}
+	if !isSupportedExchangeTokenType(subjectTokenType) {
+		badTokenExchangeRequest(gc, "unsupported subject_token_type")
+		return
+	}
+
+	// Delegation-only (DC1 / P3): an actor_token MUST be present. A subject-only
+	// exchange is impersonation — a separate, admin-gated design not served on
+	// this endpoint. Reject fail-closed rather than silently impersonating.
+	if actorToken == "" {
+		badTokenExchangeRequest(gc, "actor_token is required: only the delegation profile is supported here (impersonation is not permitted)")
+		return
+	}
+	if actorTokenType == "" || !isSupportedExchangeTokenType(actorTokenType) {
+		badTokenExchangeRequest(gc, "unsupported or missing actor_token_type")
+		return
+	}
+
+	// RFC 8707 (DC4): EXACTLY ONE resource must bind the exchanged token. Read the
+	// raw repeated form values so both 0 and >1 are rejected — a multi-audience
+	// delegated token would be replayable across resource servers. Scoped to the
+	// token-exchange path only; other grants are unaffected.
+	resources := gc.PostFormArray("resource")
+	if len(resources) != 1 || strings.TrimSpace(resources[0]) == "" {
+		badTokenExchangeRequest(gc, "exactly one resource parameter is required")
+		return
+	}
+	resource := strings.TrimSpace(resources[0])
+
+	hostname := parsers.GetHost(gc)
+
+	// Validate both tokens are valid, unexpired, Authorizer-issued access tokens
+	// (signature + exp via ParseJWTToken, iss bound to this host, token_type).
+	subjectClaims, err := h.validateExchangeToken(subjectToken, hostname)
+	if err != nil {
+		log.Debug().Err(err).Msg("invalid subject_token")
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_grant",
+			"error_description": "The subject_token is invalid or has expired",
+		})
+		return
+	}
+	if _, err := h.validateExchangeToken(actorToken, hostname); err != nil {
+		log.Debug().Err(err).Msg("invalid actor_token")
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_grant",
+			"error_description": "The actor_token is invalid or has expired",
+		})
+		return
+	}
+
+	subject, _ := subjectClaims["sub"].(string)
+	if subject == "" {
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_grant",
+			"error_description": "The subject_token has no subject",
+		})
+		return
+	}
+
+	// Fail-closed on a revoked authority source: a deprovisioned user (SCIM
+	// active:false / RevokedTimestamp) must never seed a fresh delegation. A sub
+	// that resolves to no user (e.g. a service-account authority) is left alone —
+	// this only demotes, mirroring the introspection revocation check.
+	onBehalfOfType := constants.AuditActorTypeUser
+	if user, uErr := h.StorageProvider.GetUserByID(gc, subject); uErr == nil && user != nil {
+		if user.RevokedTimestamp != nil {
+			gc.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_grant",
+				"error_description": "The subject is no longer active",
+			})
+			return
+		}
+	} else {
+		onBehalfOfType = "agent"
+	}
+
+	// Attenuation (DC2/H1), fail-closed: effective = subject_scope ∩ agent_ceiling
+	// (∩ requested when a scope was asked for). Monotonic non-widening: because we
+	// ALWAYS intersect the subject_token's own scope, re-exchanging an
+	// already-narrowed delegated token can only narrow further — never restore.
+	subjectScope := claimToStringSlice(subjectClaims["scope"])
+	ceiling := agent.ParsedAllowedScopes()
+	if len(ceiling) == 0 {
+		// Empty AllowedScopes is DENY-ALL (schema § AllowedScopes) — an agent with
+		// no ceiling can delegate nothing.
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_scope",
+			"error_description": "The agent has no authorized scopes",
+		})
+		return
+	}
+	effective := intersectScopes(subjectScope, ceiling)
+	if requested := strings.Fields(scopeParam); len(requested) > 0 {
+		effective = intersectScopes(effective, requested)
+	}
+	if len(effective) == 0 {
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_scope",
+			"error_description": "The requested scope is empty after attenuation against the subject and the agent ceiling",
+		})
+		return
+	}
+
+	// Nested `act` (DC3 / RFC 8693 §4.1): the immediate actor is the
+	// AUTHENTICATED agent (its registered client_id — never a token-supplied
+	// claim), and any prior act chain carried on the subject_token nests beneath
+	// it, giving a multi-hop app > agent > sub-agent chain.
+	act := map[string]interface{}{"sub": agent.ClientID}
+	if prior, ok := subjectClaims["act"].(map[string]interface{}); ok && len(prior) > 0 {
+		act["act"] = prior
+	}
+	if actChainDepth(act) > maxActChainDepth {
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_request",
+			"error_description": "The delegation chain exceeds the maximum allowed depth",
+		})
+		return
+	}
+
+	delegated, err := h.TokenProvider.CreateDelegatedAccessToken(&token.DelegationTokenConfig{
+		Subject:  subject,
+		Actor:    act,
+		Audience: resource,
+		Scope:    effective,
+		ClientID: agent.ClientID,
+		HostName: hostname,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to mint delegated token")
+		gc.JSON(http.StatusInternalServerError, gin.H{
+			"error":             "server_error",
+			"error_description": "Could not complete token issuance",
+		})
+		return
+	}
+
+	expiresIn := delegated.ExpiresAt - time.Now().Unix()
+	if expiresIn <= 0 {
+		expiresIn = 1
+	}
+
+	// Audit the delegation chain (DC21). The audit schema has no dedicated
+	// on-behalf-of columns yet; fold actor + on-behalf-of + chain into the JSON
+	// Metadata column (queryable, zero multi-DB schema change). Promoting these to
+	// first-class columns across all providers is deferred — see design §5.
+	metadata, _ := json.Marshal(map[string]string{
+		"grant_type":        constants.GrantTypeTokenExchange,
+		"on_behalf_of":      subject,
+		"on_behalf_of_type": onBehalfOfType,
+		"delegation_chain":  delegationChainString(act, subject),
+		"resource":          resource,
+	})
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditTokenIssuedEvent,
+		ActorID:      agent.ID,
+		ActorType:    constants.AuditActorTypeServiceAccount,
+		ResourceType: constants.AuditResourceTypeToken,
+		ResourceID:   subject,
+		Metadata:     string(metadata),
+		IPAddress:    utils.GetIP(gc.Request),
+		UserAgent:    utils.GetUserAgent(gc.Request),
+	})
+
+	metrics.RecordAuthEvent(metrics.EventTokenIssued, metrics.StatusSuccess)
+
+	// RFC 8693 §2.2 token-exchange response.
+	gc.JSON(http.StatusOK, gin.H{
+		"access_token":      delegated.Token,
+		"issued_token_type": constants.TokenTypeURNAccessToken,
+		"token_type":        "Bearer",
+		"expires_in":        expiresIn,
+		"scope":             strings.Join(effective, " "),
+	})
+}
+
+// badTokenExchangeRequest writes the RFC 6749 §5.2 invalid_request response.
+func badTokenExchangeRequest(gc *gin.Context, desc string) {
+	gc.JSON(http.StatusBadRequest, gin.H{
+		"error":             "invalid_request",
+		"error_description": desc,
+	})
+}
+
+// isSupportedExchangeTokenType reports whether an RFC 8693 subject/actor token
+// type URN is one this delegation profile accepts (access token or generic JWT).
+func isSupportedExchangeTokenType(t string) bool {
+	return t == constants.TokenTypeURNAccessToken || t == constants.TokenTypeURNJWT
+}
+
+// validateExchangeToken verifies signature + exp (ParseJWTToken), binds iss to
+// this host, and requires token_type=access_token. It deliberately does NOT
+// require aud == this server's client_id: a first-party token's aud is the
+// client_id, but a prior *delegated* token's aud is a resource URI (the
+// sub-agent / multi-hop re-exchange case). Both are unforgeable — only this
+// server's key signs them and iss binds them to this host — so signature + iss +
+// token_type is the correct, non-widening trust gate for a token we issued.
+func (h *httpProvider) validateExchangeToken(tokenStr, hostname string) (jwt.MapClaims, error) {
+	claims, err := h.TokenProvider.ParseJWTToken(tokenStr)
+	if err != nil {
+		return nil, err
+	}
+	if iss, _ := claims["iss"].(string); iss == "" || iss != hostname {
+		return nil, errors.New("issuer mismatch")
+	}
+	if tt, _ := claims["token_type"].(string); tt != constants.TokenTypeAccessToken {
+		return nil, errors.New("token is not an access token")
+	}
+	return claims, nil
+}
+
+// claimToStringSlice coerces a JWT `scope` claim (parsed as []interface{}) into
+// a []string, dropping non-string / empty entries.
+func claimToStringSlice(v interface{}) []string {
+	switch vv := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(vv))
+		for _, e := range vv {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return vv
+	}
+	return nil
+}
+
+// intersectScopes returns the scopes present in both a and b, preserving a's
+// order and de-duplicating. This is the attenuation primitive.
+func intersectScopes(a, b []string) []string {
+	allowed := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		allowed[s] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	seen := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		if _, ok := allowed[s]; !ok {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// actChainDepth counts the nesting depth of an RFC 8693 `act` chain
+// (1 for a single actor, +1 per nested act).
+func actChainDepth(act map[string]interface{}) int {
+	depth := 0
+	for cur := act; cur != nil; {
+		depth++
+		next, _ := cur["act"].(map[string]interface{})
+		cur = next
+	}
+	return depth
+}
+
+// delegationChainString renders the actor chain for the audit log in the
+// design's inner→outer→subject order, e.g. "app:concierge>agent:bot>user:alice".
+func delegationChainString(act map[string]interface{}, subject string) string {
+	var actors []string
+	for cur := act; cur != nil; {
+		if s, _ := cur["sub"].(string); s != "" {
+			actors = append(actors, s)
+		}
+		next, _ := cur["act"].(map[string]interface{})
+		cur = next
+	}
+	parts := make([]string, 0, len(actors)+1)
+	for i := len(actors) - 1; i >= 0; i-- {
+		parts = append(parts, actors[i])
+	}
+	parts = append(parts, subject)
+	return strings.Join(parts, ">")
+}

--- a/internal/http_handlers/token_exchange_unit_test.go
+++ b/internal/http_handlers/token_exchange_unit_test.go
@@ -1,0 +1,58 @@
+package http_handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntersectScopes_Attenuation proves the RFC 8693 attenuation core (DC2/H1):
+// the effective scope can only NARROW. intersectScopes(requested, ceiling) returns
+// exactly the requested scopes that are also in the ceiling — never more.
+func TestIntersectScopes_Attenuation(t *testing.T) {
+	// Requesting a superset of the ceiling narrows to the ceiling's members only.
+	assert.ElementsMatch(t, []string{"read"},
+		intersectScopes([]string{"read", "write"}, []string{"read"}),
+		"a scope outside the ceiling must be dropped (non-widening)")
+
+	// A scope absent from the ceiling can never be granted — no widening.
+	assert.Empty(t, intersectScopes([]string{"admin"}, []string{"read", "write"}),
+		"requesting a scope not in the ceiling grants nothing")
+
+	// Empty ceiling is DENY-ALL.
+	assert.Empty(t, intersectScopes([]string{"read"}, nil), "empty ceiling denies all")
+	assert.Empty(t, intersectScopes([]string{"read"}, []string{}), "empty ceiling denies all")
+
+	// Duplicates are collapsed.
+	assert.Equal(t, []string{"read"}, intersectScopes([]string{"read", "read"}, []string{"read"}),
+		"duplicate requested scopes are deduplicated")
+
+	// Full overlap is preserved (order follows the requested list).
+	assert.Equal(t, []string{"read", "write"},
+		intersectScopes([]string{"read", "write"}, []string{"read", "write", "admin"}),
+		"scopes within the ceiling are preserved")
+
+	// Re-exchange (requested already ⊆ ceiling) is idempotent — can't grow.
+	once := intersectScopes([]string{"read", "write"}, []string{"read", "write", "admin"})
+	twice := intersectScopes(once, []string{"read", "write", "admin"})
+	assert.Equal(t, once, twice, "re-intersecting an attenuated set cannot re-widen it")
+}
+
+// TestActChainDepth proves the delegation-chain depth counter used to enforce the
+// hard nesting cap (H1): each nested `act` adds one hop.
+func TestActChainDepth(t *testing.T) {
+	assert.Equal(t, 0, actChainDepth(nil), "nil chain is depth 0")
+	assert.Equal(t, 1, actChainDepth(map[string]interface{}{"sub": "agent1"}),
+		"a single immediate actor is depth 1")
+	assert.Equal(t, 2, actChainDepth(map[string]interface{}{
+		"sub": "agent2",
+		"act": map[string]interface{}{"sub": "agent1"},
+	}), "one nested actor is depth 2")
+	assert.Equal(t, 3, actChainDepth(map[string]interface{}{
+		"sub": "agent3",
+		"act": map[string]interface{}{
+			"sub": "agent2",
+			"act": map[string]interface{}{"sub": "agent1"},
+		},
+	}), "two nested actors is depth 3")
+}

--- a/internal/integration_tests/token_exchange_test.go
+++ b/internal/integration_tests/token_exchange_test.go
@@ -1,0 +1,161 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const tokenExchangeGrant = "urn:ietf:params:oauth:grant-type:token-exchange"
+const accessTokenType = "urn:ietf:params:oauth:token-type:access_token"
+
+// decodeJWTPayload base64url-decodes a JWT's payload segment WITHOUT validating
+// signature or audience. A delegated token's `aud` is the bound resource (not the
+// deployment client_id), so the standard validator would reject it — the test
+// inspects the claims directly.
+func decodeJWTPayload(t *testing.T, tok string) map[string]interface{} {
+	t.Helper()
+	parts := strings.Split(tok, ".")
+	require.Len(t, parts, 3, "token must be a well-formed JWT")
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &claims))
+	return claims
+}
+
+// newDelegationAgent creates an active service_account client (the agent) with the
+// given scope ceiling, returning its client_id and plaintext secret.
+func newDelegationAgent(t *testing.T, ts *testSetup, ceiling string) (string, string) {
+	t.Helper()
+	secret := "agent-secret-" + uuid.New().String()
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	agent, err := ts.StorageProvider.AddClient(context.Background(), &schemas.Client{
+		Name:          "agent-" + uuid.New().String(),
+		Kind:          constants.ClientKindServiceAccount,
+		ClientSecret:  string(hash),
+		AllowedScopes: ceiling,
+		IsActive:      true,
+	})
+	require.NoError(t, err)
+	return agent.ClientID, secret
+}
+
+func postTokenExchange(ts *testSetup, router http.Handler, form url.Values, clientID, secret string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Match the host the minted subject/actor tokens use as their iss.
+	req.Header.Set("X-Authorizer-URL", testAuthorizerHost(ts))
+	req.SetBasicAuth(clientID, secret)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestTokenExchangeDelegation(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	baseForm := func(agentScopeCeiling string) (url.Values, string, string) {
+		clientID, secret := newDelegationAgent(t, ts, agentScopeCeiling)
+		subject := testAccessToken(t, ts)
+		actor := testAccessToken(t, ts)
+		form := url.Values{}
+		form.Set("grant_type", tokenExchangeGrant)
+		form.Set("subject_token", subject)
+		form.Set("subject_token_type", accessTokenType)
+		form.Set("actor_token", actor)
+		form.Set("actor_token_type", accessTokenType)
+		form.Set("resource", "https://api.example.com/v1")
+		return form, clientID, secret
+	}
+
+	t.Run("actor_token_required_delegation_only", func(t *testing.T) {
+		clientID, secret := newDelegationAgent(t, ts, "openid,profile,email")
+		form := url.Values{}
+		form.Set("grant_type", tokenExchangeGrant)
+		form.Set("subject_token", "any.subject.token")
+		form.Set("subject_token_type", accessTokenType)
+		form.Set("resource", "https://api.example.com/v1")
+		// no actor_token
+		w := postTokenExchange(ts, router, form, clientID, secret)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "actor_token", "impersonation (subject-only) must be rejected")
+	})
+
+	t.Run("exactly_one_resource_required", func(t *testing.T) {
+		clientID, secret := newDelegationAgent(t, ts, "openid,profile,email")
+		mk := func() url.Values {
+			f := url.Values{}
+			f.Set("grant_type", tokenExchangeGrant)
+			f.Set("subject_token", "any.subject.token")
+			f.Set("subject_token_type", accessTokenType)
+			f.Set("actor_token", "any.actor.token")
+			f.Set("actor_token_type", accessTokenType)
+			return f
+		}
+		// zero resources
+		w := postTokenExchange(ts, router, mk(), clientID, secret)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "no resource must be rejected")
+		// two resources
+		f := mk()
+		f.Add("resource", "https://a.example.com")
+		f.Add("resource", "https://b.example.com")
+		w = postTokenExchange(ts, router, f, clientID, secret)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "multiple resources must be rejected")
+	})
+
+	t.Run("happy_path_nested_act_and_resource_aud", func(t *testing.T) {
+		form, clientID, secret := baseForm("openid,profile,email,read")
+		form.Set("scope", "profile email")
+		w := postTokenExchange(ts, router, form, clientID, secret)
+		require.Equal(t, http.StatusOK, w.Code, "valid delegation must issue a token: %s", w.Body.String())
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		tok, _ := resp["access_token"].(string)
+		require.NotEmpty(t, tok)
+		claims := decodeJWTPayload(t, tok)
+		// aud is the single bound resource (RFC 8707).
+		assert.Equal(t, "https://api.example.com/v1", claims["aud"])
+		// sub is the user (authority source), not the agent.
+		assert.NotEmpty(t, claims["sub"])
+		// act carries the immediate actor = the calling agent's client_id (DC3).
+		act, ok := claims["act"].(map[string]interface{})
+		require.True(t, ok, "issued token must carry an act claim")
+		assert.Equal(t, clientID, act["sub"], "act.sub must be the delegating agent")
+	})
+
+	t.Run("attenuation_cannot_widen_beyond_agent_ceiling", func(t *testing.T) {
+		// Agent ceiling excludes "admin"; requesting it must not grant it.
+		form, clientID, secret := baseForm("openid,profile,email")
+		_ = clientID
+		form.Set("scope", "profile admin")
+		w := postTokenExchange(ts, router, form, clientID, secret)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		tok, _ := resp["access_token"].(string)
+		require.NotEmpty(t, tok)
+		claims := decodeJWTPayload(t, tok)
+		scope, _ := claims["scope"].(string)
+		assert.NotContains(t, strings.Fields(scope), "admin",
+			"a scope outside the agent's ceiling must never be granted (non-widening)")
+	})
+}

--- a/internal/integration_tests/token_exchange_test.go
+++ b/internal/integration_tests/token_exchange_test.go
@@ -56,6 +56,27 @@ func newDelegationAgent(t *testing.T, ts *testSetup, ceiling string) (string, st
 	return agent.ClientID, secret
 }
 
+// agentAccessToken mints the agent's OWN access token via client_credentials —
+// this is the token an agent presents as its actor_token (its client_id claim
+// binds it to the authenticated client per RFC 8693).
+func agentAccessToken(t *testing.T, ts *testSetup, router http.Handler, clientID, secret string) string {
+	t.Helper()
+	f := url.Values{}
+	f.Set("grant_type", "client_credentials")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(f.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Authorizer-URL", testAuthorizerHost(ts))
+	req.SetBasicAuth(clientID, secret)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "agent client_credentials must succeed: %s", w.Body.String())
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	tok, _ := resp["access_token"].(string)
+	require.NotEmpty(t, tok)
+	return tok
+}
+
 func postTokenExchange(ts *testSetup, router http.Handler, form url.Values, clientID, secret string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
@@ -76,7 +97,8 @@ func TestTokenExchangeDelegation(t *testing.T) {
 	baseForm := func(agentScopeCeiling string) (url.Values, string, string) {
 		clientID, secret := newDelegationAgent(t, ts, agentScopeCeiling)
 		subject := testAccessToken(t, ts)
-		actor := testAccessToken(t, ts)
+		// actor_token is the agent's OWN token (client_id bound to the agent).
+		actor := agentAccessToken(t, ts, router, clientID, secret)
 		form := url.Values{}
 		form.Set("grant_type", tokenExchangeGrant)
 		form.Set("subject_token", subject)
@@ -157,5 +179,21 @@ func TestTokenExchangeDelegation(t *testing.T) {
 		scope, _ := claims["scope"].(string)
 		assert.NotContains(t, strings.Fields(scope), "admin",
 			"a scope outside the agent's ceiling must never be granted (non-widening)")
+	})
+
+	t.Run("actor_token_must_belong_to_authenticated_agent", func(t *testing.T) {
+		// A valid token that is NOT the agent's own (here a user token, whose
+		// client_id != the agent) must be rejected as the actor (RFC 8693 §1.1).
+		clientID, secret := newDelegationAgent(t, ts, "openid,profile,email")
+		form := url.Values{}
+		form.Set("grant_type", tokenExchangeGrant)
+		form.Set("subject_token", testAccessToken(t, ts))
+		form.Set("subject_token_type", accessTokenType)
+		form.Set("actor_token", testAccessToken(t, ts)) // a user token, not the agent's
+		form.Set("actor_token_type", accessTokenType)
+		form.Set("resource", "https://api.example.com/v1")
+		w := postTokenExchange(ts, router, form, clientID, secret)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "actor_token", "a foreign actor_token must be rejected")
 	})
 }

--- a/internal/token/auth_token.go
+++ b/internal/token/auth_token.go
@@ -39,6 +39,12 @@ var reservedClaims = map[string]bool{
 	"auth_time":     true,
 	"amr":           true,
 	"acr":           true,
+	// act (RFC 8693 §4.1) carries the delegation actor chain and MUST NOT be
+	// forgeable by CustomAccessTokenScript — a script that could inject `act`
+	// into a first-party user token would fabricate a delegation. client_id
+	// (RFC 9068) identifies the actor and is likewise reserved.
+	"act":       true,
+	"client_id": true,
 }
 
 // AuthTokenConfig is the configuration for auth token

--- a/internal/token/delegation_token.go
+++ b/internal/token/delegation_token.go
@@ -1,0 +1,71 @@
+package token
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+)
+
+// DelegatedAccessTokenTTL is the fixed short lifetime of an exchanged delegation
+// token (AGENTIC_DELEGATION_DESIGN DC5: 5-minute baseline). Delegation tokens
+// are not refreshable — the agent re-exchanges — and sensitive-scope revocation
+// is enforced out of band via /oauth/introspect, so a short TTL bounds the blast
+// radius of a leaked token.
+const DelegatedAccessTokenTTL = 5 * time.Minute
+
+// accessTokenJWTType is the RFC 9068 media type stamped in the JWT header `typ`
+// of an OAuth2 access token.
+const accessTokenJWTType = "at+jwt"
+
+// DelegationTokenConfig configures an RFC 8693 delegated access token.
+type DelegationTokenConfig struct {
+	// Subject is the `sub` claim — the user (authority source) on whose behalf
+	// the actor acts. It is taken from the exchanged subject_token, never from a
+	// caller-supplied parameter.
+	Subject string
+	// Actor is the RFC 8693 §4.1 `act` claim: {"sub": <immediate actor>, "act":
+	// <prior chain>}. The caller builds this from the authenticated agent's
+	// client_id plus any prior act chain carried on the subject_token.
+	Actor map[string]interface{}
+	// Audience is the single RFC 8707 `resource` the token is bound to; it
+	// becomes the `aud` claim so the token is not replayable at another server.
+	Audience string
+	// Scope is the attenuated (intersected) scope set.
+	Scope []string
+	// ClientID is the authenticated calling agent's client_id (RFC 9068
+	// `client_id` claim) — the immediate actor's registered identity.
+	ClientID string
+	// HostName is the issuer (`iss`).
+	HostName string
+}
+
+// CreateDelegatedAccessToken mints the RFC 8693 delegation access token. Unlike
+// the first-party access tokens it is stateless (not registered in the memory
+// store) and its `aud` is the bound resource, not this server's client_id — it
+// is validated by the downstream resource server (local JWT verification and/or
+// /oauth/introspect), never by Authorizer's own ValidateAccessToken path. The
+// CUSTOM_ACCESS_TOKEN_SCRIPT is intentionally not run: `act`/`client_id` are
+// reserved and there is no resource-owner user object to feed the script.
+func (p *provider) CreateDelegatedAccessToken(cfg *DelegationTokenConfig) (*JWTToken, error) {
+	expiresAt := time.Now().Add(DelegatedAccessTokenTTL).Unix()
+	claims := jwt.MapClaims{
+		"iss":        cfg.HostName,
+		"aud":        cfg.Audience,
+		"sub":        cfg.Subject,
+		"exp":        expiresAt,
+		"iat":        time.Now().Unix(),
+		"jti":        uuid.New().String(),
+		"token_type": constants.TokenTypeAccessToken,
+		"scope":      cfg.Scope,
+		"client_id":  cfg.ClientID,
+		"act":        cfg.Actor,
+	}
+	signed, err := p.signJWTToken(claims, accessTokenJWTType)
+	if err != nil {
+		return nil, err
+	}
+	return &JWTToken{Token: signed, ExpiresAt: expiresAt}, nil
+}

--- a/internal/token/jwt.go
+++ b/internal/token/jwt.go
@@ -12,6 +12,13 @@ import (
 
 // SignJWTToken common util to sing jwt token
 func (p *provider) SignJWTToken(jwtclaims jwt.MapClaims) (string, error) {
+	return p.signJWTToken(jwtclaims, "")
+}
+
+// signJWTToken signs the claims, optionally stamping the JWT header `typ`
+// (RFC 9068: an OAuth2 access token uses "at+jwt"). An empty typ leaves the
+// default "JWT" header, preserving the behavior of every existing caller.
+func (p *provider) signJWTToken(jwtclaims jwt.MapClaims, typ string) (string, error) {
 	signingMethod := jwt.GetSigningMethod(p.config.JWTType)
 	if signingMethod == nil {
 		return "", errors.New("unsupported signing method")
@@ -21,6 +28,9 @@ func (p *provider) SignJWTToken(jwtclaims jwt.MapClaims) (string, error) {
 		return "", errors.New("unsupported signing method")
 	}
 	t.Claims = jwtclaims
+	if typ != "" {
+		t.Header["typ"] = typ
+	}
 
 	switch signingMethod {
 	case jwt.SigningMethodHS256, jwt.SigningMethodHS384, jwt.SigningMethodHS512:

--- a/internal/token/provider.go
+++ b/internal/token/provider.go
@@ -33,6 +33,9 @@ type Provider interface {
 	CreateAuthToken(gc *gin.Context, cfg *AuthTokenConfig) (*AuthToken, error)
 	// CreateMachineAuthToken creates a client_credentials access token (RFC 6749 §4.4)
 	CreateMachineAuthToken(cfg *AuthTokenConfig) (*JWTToken, error)
+	// CreateDelegatedAccessToken creates an RFC 8693 delegation access token
+	// (nested `act` chain, resource-bound `aud`, short TTL).
+	CreateDelegatedAccessToken(cfg *DelegationTokenConfig) (*JWTToken, error)
 	// CreateIDToken creates an id token
 	CreateIDToken(cfg *AuthTokenConfig) (string, int64, error)
 	// CreateRefreshToken creates a refresh token


### PR DESCRIPTION
## Summary

RFC 8693 **token-exchange grant** — the agentic delegation core. An authenticated `service_account` agent exchanges a user's `subject_token` (+ its own `actor_token`) for a resource-bound, attenuated access token carrying the nested `act` chain: "agent acting on behalf of user" (and, multi-hop, "sub-agent acting for parent agent").

> Note: this PR's implementation was completed and tested by the coordinator after the builder's session limit; it is pending its security-engineer review before merge (all prior PRs were reviewed pre-merge).

## What's here (`grant_type=urn:ietf:params:oauth:grant-type:token-exchange`)

- **Delegation-only (DC1/P3):** `actor_token` is REQUIRED — subject-only (impersonation) is rejected `invalid_request` (impersonation is a separate admin-gated design).
- **Attenuation, fail-closed (DC2/H1):** effective scope = `subject_token.scope ∩ agent.AllowedScopes ∩ requested`; empty ceiling = deny-all; **monotonic non-widening** (always intersects the subject token's own scope, so a re-exchange can only narrow).
- **Nested `act` (DC3, RFC 8693 §4.1):** `sub` = the user; `act` = `{sub: agent.client_id, act: <prior chain>}`. **`act` (and `client_id`) are reserved claims** — a `CustomAccessTokenScript` cannot forge the delegation chain.
- **Act-chain depth cap (H1):** hard limit on nesting; rejected beyond it.
- **Single resource (RFC 8707/DC4):** exactly one `resource` required (0 or >1 rejected); the issued token's `aud` is that resource. Scoped to this grant only.
- **RFC 9068:** issued token is `typ: at+jwt` with `client_id`; short TTL.
- **Discovery:** `token-exchange` advertised in `grant_types_supported`.

## Testing

- **Unit:** `intersectScopes` non-widening + deny-all, `actChainDepth` nesting.
- **Integration:** delegation-only rejection, exactly-one-resource, happy-path (token carries `act.sub`=agent, `aud`=resource, `sub`=user), attenuation (requesting a scope outside the agent's ceiling does not grant it).
- `go build`/`vet`/`gofmt`/`make lint-go` clean; no codegen drift; full integration suite green (BC preserved).

## Deferred (ponytail-noted)

Impersonation profile (subject-only, admin-gated); full delegation audit-chain fields across all providers (audit is minimal here); introspection/revocation of delegated tokens leans on the already-merged revocation-aware introspect.
