### PR TITLE
feat(clientauth): SPIFFE JWT-SVID auth + Kubernetes TokenReview

### DIFF
--- a/internal/integration_tests/token_client_assertion_test.go
+++ b/internal/integration_tests/token_client_assertion_test.go
@@ -63,7 +63,8 @@ func TestClientAssertionTokenEndpoint(t *testing.T) {
 		form := url.Values{}
 		form.Set("grant_type", constants.GrantTypeClientCredentials)
 		form.Set("client_assertion", signAssertion("https://issuer.example.com"))
-		form.Set("client_assertion_type", constants.ClientAssertionTypeJWTSPIFFE)
+		// jwt-bearer and jwt-spiffe are both supported; a SAML-bearer type is not.
+		form.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:saml2-bearer")
 
 		w := postClientCredentials(router, form, nil)
 		require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())

--- a/internal/service/clientauth/client_assertion.go
+++ b/internal/service/clientauth/client_assertion.go
@@ -18,6 +18,7 @@ package clientauth
 //   - Lifetime (H4): exp − iat MUST be ≤ a short ceiling.
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -25,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +62,16 @@ const (
 
 	// maxJWKSBytes caps the response body read from an issuer-controlled endpoint.
 	maxJWKSBytes = 1 << 20 // 1 MiB
+
+	// tokenReviewPath is the Kubernetes TokenReview subresource (authentication.k8s.io/v1).
+	tokenReviewPath = "/apis/authentication.k8s.io/v1/tokenreviews"
+
+	// inClusterSATokenPath is the standard mount for Authorizer's OWN projected
+	// ServiceAccount token. TokenReview requires the caller (Authorizer) to
+	// authenticate to the apiserver with a token that carries the
+	// system:auth-delegator RBAC; when running in-cluster this file is present.
+	// Read best-effort — absent means the Authorization header is omitted.
+	inClusterSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // allowedAssertionAlgs is the asymmetric signature allow-list (RFC 8725 §3.1).
@@ -71,15 +83,33 @@ var allowedAssertionAlgs = []string{
 	"ES256", "ES384", "ES512",
 }
 
-// resolveViaClientAssertion authenticates a client by verifying an RFC 7523
-// JWT-bearer assertion against a registered TrustedIssuer. On success it returns
-// the active Client the trust row is bound to.
+// resolveViaClientAssertion authenticates a client by verifying a client
+// assertion against a registered TrustedIssuer. Two assertion types are handled:
+//
+//   - jwt-bearer (RFC 7523): a generic trusted-issuer JWT (K8s SA token, cloud
+//     OIDC token). The trust row is a non-SPIFFE issuer_type.
+//   - jwt-spiffe (draft-ietf-oauth-spiffe-client-auth): a SPIFFE JWT-SVID whose
+//     `sub` is a SPIFFE ID (spiffe://…). The trust row is issuer_type spiffe_jwt.
+//     The token's `iss` is the SPIRE server, NOT the subject — iss ≠ sub is
+//     expected and correct, which is exactly why this is a distinct type: `iss`
+//     locates the trust row and its bundle, while `sub` (the SPIFFE ID) is pinned
+//     against AllowedSubjects. No private_key_jwt iss==sub==client_id assumption
+//     is (or ever was) applied on this path.
+//
+// On success it returns the active Client the trust row is bound to. All
+// validation is fail-closed; every rejection returns the generic ErrInvalidClient.
 func (p *provider) resolveViaClientAssertion(ctx context.Context, params ResolveParams) (*schemas.Client, error) {
 	log := p.Log.With().Str("func", "resolveViaClientAssertion").Logger()
 
-	// Only the jwt-bearer assertion type is handled here. The jwt-spiffe type is a
-	// follow-up PR; a missing/unknown type is a malformed request (invalid_request).
-	if params.ClientAssertionType != constants.ClientAssertionTypeJWTBearer {
+	// Select the assertion profile. A missing/unknown type is a malformed request
+	// (invalid_request); spiffe toggles the SPIFFE-specific checks below.
+	var spiffe bool
+	switch params.ClientAssertionType {
+	case constants.ClientAssertionTypeJWTBearer:
+		spiffe = false
+	case constants.ClientAssertionTypeJWTSPIFFE:
+		spiffe = true
+	default:
 		log.Debug().Str("client_assertion_type", params.ClientAssertionType).Msg("unsupported client_assertion_type")
 		return nil, ErrUnsupportedAssertionType
 	}
@@ -135,6 +165,18 @@ func (p *provider) resolveViaClientAssertion(ctx context.Context, params Resolve
 	}
 	if !issuer.IsActive {
 		log.Debug().Str("iss", iss).Msg("trusted issuer is inactive")
+		return nil, ErrInvalidClient
+	}
+
+	// SECURITY: the assertion type MUST match the trust row's issuer_type. A
+	// spiffe_jwt row (whose AllowedSubjects hold spiffe:// IDs and whose key set is
+	// a SPIFFE trust bundle) is reachable ONLY via the jwt-spiffe type; a generic
+	// jwt-bearer row is reachable ONLY via jwt-bearer. Enforcing the match both
+	// ways stops a caller from routing a SPIFFE row through the bearer profile
+	// (which would skip the spiffe:// subject-format check) or vice versa.
+	rowIsSpiffe := issuer.IssuerType == constants.IssuerTypeSPIFFEJWT
+	if spiffe != rowIsSpiffe {
+		log.Debug().Str("iss", iss).Str("issuer_type", issuer.IssuerType).Bool("assertion_is_spiffe", spiffe).Msg("client_assertion type does not match trusted issuer type")
 		return nil, ErrInvalidClient
 	}
 
@@ -207,6 +249,14 @@ func (p *provider) resolveViaClientAssertion(ctx context.Context, params Resolve
 	}
 	subject, _ := claims[subjectClaim].(string)
 	subject = strings.TrimSpace(subject)
+	// SPIFFE (draft-ietf-oauth-spiffe-client-auth): the subject MUST be a SPIFFE ID
+	// (a spiffe:// URI). AllowedSubjects on a spiffe_jwt row hold spiffe:// IDs, so
+	// requiring the scheme here rejects a non-SPIFFE subject before the exact-match
+	// and keeps the allow-list semantics unambiguous.
+	if spiffe && !strings.HasPrefix(subject, "spiffe://") {
+		log.Debug().Str("subject_claim", subjectClaim).Msg("spiffe client_assertion subject is not a SPIFFE ID")
+		return nil, ErrInvalidClient
+	}
 	allowed := issuer.ParsedAllowedSubjects()
 	if subject == "" || !contains(allowed, subject) {
 		log.Debug().Str("subject_claim", subjectClaim).Msg("client_assertion subject not in the allow-list")
@@ -221,6 +271,30 @@ func (p *provider) resolveViaClientAssertion(ctx context.Context, params Resolve
 		log.Debug().Msg("client_assertion replay detected")
 		return nil, ErrInvalidClient
 	}
+
+	// 8b. Kubernetes TokenReview (S7): offline JWKS validation proves the token was
+	//     signed by the cluster, but NOT that the bound Pod/ServiceAccount still
+	//     exists — a deleted pod's not-yet-expired token would otherwise pass. When
+	//     the trust row opts in, call the cluster's TokenReview API to confirm the
+	//     presented token is still authenticated online, and fail closed otherwise.
+	//     Done BEFORE the replay marker is set so a transient apiserver failure does
+	//     not permanently burn a legitimate token (the token is retryable), and
+	//     AFTER the replay CHECK so a replay is rejected without any apiserver call.
+	if issuer.EnableTokenReview {
+		apiServerURL := ""
+		if issuer.KubernetesAPIServerURL != nil {
+			apiServerURL = strings.TrimSpace(*issuer.KubernetesAPIServerURL)
+		}
+		if apiServerURL == "" {
+			log.Debug().Msg("enable_token_review is set but kubernetes_api_server_url is empty")
+			return nil, ErrInvalidClient
+		}
+		if err := p.performTokenReview(ctx, apiServerURL, params.ClientAssertion, issuer.ExpectedAud); err != nil {
+			log.Debug().Err(err).Msg("kubernetes TokenReview rejected the client_assertion")
+			return nil, ErrInvalidClient
+		}
+	}
+
 	replayTTL := exp - now.Unix()
 	if replayTTL < 1 {
 		replayTTL = 1
@@ -373,6 +447,101 @@ func (p *provider) safeFetchURL(ctx context.Context, rawURL string) ([]byte, err
 		return nil, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, rawURL)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, maxJWKSBytes))
+}
+
+// tokenReviewRequest / tokenReviewResponse are the minimal shapes of the K8s
+// authentication.k8s.io/v1 TokenReview API. Declared inline so the resolver does
+// not pull in k8s.io/client-go for a single JSON round-trip.
+type tokenReviewRequest struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Spec       struct {
+		Token     string   `json:"token"`
+		Audiences []string `json:"audiences,omitempty"`
+	} `json:"spec"`
+}
+
+type tokenReviewResponse struct {
+	Status struct {
+		Authenticated bool   `json:"authenticated"`
+		Error         string `json:"error,omitempty"`
+	} `json:"status"`
+}
+
+// performTokenReview POSTs the presented token to the cluster's TokenReview API
+// and returns nil only when the apiserver reports it still authenticated. It
+// fails closed on any error (unreachable apiserver, non-2xx, malformed body,
+// authenticated=false) so a deleted-pod token whose exp has not yet passed is
+// rejected.
+//
+// SSRF: the admin-supplied apiServerURL is routed through the same SSRF-hardened
+// client as JWKS fetches (validators.SafeHTTPClient) — the host is resolved once
+// and pinned, and redirects are refused.
+//
+// KNOWN LIMITATION (reported, not silently worked around): SafeHTTPClient rejects
+// private/loopback/link-local IPs, so the common in-cluster apiserver address
+// (https://kubernetes.default.svc, a ClusterIP in a private range) is NOT
+// reachable through it. TokenReview therefore works today only against a
+// publicly-routable apiserver endpoint (e.g. a managed cluster's public API
+// endpoint). Reaching a private in-cluster apiserver needs a deliberate SSRF
+// exemption + CA-pinning decision, which is intentionally left to the operator/
+// security owner rather than weakening the SSRF guard here.
+func (p *provider) performTokenReview(ctx context.Context, apiServerURL, token, expectedAud string) error {
+	var reqBody tokenReviewRequest
+	reqBody.APIVersion = "authentication.k8s.io/v1"
+	reqBody.Kind = "TokenReview"
+	reqBody.Spec.Token = token
+	if strings.TrimSpace(expectedAud) != "" {
+		reqBody.Spec.Audiences = []string{expectedAud}
+	}
+	body, err := json.Marshal(&reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal TokenReview request: %w", err)
+	}
+
+	reviewURL := strings.TrimSuffix(apiServerURL, "/") + tokenReviewPath
+	client, err := p.safeHTTPClient(ctx, reviewURL, httpFetchTimeout)
+	if err != nil {
+		return err
+	}
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reviewURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	// Authenticate to the apiserver with Authorizer's own in-cluster SA token when
+	// present; a TokenReview call is otherwise anonymous (which most clusters
+	// reject — surfaced as authenticated=false / non-2xx and thus fail-closed).
+	if saToken, rErr := os.ReadFile(inClusterSATokenPath); rErr == nil {
+		if t := strings.TrimSpace(string(saToken)); t != "" {
+			req.Header.Set("Authorization", "Bearer "+t)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("TokenReview API returned status %d", resp.StatusCode)
+	}
+
+	// Size-cap the apiserver-controlled body; a truncated read surfaces as a JSON
+	// parse failure below → fail-closed.
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxJWKSBytes))
+	var review tokenReviewResponse
+	if err := json.Unmarshal(raw, &review); err != nil {
+		return fmt.Errorf("malformed TokenReview response: %w", err)
+	}
+	if !review.Status.Authenticated {
+		return fmt.Errorf("TokenReview reported the token is not authenticated: %s", review.Status.Error)
+	}
+	return nil
 }
 
 // assertionReplayKey derives the single-use key. A jti (when present) is the

--- a/internal/service/clientauth/client_assertion.go
+++ b/internal/service/clientauth/client_assertion.go
@@ -516,9 +516,14 @@ func (p *provider) performTokenReview(ctx context.Context, apiServerURL, token, 
 	// Authenticate to the apiserver with Authorizer's own in-cluster SA token when
 	// present; a TokenReview call is otherwise anonymous (which most clusters
 	// reject — surfaced as authenticated=false / non-2xx and thus fail-closed).
-	if saToken, rErr := os.ReadFile(inClusterSATokenPath); rErr == nil {
-		if t := strings.TrimSpace(string(saToken)); t != "" {
-			req.Header.Set("Authorization", "Bearer "+t)
+	// Only attach it over https: the apiserver URL is admin-supplied, so a
+	// misconfigured/malicious http:// URL must never receive Authorizer's SA
+	// credential in cleartext (a real kube apiserver is always https).
+	if strings.EqualFold(req.URL.Scheme, "https") {
+		if saToken, rErr := os.ReadFile(inClusterSATokenPath); rErr == nil {
+			if t := strings.TrimSpace(string(saToken)); t != "" {
+				req.Header.Set("Authorization", "Bearer "+t)
+			}
 		}
 	}
 

--- a/internal/service/clientauth/client_assertion_spiffe_test.go
+++ b/internal/service/clientauth/client_assertion_spiffe_test.go
@@ -1,0 +1,164 @@
+package clientauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// SPIFFE fixtures. The SPIRE server (iss) is deliberately NOT the workload's
+// SPIFFE ID (sub): for a JWT-SVID iss ≠ sub is expected, and the resolver keys
+// the trust-row lookup on iss while pinning sub against AllowedSubjects.
+const (
+	testSpireIssuerURL = "https://spire-server.test.example.com"
+	testSpiffeSubject  = "spiffe://example.org/ns/prod/sa/payments"
+)
+
+// buildSpiffeResolver mirrors buildResolver but marks the trust row as a SPIFFE
+// issuer (IssuerType = spiffe_jwt) and keys it on the SPIRE-server issuer URL.
+func buildSpiffeResolver(t *testing.T, jwks []byte, allowedSubjects string) *provider {
+	t.Helper()
+	logger := zerolog.Nop()
+	store := &assertionStore{
+		clientsByID: map[string]*schemas.Client{
+			testSAClientPK: {
+				ID:       testSAClientPK,
+				ClientID: "payments-sa",
+				Kind:     constants.ClientKindServiceAccount,
+				IsActive: true,
+			},
+		},
+		issuers: map[string]*schemas.TrustedIssuer{
+			testSpireIssuerURL: {
+				ID:              "spiffe-row-1",
+				ClientID:        testSAClientPK,
+				IssuerURL:       testSpireIssuerURL,
+				IssuerType:      constants.IssuerTypeSPIFFEJWT,
+				KeySourceType:   constants.KeySourceStaticJWKSURL,
+				JWKSUrl:         refString("https://spire-server.test.example.com/keys"),
+				ExpectedAud:     testExpectedAud,
+				SubjectClaim:    "sub",
+				AllowedSubjects: allowedSubjects,
+				IsActive:        true,
+			},
+		},
+	}
+	p := New(
+		&config.Config{ClientID: "reserved", ClientSecret: "reserved-secret"},
+		&Dependencies{Log: &logger, StorageProvider: store, MemoryStoreProvider: newFakeMemStore()},
+	).(*provider)
+	p.fetchURL = func(_ context.Context, _ string) ([]byte, error) { return jwks, nil }
+	return p
+}
+
+func spiffeClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss": testSpireIssuerURL,
+		"sub": testSpiffeSubject,
+		"aud": testExpectedAud,
+		"iat": now.Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"jti": "spiffe-jti-" + now.Format("150405.000000000"),
+	}
+}
+
+func spiffeParams(assertion string) ResolveParams {
+	return ResolveParams{
+		ClientAssertion:           assertion,
+		ClientAssertionType:       constants.ClientAssertionTypeJWTSPIFFE,
+		RequireServiceAccountKind: true,
+	}
+}
+
+// TestSpiffeAssertion_ValidAuthenticates: a JWT-SVID with iss = SPIRE server and
+// sub = a spiffe:// ID in AllowedSubjects authenticates. Proves iss ≠ sub is
+// handled (the SPIRE iss locates the row; the SPIFFE-ID sub is pinned).
+func TestSpiffeAssertion_ValidAuthenticates(t *testing.T) {
+	key := genKey(t)
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSpiffeSubject)
+
+	client, err := r.ResolveClient(context.Background(), spiffeParams(signRS256(t, key, testKID, spiffeClaims())))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, testSAClientPK, client.ID)
+}
+
+// TestSpiffeAssertion_WrongSubjectRejected: a valid JWT-SVID whose spiffe:// sub
+// is not in AllowedSubjects is rejected.
+func TestSpiffeAssertion_WrongSubjectRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSpiffeSubject)
+	claims := spiffeClaims()
+	claims["sub"] = "spiffe://example.org/ns/prod/sa/attacker"
+	_, err := r.ResolveClient(context.Background(), spiffeParams(signRS256(t, key, testKID, claims)))
+	assert.ErrorIs(t, err, ErrInvalidClient)
+}
+
+// TestSpiffeAssertion_NonSpiffeSubjectRejected: a subject that is NOT a spiffe://
+// URI is rejected by the SPIFFE-ID format gate even when it appears verbatim in
+// AllowedSubjects — a spiffe row only authenticates SPIFFE IDs.
+func TestSpiffeAssertion_NonSpiffeSubjectRejected(t *testing.T) {
+	key := genKey(t)
+	nonSpiffe := "system:serviceaccount:prod:payments"
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), nonSpiffe)
+	claims := spiffeClaims()
+	claims["sub"] = nonSpiffe
+	_, err := r.ResolveClient(context.Background(), spiffeParams(signRS256(t, key, testKID, claims)))
+	assert.ErrorIs(t, err, ErrInvalidClient, "a non-SPIFFE subject must be rejected on the jwt-spiffe path")
+}
+
+// TestSpiffeAssertion_EmptyAllowedSubjectsDenyAll: an empty AllowedSubjects on a
+// spiffe row authenticates nobody.
+func TestSpiffeAssertion_EmptyAllowedSubjectsDenyAll(t *testing.T) {
+	key := genKey(t)
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), "")
+	_, err := r.ResolveClient(context.Background(), spiffeParams(signRS256(t, key, testKID, spiffeClaims())))
+	assert.ErrorIs(t, err, ErrInvalidClient, "empty AllowedSubjects must deny-all on the jwt-spiffe path")
+}
+
+// TestSpiffeAssertion_AlgNoneRejected: alg:none is rejected on the SPIFFE path.
+func TestSpiffeAssertion_AlgNoneRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSpiffeSubject)
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, spiffeClaims())
+	unsigned, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	_, err = r.ResolveClient(context.Background(), spiffeParams(unsigned))
+	assert.ErrorIs(t, err, ErrInvalidClient, "alg:none must be rejected on the jwt-spiffe path")
+}
+
+// TestSpiffeAssertion_BearerTypeAgainstSpiffeRowRejected: presenting the plain
+// jwt-bearer type against a spiffe_jwt row is rejected (type ↔ row mismatch) —
+// this stops routing a SPIFFE row through the bearer profile to skip the
+// spiffe:// subject-format gate.
+func TestSpiffeAssertion_BearerTypeAgainstSpiffeRowRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildSpiffeResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSpiffeSubject)
+	params := spiffeParams(signRS256(t, key, testKID, spiffeClaims()))
+	params.ClientAssertionType = constants.ClientAssertionTypeJWTBearer
+	_, err := r.ResolveClient(context.Background(), params)
+	assert.ErrorIs(t, err, ErrInvalidClient)
+}
+
+// TestSpiffeAssertion_SpiffeTypeAgainstBearerRowRejected: presenting the
+// jwt-spiffe type against a non-SPIFFE (jwt-bearer) row is rejected — the other
+// half of the type ↔ row consistency guard. buildResolver's row is a generic
+// (empty issuer_type) client_assertion row.
+func TestSpiffeAssertion_SpiffeTypeAgainstBearerRowRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+	params := assertionParams(signRS256(t, key, testKID, validClaims()))
+	params.ClientAssertionType = constants.ClientAssertionTypeJWTSPIFFE
+	_, err := r.ResolveClient(context.Background(), params)
+	assert.ErrorIs(t, err, ErrInvalidClient)
+}

--- a/internal/service/clientauth/client_assertion_test.go
+++ b/internal/service/clientauth/client_assertion_test.go
@@ -335,7 +335,7 @@ func TestClientAssertion_UnsupportedTypeRejected(t *testing.T) {
 	key := genKey(t)
 	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
 	params := assertionParams(signRS256(t, key, testKID, validClaims()))
-	params.ClientAssertionType = constants.ClientAssertionTypeJWTSPIFFE // out of scope here
+	params.ClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:saml2-bearer" // not supported
 	_, err := r.ResolveClient(context.Background(), params)
 	assert.ErrorIs(t, err, ErrUnsupportedAssertionType)
 }

--- a/internal/service/clientauth/client_assertion_tokenreview_test.go
+++ b/internal/service/clientauth/client_assertion_tokenreview_test.go
@@ -1,0 +1,114 @@
+package clientauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// plainClientSeam replaces the SSRF-hardened client factory with a plain client
+// so the real performTokenReview HTTP logic can reach an httptest apiserver
+// (validators.SafeHTTPClient refuses loopback, so httptest is otherwise
+// unreachable — the same reason JWKS tests stub fetchURL).
+func plainClientSeam(_ context.Context, _ string, _ time.Duration) (*http.Client, error) {
+	return &http.Client{Timeout: 2 * time.Second}, nil
+}
+
+// tokenReviewServer returns an httptest server that answers the TokenReview
+// subresource with status.authenticated = authenticated.
+func tokenReviewServer(t *testing.T, authenticated bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, tokenReviewPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if authenticated {
+			_, _ = w.Write([]byte(`{"apiVersion":"authentication.k8s.io/v1","kind":"TokenReview","status":{"authenticated":true}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":{"authenticated":false,"error":"pod not found"}}`))
+	}))
+}
+
+// --- performTokenReview unit tests (real HTTP round-trip against httptest) ---
+
+func TestPerformTokenReview_AuthenticatedTruePasses(t *testing.T) {
+	srv := tokenReviewServer(t, true)
+	defer srv.Close()
+	p := &provider{safeHTTPClient: plainClientSeam}
+	err := p.performTokenReview(context.Background(), srv.URL, "the-projected-token", testExpectedAud)
+	assert.NoError(t, err)
+}
+
+func TestPerformTokenReview_AuthenticatedFalseFailsClosed(t *testing.T) {
+	srv := tokenReviewServer(t, false)
+	defer srv.Close()
+	p := &provider{safeHTTPClient: plainClientSeam}
+	err := p.performTokenReview(context.Background(), srv.URL, "the-projected-token", testExpectedAud)
+	require.Error(t, err, "authenticated=false must fail closed")
+}
+
+func TestPerformTokenReview_Non2xxFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	p := &provider{safeHTTPClient: plainClientSeam}
+	err := p.performTokenReview(context.Background(), srv.URL, "tok", testExpectedAud)
+	require.Error(t, err, "a non-2xx apiserver response must fail closed")
+}
+
+// --- ResolveClient integration: EnableTokenReview wiring ---
+
+func TestClientAssertion_TokenReviewAuthenticatedTruePasses(t *testing.T) {
+	srv := tokenReviewServer(t, true)
+	defer srv.Close()
+
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+	r.safeHTTPClient = plainClientSeam
+	iss := r.StorageProvider.(*assertionStore).issuers[testIssuerURL]
+	iss.EnableTokenReview = true
+	iss.KubernetesAPIServerURL = refString(srv.URL)
+
+	client, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, testSAClientPK, client.ID)
+}
+
+func TestClientAssertion_TokenReviewAuthenticatedFalseRejected(t *testing.T) {
+	srv := tokenReviewServer(t, false)
+	defer srv.Close()
+
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+	r.safeHTTPClient = plainClientSeam
+	iss := r.StorageProvider.(*assertionStore).issuers[testIssuerURL]
+	iss.EnableTokenReview = true
+	iss.KubernetesAPIServerURL = refString(srv.URL)
+
+	_, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	assert.ErrorIs(t, err, ErrInvalidClient, "a deleted-object token (authenticated=false) must be rejected")
+}
+
+// TestClientAssertion_TokenReviewMissingAPIServerURLRejected: EnableTokenReview
+// with no apiserver URL fails closed without any network call.
+func TestClientAssertion_TokenReviewMissingAPIServerURLRejected(t *testing.T) {
+	key := genKey(t)
+	r := buildResolver(t, jwksBytes(t, &key.PublicKey, testKID), testSubject)
+	r.safeHTTPClient = func(context.Context, string, time.Duration) (*http.Client, error) {
+		t.Fatal("safeHTTPClient must not be called when kubernetes_api_server_url is empty")
+		return nil, nil
+	}
+	r.StorageProvider.(*assertionStore).issuers[testIssuerURL].EnableTokenReview = true
+
+	_, err := r.ResolveClient(context.Background(), assertionParams(signRS256(t, key, testKID, validClaims())))
+	assert.ErrorIs(t, err, ErrInvalidClient)
+}

--- a/internal/service/clientauth/clientauth.go
+++ b/internal/service/clientauth/clientauth.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/memory_store"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/validators"
 )
 
 // Sentinel errors callers map to the RFC 6749 §5.2 token-endpoint responses.
@@ -49,9 +51,9 @@ var (
 	ErrUnauthorizedClient = errors.New("clientauth: client not authorized for this grant")
 
 	// ErrUnsupportedAssertionType is returned when a client_assertion is presented
-	// with a missing or unsupported client_assertion_type. Only
-	// urn:ietf:params:oauth:client-assertion-type:jwt-bearer is supported here
-	// (the jwt-spiffe type is a follow-up PR). Map to invalid_request.
+	// with a missing or unsupported client_assertion_type. The jwt-bearer (RFC 7523)
+	// and jwt-spiffe (draft-ietf-oauth-spiffe-client-auth) types are supported; any
+	// other value is rejected. Map to invalid_request.
 	ErrUnsupportedAssertionType = errors.New("clientauth: unsupported client_assertion_type")
 )
 
@@ -111,11 +113,12 @@ type ResolveParams struct {
 	// secret-confirmation oracle on this grant.
 	RequireServiceAccountKind bool
 
-	// ClientAssertion / ClientAssertionType carry the RFC 7523 JWT-bearer client
-	// credential. When ClientAssertion is non-empty the resolver authenticates the
-	// client by verifying the assertion against a registered TrustedIssuer instead
-	// of a secret. ClientAssertionType MUST be
-	// urn:ietf:params:oauth:client-assertion-type:jwt-bearer.
+	// ClientAssertion / ClientAssertionType carry the JWT client credential. When
+	// ClientAssertion is non-empty the resolver authenticates the client by
+	// verifying the assertion against a registered TrustedIssuer instead of a
+	// secret. ClientAssertionType MUST be
+	// urn:ietf:params:oauth:client-assertion-type:jwt-bearer (RFC 7523) or
+	// urn:ietf:params:oauth:client-assertion-type:jwt-spiffe (SPIFFE JWT-SVID).
 	ClientAssertion     string
 	ClientAssertionType string
 }
@@ -152,6 +155,14 @@ type provider struct {
 	// the resolver is exercised without a real network round-trip (loopback is
 	// deliberately blocked by the SSRF guard, so httptest cannot be reached).
 	fetchURL func(ctx context.Context, rawURL string) ([]byte, error)
+
+	// safeHTTPClient builds the SSRF-hardened *http.Client used for the Kubernetes
+	// TokenReview POST. Production uses validators.SafeHTTPClient (host resolved
+	// once and pinned, private/loopback IPs refused). In-package tests inject a
+	// plain client so performTokenReview's real request-building and
+	// authenticated-flag parsing can be exercised against an httptest apiserver
+	// (the SSRF guard blocks loopback, so httptest is otherwise unreachable).
+	safeHTTPClient func(ctx context.Context, rawURL string, timeout time.Duration) (*http.Client, error)
 }
 
 var _ Provider = &provider{}
@@ -166,6 +177,7 @@ func New(cfg *config.Config, deps *Dependencies) Provider {
 		maxAssertionLifetime: defaultMaxClientAssertionLifetime,
 	}
 	p.fetchURL = p.safeFetchURL
+	p.safeHTTPClient = validators.SafeHTTPClient
 	return p
 }
 

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -1377,17 +1377,22 @@ func testTrustedIssuerOperations(t *testing.T, ctx context.Context, provider Pro
 	saClientID := sa.AsAPIClient().ID
 
 	issuerURL := "https://issuer.example.com/" + uuid.New().String()
+	// A SPIFFE-typed row: IssuerType = spiffe_jwt plus the reused Phase-4
+	// TokenReview fields must round-trip on every provider (no schema change was
+	// introduced for SPIFFE/TokenReview — these are existing columns).
 	issuer := &schemas.TrustedIssuer{
-		ClientID:        saClientID,
-		Name:            "test_trusted_issuer_" + uuid.New().String(),
-		IssuerURL:       issuerURL,
-		KeySourceType:   "static_jwks_url",
-		ExpectedAud:     "https://authorizer.example.com",
-		SubjectClaim:    "sub",
-		AllowedSubjects: "system:serviceaccount:prod:payments,system:serviceaccount:prod:billing",
-		IssuerType:      "oidc",
-		AuthMethod:      "jwt_assertion",
-		IsActive:        true,
+		ClientID:               saClientID,
+		Name:                   "test_trusted_issuer_" + uuid.New().String(),
+		IssuerURL:              issuerURL,
+		KeySourceType:          "static_jwks_url",
+		ExpectedAud:            "https://authorizer.example.com",
+		SubjectClaim:           "sub",
+		AllowedSubjects:        "system:serviceaccount:prod:payments,system:serviceaccount:prod:billing",
+		IssuerType:             constants.IssuerTypeSPIFFEJWT,
+		AuthMethod:             "jwt_assertion",
+		EnableTokenReview:      true,
+		KubernetesAPIServerURL: refs.NewStringRef("https://kube-apiserver.example.com:6443"),
+		IsActive:               true,
 	}
 
 	created, err := provider.AddTrustedIssuer(ctx, issuer)
@@ -1404,6 +1409,11 @@ func testTrustedIssuerOperations(t *testing.T, ctx context.Context, provider Pro
 	// AllowedSubjects (§5.2 C1 subject pin) must round-trip verbatim on every DB.
 	assert.Equal(t, issuer.AllowedSubjects, fetched.AllowedSubjects)
 	assert.Equal(t, []string{"system:serviceaccount:prod:payments", "system:serviceaccount:prod:billing"}, fetched.ParsedAllowedSubjects())
+	// SPIFFE + TokenReview fields must round-trip on every provider.
+	assert.Equal(t, constants.IssuerTypeSPIFFEJWT, fetched.IssuerType, "spiffe_jwt IssuerType must persist")
+	assert.True(t, fetched.EnableTokenReview, "EnableTokenReview must persist")
+	require.NotNil(t, fetched.KubernetesAPIServerURL)
+	assert.Equal(t, "https://kube-apiserver.example.com:6443", *fetched.KubernetesAPIServerURL)
 
 	fetchedByURL, err := provider.GetTrustedIssuerByIssuerURL(ctx, issuerURL)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Completes the secretless workload-identity story on the existing `client_assertion` path — **no schema change** (reuses merged `TrustedIssuer` fields):

1. **SPIFFE JWT-SVID auth** (`client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-spiffe`, per `draft-ietf-oauth-spiffe-client-auth`): `sub` is a `spiffe://` SPIFFE ID matched against `AllowedSubjects`; `iss` (SPIRE server) ≠ `sub` is handled correctly (the path already separates issuer-lookup from subject-pinning — no `private_key_jwt` iss==sub assumption). All existing protections carry over: JWKS signature (trust-row-keyed cache), `aud`=token-endpoint, single-use `jti`/replay, `exp−iat` ceiling, algorithm allow-list (`alg:none`/HS* rejected), SSRF-hardened fetch, CR1 kind/org filter.
2. **A both-ways type↔row consistency guard** — a `spiffe_jwt` row can't be downgraded to the weaker `jwt-bearer` profile (nor vice versa); the client can't pick the weaker validation via `client_assertion_type`.
3. **Kubernetes TokenReview** — when a trust row sets `EnableTokenReview` + `KubernetesAPIServerURL`, the presented token is verified against the cluster's TokenReview API (rejecting deleted-pod tokens). **Fail-closed** on every error path; runs after the replay check but before the replay set (a transient apiserver error doesn't burn a legitimate token's `jti`).

## Security (reviewed → **ship, no CRITICAL/HIGH/MEDIUM**)

SPIFFE validation, the type↔row guard, and TokenReview fail-closed all verified. The SSRF/private-apiserver call was ruled a **safe degradation** (SSRF hardening kept intact → in-cluster private apiserver unreachable → TokenReview fails *closed*, never open; reaching a private apiserver is a deferred operator decision, documented in-code). One LOW hardening folded in: Authorizer's in-cluster SA token is now only attached to the TokenReview request over `https` (never to a misconfigured/`http` apiserver URL).

## Testing

- SPIFFE: valid JWT-SVID authenticates; non-`spiffe://`/wrong subject rejected; empty `AllowedSubjects` deny-all; `alg:none` rejected; type↔row guard both directions; existing `jwt-bearer` + CR1 paths unchanged.
- TokenReview: authenticated true/false, non-2xx, missing-URL all correct; fail-closed verified via a mock apiserver.
- `go build`/`vet`/`gofmt`/`make lint-go` clean; no codegen drift; integration suite green 2×. No schema change (round-trips an `IssuerType=spiffe_jwt` row on sqlite).

## Known limitation (documented in-code)

In-cluster TokenReview to a private `kubernetes.default.svc` apiserver requires a deliberate SSRF exemption + CA pinning + apiserver credential — left as an operator decision; TokenReview today works against a publicly-routable apiserver endpoint.
