### PR TITLE
feat(sso): per-organization SAML 2.0 Service Provider SSO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.8.37
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/smithy-go v1.24.3
+	github.com/beevik/etree v1.5.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/couchbase/gocb/v2 v2.6.4
+	github.com/crewjam/saml v0.5.1
 	github.com/ekristen/gorm-libsql v0.0.0-20231101204708-6e113112bcc2
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -32,6 +34,7 @@ require (
 	github.com/redis/go-redis/v9 v9.6.3
 	github.com/robertkrimen/otto v0.2.1
 	github.com/rs/zerolog v1.33.0
+	github.com/russellhaering/goxmldsig v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/twilio/twilio-go v1.14.1
@@ -119,6 +122,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
@@ -128,6 +132,7 @@ require (
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/libsql/libsql-client-go v0.0.0-20231026052543-fce76c0f39a7 // indirect
 	github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 // indirect
+	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.8.37
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/smithy-go v1.24.3
-	github.com/beevik/etree v1.5.0
+	github.com/beevik/etree v1.6.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/couchbase/gocb/v2 v2.6.4
 	github.com/crewjam/saml v0.5.1
@@ -34,7 +34,7 @@ require (
 	github.com/redis/go-redis/v9 v9.6.3
 	github.com/robertkrimen/otto v0.2.1
 	github.com/rs/zerolog v1.33.0
-	github.com/russellhaering/goxmldsig v1.4.0
+	github.com/russellhaering/goxmldsig v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/twilio/twilio-go v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJi
 github.com/aws/smithy-go v1.24.3 h1:XgOAaUgx+HhVBoP4v8n6HCQoTRDhoMghKqw4LNHsDNg=
 github.com/aws/smithy-go v1.24.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
+github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -146,6 +148,8 @@ github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259/go.mo
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crewjam/saml v0.5.1 h1:g+mfp0CrLuLRZCK793PgJcZeg5dS/0CDwoeAX2zcwNI=
+github.com/crewjam/saml v0.5.1/go.mod h1:r0fDkmFe5URDgPrmtH0IYokva6fac3AUdstiPhyEolQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -314,6 +318,9 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -327,6 +334,8 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -348,6 +357,8 @@ github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475 h1:6Pf
 github.com/libsql/sqlite-antlr4-parser v0.0.0-20230802215326-5cb5bb604475/go.mod h1:20nXSmcf0nAscrzqsXeC2/tA3KkV2eCiJqYuyAgl+ss=
 github.com/localtunnel/go-localtunnel v0.0.0-20170326223115-8a804488f275 h1:IZycmTpoUtQK3PD60UYBwjaCUHUP7cML494ao9/O8+Q=
 github.com/localtunnel/go-localtunnel v0.0.0-20170326223115-8a804488f275/go.mod h1:zt6UU74K6Z6oMOYJbJzYpYucqdcQwSMPBEdSvGiaUMw=
+github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
+github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
@@ -408,6 +419,7 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -435,11 +447,15 @@ github.com/robertkrimen/otto v0.2.1 h1:FVP0PJ0AHIjC+N4pKCG9yCDz6LHNPCwi/GKID5pGG
 github.com/robertkrimen/otto v0.2.1/go.mod h1:UPwtJ1Xu7JrLcZjNWN8orJaM5n5YEtqL//farB5FlRY=
 github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe9DaXH8=
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
+github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
@@ -480,6 +496,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -708,6 +725,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/mail.v2 v2.3.1 h1:WYFn/oANrAGP2C0dcV6/pbkPzv8yGzqTjPmTeO7qoXk=
@@ -732,6 +750,8 @@ gorm.io/gorm v1.25.2-0.20230530020048-26663ab9bf55/go.mod h1:L4uxeKpfBml98NYqVqw
 gorm.io/gorm v1.25.2-0.20230610234218-206613868439/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/gorm v1.25.10 h1:dQpO+33KalOA+aFYGlK+EfxcI5MbO7EP2yYygwh9h+s=
 gorm.io/gorm v1.25.10/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 modernc.org/cc/v4 v4.28.2 h1:3tQ0lf2ADtoby2EtSP+J7IE2SHwEJdP8ioR59wx7XpY=

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJi
 github.com/aws/smithy-go v1.24.3 h1:XgOAaUgx+HhVBoP4v8n6HCQoTRDhoMghKqw4LNHsDNg=
 github.com/aws/smithy-go v1.24.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
-github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
-github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
+github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
+github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -318,7 +318,6 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -334,8 +333,6 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -419,7 +416,6 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -447,15 +443,13 @@ github.com/robertkrimen/otto v0.2.1 h1:FVP0PJ0AHIjC+N4pKCG9yCDz6LHNPCwi/GKID5pGG
 github.com/robertkrimen/otto v0.2.1/go.mod h1:UPwtJ1Xu7JrLcZjNWN8orJaM5n5YEtqL//farB5FlRY=
 github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe9DaXH8=
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
-github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
-github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
+github.com/russellhaering/goxmldsig v1.6.0 h1:8fdWXEPh2k/NZNQBPFNoVfS3JmzS4ZprY/sAOpKQLks=
+github.com/russellhaering/goxmldsig v1.6.0/go.mod h1:TrnaquDcYxWXfJrOjeMBTX4mLBeYAqaHEyUeWPxZlBM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
@@ -725,7 +719,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/mail.v2 v2.3.1 h1:WYFn/oANrAGP2C0dcV6/pbkPzv8yGzqTjPmTeO7qoXk=

--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -35,6 +35,8 @@ const (
 	AuditResourceTypeTrustedIssuer = "trusted_issuer"
 	// AuditResourceTypeOrgOIDCConnection represents a per-org upstream OIDC IdP.
 	AuditResourceTypeOrgOIDCConnection = "org_oidc_connection"
+	// AuditResourceTypeOrgSAMLConnection represents a per-org upstream SAML IdP.
+	AuditResourceTypeOrgSAMLConnection = "org_saml_connection"
 	// AuditResourceTypeOrganization represents an organization entity.
 	AuditResourceTypeOrganization = "organization"
 	// AuditResourceTypeOrgMembership represents an org membership entity.
@@ -135,6 +137,12 @@ const (
 	AuditSSOCallbackSuccessEvent = "sso.callback_success"
 	// AuditSSOCallbackFailedEvent is logged when an org OIDC SSO callback fails.
 	AuditSSOCallbackFailedEvent = "sso.callback_failed"
+	// AuditSAMLLoginInitiatedEvent is logged when an org SAML SP login is started.
+	AuditSAMLLoginInitiatedEvent = "saml.login_initiated"
+	// AuditSAMLACSSuccessEvent is logged when an org SAML ACS assertion is accepted.
+	AuditSAMLACSSuccessEvent = "saml.acs_success"
+	// AuditSAMLACSFailedEvent is logged when an org SAML ACS assertion is rejected.
+	AuditSAMLACSFailedEvent = "saml.acs_failed"
 
 	// AuditTokenIssuedEvent is logged when a new token is issued.
 	AuditTokenIssuedEvent = "token.issued"
@@ -169,6 +177,12 @@ const (
 	AuditOrgOIDCConnectionUpdatedEvent = "admin.org_oidc_connection_updated"
 	// AuditOrgOIDCConnectionDeletedEvent is logged when an admin deletes an org OIDC connection.
 	AuditOrgOIDCConnectionDeletedEvent = "admin.org_oidc_connection_deleted"
+	// AuditOrgSAMLConnectionCreatedEvent is logged when an admin creates an org SAML connection.
+	AuditOrgSAMLConnectionCreatedEvent = "admin.org_saml_connection_created"
+	// AuditOrgSAMLConnectionUpdatedEvent is logged when an admin updates an org SAML connection.
+	AuditOrgSAMLConnectionUpdatedEvent = "admin.org_saml_connection_updated"
+	// AuditOrgSAMLConnectionDeletedEvent is logged when an admin deletes an org SAML connection.
+	AuditOrgSAMLConnectionDeletedEvent = "admin.org_saml_connection_deleted"
 	// AuditTrustedIssuerCreatedEvent is logged when an admin adds a trusted issuer.
 	AuditTrustedIssuerCreatedEvent = "admin.trusted_issuer_created"
 	// AuditTrustedIssuerUpdatedEvent is logged when an admin updates a trusted issuer.

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -288,12 +288,14 @@ type ComplexityRoot struct {
 		AdminSignup             func(childComplexity int, params model.AdminSignupRequest) int
 		CreateClient            func(childComplexity int, params model.CreateClientRequest) int
 		CreateOrgOidcConnection func(childComplexity int, params model.CreateOrgOIDCConnectionRequest) int
+		CreateOrgSamlConnection func(childComplexity int, params model.CreateOrgSAMLConnectionRequest) int
 		CreateOrganization      func(childComplexity int, params model.CreateOrganizationRequest) int
 		CreateScimEndpoint      func(childComplexity int, params model.CreateScimEndpointRequest) int
 		DeactivateAccount       func(childComplexity int) int
 		DeleteClient            func(childComplexity int, params model.ClientRequest) int
 		DeleteEmailTemplate     func(childComplexity int, params model.DeleteEmailTemplateRequest) int
 		DeleteOrgOidcConnection func(childComplexity int, params model.OrgOIDCConnectionRequest) int
+		DeleteOrgSamlConnection func(childComplexity int, params model.OrgSAMLConnectionRequest) int
 		DeleteOrganization      func(childComplexity int, params model.OrganizationRequest) int
 		DeleteScimEndpoint      func(childComplexity int, params model.ScimEndpointRequest) int
 		DeleteTrustedIssuer     func(childComplexity int, params model.TrustedIssuerRequest) int
@@ -326,6 +328,7 @@ type ComplexityRoot struct {
 		UpdateEmailTemplate     func(childComplexity int, params model.UpdateEmailTemplateRequest) int
 		UpdateEnv               func(childComplexity int, params model.UpdateEnvRequest) int
 		UpdateOrgOidcConnection func(childComplexity int, params model.UpdateOrgOIDCConnectionRequest) int
+		UpdateOrgSamlConnection func(childComplexity int, params model.UpdateOrgSAMLConnectionRequest) int
 		UpdateOrganization      func(childComplexity int, params model.UpdateOrganizationRequest) int
 		UpdateProfile           func(childComplexity int, params model.UpdateProfileRequest) int
 		UpdateTrustedIssuer     func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
@@ -360,6 +363,21 @@ type ComplexityRoot struct {
 		Scopes      func(childComplexity int) int
 		SsoClientID func(childComplexity int) int
 		UpdatedAt   func(childComplexity int) int
+	}
+
+	OrgSAMLConnection struct {
+		AcsURL            func(childComplexity int) int
+		AllowIdpInitiated func(childComplexity int) int
+		AttributeMapping  func(childComplexity int) int
+		CreatedAt         func(childComplexity int) int
+		ID                func(childComplexity int) int
+		IdpEntityID       func(childComplexity int) int
+		IdpSsoURL         func(childComplexity int) int
+		IsActive          func(childComplexity int) int
+		Name              func(childComplexity int) int
+		OrgID             func(childComplexity int) int
+		SpEntityID        func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
 	}
 
 	Organization struct {
@@ -411,6 +429,7 @@ type ComplexityRoot struct {
 		Meta                 func(childComplexity int) int
 		OrgMembers           func(childComplexity int, params model.ListOrgMembersRequest) int
 		OrgOidcConnection    func(childComplexity int, params model.OrgOIDCConnectionRequest) int
+		OrgSamlConnection    func(childComplexity int, params model.OrgSAMLConnectionRequest) int
 		Organization         func(childComplexity int, params model.OrganizationRequest) int
 		Organizations        func(childComplexity int, params *model.ListOrganizationsRequest) int
 		Profile              func(childComplexity int) int
@@ -593,6 +612,9 @@ type MutationResolver interface {
 	CreateOrgOidcConnection(ctx context.Context, params model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
 	UpdateOrgOidcConnection(ctx context.Context, params model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
 	DeleteOrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.Response, error)
+	CreateOrgSamlConnection(ctx context.Context, params model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	UpdateOrgSamlConnection(ctx context.Context, params model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	DeleteOrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.Response, error)
 	CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error)
 	UpdateOrganization(ctx context.Context, params model.UpdateOrganizationRequest) (*model.Organization, error)
 	DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error)
@@ -630,6 +652,7 @@ type QueryResolver interface {
 	TrustedIssuer(ctx context.Context, params model.TrustedIssuerRequest) (*model.TrustedIssuer, error)
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
 	OrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	OrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
 	Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error)
 	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
 	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
@@ -1907,6 +1930,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateOrgOidcConnection(childComplexity, args["params"].(model.CreateOrgOIDCConnectionRequest)), true
 
+	case "Mutation._create_org_saml_connection":
+		if e.complexity.Mutation.CreateOrgSamlConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_org_saml_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateOrgSamlConnection(childComplexity, args["params"].(model.CreateOrgSAMLConnectionRequest)), true
+
 	case "Mutation._create_organization":
 		if e.complexity.Mutation.CreateOrganization == nil {
 			break
@@ -1973,6 +2008,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteOrgOidcConnection(childComplexity, args["params"].(model.OrgOIDCConnectionRequest)), true
+
+	case "Mutation._delete_org_saml_connection":
+		if e.complexity.Mutation.DeleteOrgSamlConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_org_saml_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteOrgSamlConnection(childComplexity, args["params"].(model.OrgSAMLConnectionRequest)), true
 
 	case "Mutation._delete_organization":
 		if e.complexity.Mutation.DeleteOrganization == nil {
@@ -2348,6 +2395,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateOrgOidcConnection(childComplexity, args["params"].(model.UpdateOrgOIDCConnectionRequest)), true
 
+	case "Mutation._update_org_saml_connection":
+		if e.complexity.Mutation.UpdateOrgSamlConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_org_saml_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateOrgSamlConnection(childComplexity, args["params"].(model.UpdateOrgSAMLConnectionRequest)), true
+
 	case "Mutation._update_organization":
 		if e.complexity.Mutation.UpdateOrganization == nil {
 			break
@@ -2557,6 +2616,90 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.OrgOIDCConnection.UpdatedAt(childComplexity), true
+
+	case "OrgSAMLConnection.acs_url":
+		if e.complexity.OrgSAMLConnection.AcsURL == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.AcsURL(childComplexity), true
+
+	case "OrgSAMLConnection.allow_idp_initiated":
+		if e.complexity.OrgSAMLConnection.AllowIdpInitiated == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.AllowIdpInitiated(childComplexity), true
+
+	case "OrgSAMLConnection.attribute_mapping":
+		if e.complexity.OrgSAMLConnection.AttributeMapping == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.AttributeMapping(childComplexity), true
+
+	case "OrgSAMLConnection.created_at":
+		if e.complexity.OrgSAMLConnection.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.CreatedAt(childComplexity), true
+
+	case "OrgSAMLConnection.id":
+		if e.complexity.OrgSAMLConnection.ID == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.ID(childComplexity), true
+
+	case "OrgSAMLConnection.idp_entity_id":
+		if e.complexity.OrgSAMLConnection.IdpEntityID == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.IdpEntityID(childComplexity), true
+
+	case "OrgSAMLConnection.idp_sso_url":
+		if e.complexity.OrgSAMLConnection.IdpSsoURL == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.IdpSsoURL(childComplexity), true
+
+	case "OrgSAMLConnection.is_active":
+		if e.complexity.OrgSAMLConnection.IsActive == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.IsActive(childComplexity), true
+
+	case "OrgSAMLConnection.name":
+		if e.complexity.OrgSAMLConnection.Name == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.Name(childComplexity), true
+
+	case "OrgSAMLConnection.org_id":
+		if e.complexity.OrgSAMLConnection.OrgID == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.OrgID(childComplexity), true
+
+	case "OrgSAMLConnection.sp_entity_id":
+		if e.complexity.OrgSAMLConnection.SpEntityID == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.SpEntityID(childComplexity), true
+
+	case "OrgSAMLConnection.updated_at":
+		if e.complexity.OrgSAMLConnection.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgSAMLConnection.UpdatedAt(childComplexity), true
 
 	case "Organization.created_at":
 		if e.complexity.Organization.CreatedAt == nil {
@@ -2843,6 +2986,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.OrgOidcConnection(childComplexity, args["params"].(model.OrgOIDCConnectionRequest)), true
+
+	case "Query._org_saml_connection":
+		if e.complexity.Query.OrgSamlConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Query__org_saml_connection_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OrgSamlConnection(childComplexity, args["params"].(model.OrgSAMLConnectionRequest)), true
 
 	case "Query._organization":
 		if e.complexity.Query.Organization == nil {
@@ -3597,6 +3752,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputClientRequest,
 		ec.unmarshalInputCreateClientRequest,
 		ec.unmarshalInputCreateOrgOIDCConnectionRequest,
+		ec.unmarshalInputCreateOrgSAMLConnectionRequest,
 		ec.unmarshalInputCreateOrganizationRequest,
 		ec.unmarshalInputCreateScimEndpointRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
@@ -3625,6 +3781,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMobileSignUpRequest,
 		ec.unmarshalInputOAuthRevokeRequest,
 		ec.unmarshalInputOrgOIDCConnectionRequest,
+		ec.unmarshalInputOrgSAMLConnectionRequest,
 		ec.unmarshalInputOrganizationRequest,
 		ec.unmarshalInputPaginatedRequest,
 		ec.unmarshalInputPaginationRequest,
@@ -3643,6 +3800,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateEmailTemplateRequest,
 		ec.unmarshalInputUpdateEnvRequest,
 		ec.unmarshalInputUpdateOrgOIDCConnectionRequest,
+		ec.unmarshalInputUpdateOrgSAMLConnectionRequest,
 		ec.unmarshalInputUpdateOrganizationRequest,
 		ec.unmarshalInputUpdateProfileRequest,
 		ec.unmarshalInputUpdateTrustedIssuerRequest,
@@ -4110,6 +4268,31 @@ type OrgOIDCConnection {
   sso_client_id: String!
   scopes: String
   redirect_uri: String
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+# OrgSAMLConnection is a per-organization upstream SAML 2.0 IdP for which
+# Authorizer acts as the Service Provider. The IdP signing certificate is
+# accepted on write but never projected back here.
+type OrgSAMLConnection {
+  id: ID!
+  org_id: String!
+  name: String!
+  # idp_entity_id: the upstream IdP entity ID (the assertion Issuer).
+  idp_entity_id: String!
+  # idp_sso_url: the IdP Single Sign-On endpoint the AuthnRequest is sent to.
+  idp_sso_url: String
+  # sp_entity_id / acs_url: the SP identity Authorizer advertises for this org.
+  # Empty means "derived from the request host". Register these at the IdP, or
+  # fetch the concrete SP metadata XML from /oauth/saml/{org}/metadata.
+  sp_entity_id: String
+  acs_url: String
+  # attribute_mapping: JSON mapping profile fields to SAML attribute names.
+  attribute_mapping: String
+  # allow_idp_initiated: whether IdP-initiated SSO is permitted (default false).
+  allow_idp_initiated: Boolean!
   is_active: Boolean!
   created_at: Int64
   updated_at: Int64
@@ -4628,6 +4811,46 @@ input OrgOIDCConnectionRequest {
   org_id: String
 }
 
+input CreateOrgSAMLConnectionRequest {
+  org_id: String!
+  name: String!
+  # idp_entity_id: the upstream IdP entity ID (matched against the assertion
+  # Issuer). Globally unique across all trusted issuers.
+  idp_entity_id: String!
+  # idp_sso_url: the IdP Single Sign-On endpoint (HTTP-Redirect binding).
+  idp_sso_url: String!
+  # idp_certificate: the IdP X.509 signing certificate (PEM). Assertion
+  # signatures are validated ONLY against this certificate.
+  idp_certificate: String!
+  # sp_entity_id / acs_url: override the host-derived SP identity. Optional.
+  sp_entity_id: String
+  acs_url: String
+  # attribute_mapping: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  attribute_mapping: String
+  # allow_idp_initiated: default false (SP-initiated only).
+  allow_idp_initiated: Boolean
+}
+
+input UpdateOrgSAMLConnectionRequest {
+  id: ID!
+  name: String
+  idp_entity_id: String
+  idp_sso_url: String
+  # Supplying idp_certificate replaces it; omitting leaves the stored cert intact.
+  idp_certificate: String
+  sp_entity_id: String
+  acs_url: String
+  attribute_mapping: String
+  allow_idp_initiated: Boolean
+  is_active: Boolean
+}
+
+input OrgSAMLConnectionRequest {
+  # Look up by connection id OR by org_id (supply exactly one).
+  id: ID
+  org_id: String
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -4863,6 +5086,10 @@ type Mutation {
   _create_org_oidc_connection(params: CreateOrgOIDCConnectionRequest!): OrgOIDCConnection!
   _update_org_oidc_connection(params: UpdateOrgOIDCConnectionRequest!): OrgOIDCConnection!
   _delete_org_oidc_connection(params: OrgOIDCConnectionRequest!): Response!
+  # Per-organization SSO SAML connections (Authorizer as Service Provider)
+  _create_org_saml_connection(params: CreateOrgSAMLConnectionRequest!): OrgSAMLConnection!
+  _update_org_saml_connection(params: UpdateOrgSAMLConnectionRequest!): OrgSAMLConnection!
+  _delete_org_saml_connection(params: OrgSAMLConnectionRequest!): Response!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -4910,6 +5137,7 @@ type Query {
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _org_saml_connection(params: OrgSAMLConnectionRequest!): OrgSAMLConnection!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!
@@ -5159,6 +5387,34 @@ func (ec *executionContext) field_Mutation__create_org_oidc_connection_argsParam
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_org_saml_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_org_saml_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_org_saml_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateOrgSAMLConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateOrgSAMLConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrgSAMLConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateOrgSAMLConnectionRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__create_organization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -5296,6 +5552,34 @@ func (ec *executionContext) field_Mutation__delete_org_oidc_connection_argsParam
 	}
 
 	var zeroVal model.OrgOIDCConnectionRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_org_saml_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_org_saml_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_org_saml_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrgSAMLConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrgSAMLConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrgSAMLConnectionRequest
 	return zeroVal, nil
 }
 
@@ -5856,6 +6140,34 @@ func (ec *executionContext) field_Mutation__update_org_oidc_connection_argsParam
 	}
 
 	var zeroVal model.UpdateOrgOIDCConnectionRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_org_saml_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_org_saml_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_org_saml_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateOrgSAMLConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateOrgSAMLConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrgSAMLConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateOrgSAMLConnectionRequest
 	return zeroVal, nil
 }
 
@@ -6612,6 +6924,34 @@ func (ec *executionContext) field_Query__org_oidc_connection_argsParams(
 	}
 
 	var zeroVal model.OrgOIDCConnectionRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__org_saml_connection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__org_saml_connection_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__org_saml_connection_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.OrgSAMLConnectionRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.OrgSAMLConnectionRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnectionRequest(ctx, tmp)
+	}
+
+	var zeroVal model.OrgSAMLConnectionRequest
 	return zeroVal, nil
 }
 
@@ -16811,6 +17151,227 @@ func (ec *executionContext) fieldContext_Mutation__delete_org_oidc_connection(ct
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_org_saml_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_org_saml_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrgSamlConnection(rctx, fc.Args["params"].(model.CreateOrgSAMLConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgSAMLConnection)
+	fc.Result = res
+	return ec.marshalNOrgSAMLConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_org_saml_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgSAMLConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgSAMLConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgSAMLConnection_name(ctx, field)
+			case "idp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_idp_entity_id(ctx, field)
+			case "idp_sso_url":
+				return ec.fieldContext_OrgSAMLConnection_idp_sso_url(ctx, field)
+			case "sp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_sp_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_OrgSAMLConnection_acs_url(ctx, field)
+			case "attribute_mapping":
+				return ec.fieldContext_OrgSAMLConnection_attribute_mapping(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_OrgSAMLConnection_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgSAMLConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgSAMLConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgSAMLConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgSAMLConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_org_saml_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_org_saml_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_org_saml_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateOrgSamlConnection(rctx, fc.Args["params"].(model.UpdateOrgSAMLConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgSAMLConnection)
+	fc.Result = res
+	return ec.marshalNOrgSAMLConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_org_saml_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgSAMLConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgSAMLConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgSAMLConnection_name(ctx, field)
+			case "idp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_idp_entity_id(ctx, field)
+			case "idp_sso_url":
+				return ec.fieldContext_OrgSAMLConnection_idp_sso_url(ctx, field)
+			case "sp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_sp_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_OrgSAMLConnection_acs_url(ctx, field)
+			case "attribute_mapping":
+				return ec.fieldContext_OrgSAMLConnection_attribute_mapping(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_OrgSAMLConnection_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgSAMLConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgSAMLConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgSAMLConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgSAMLConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_org_saml_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_org_saml_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_org_saml_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteOrgSamlConnection(rctx, fc.Args["params"].(model.OrgSAMLConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_org_saml_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_org_saml_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__create_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__create_organization(ctx, field)
 	if err != nil {
@@ -18570,6 +19131,516 @@ func (ec *executionContext) _OrgOIDCConnection_updated_at(ctx context.Context, f
 func (ec *executionContext) fieldContext_OrgOIDCConnection_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "OrgOIDCConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_org_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_name(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_idp_entity_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_idp_entity_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdpEntityID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_idp_entity_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_idp_sso_url(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_idp_sso_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdpSsoURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_idp_sso_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_sp_entity_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_sp_entity_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpEntityID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_sp_entity_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_acs_url(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_acs_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AcsURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_acs_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_attribute_mapping(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_attribute_mapping(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AttributeMapping, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_attribute_mapping(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_allow_idp_initiated(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_allow_idp_initiated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllowIdpInitiated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_allow_idp_initiated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_is_active(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_is_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_is_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_created_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgSAMLConnection_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgSAMLConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgSAMLConnection_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgSAMLConnection_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgSAMLConnection",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -20769,6 +21840,87 @@ func (ec *executionContext) fieldContext_Query__org_oidc_connection(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query__org_oidc_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__org_saml_connection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__org_saml_connection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().OrgSamlConnection(rctx, fc.Args["params"].(model.OrgSAMLConnectionRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgSAMLConnection)
+	fc.Result = res
+	return ec.marshalNOrgSAMLConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__org_saml_connection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrgSAMLConnection_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgSAMLConnection_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_OrgSAMLConnection_name(ctx, field)
+			case "idp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_idp_entity_id(ctx, field)
+			case "idp_sso_url":
+				return ec.fieldContext_OrgSAMLConnection_idp_sso_url(ctx, field)
+			case "sp_entity_id":
+				return ec.fieldContext_OrgSAMLConnection_sp_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_OrgSAMLConnection_acs_url(ctx, field)
+			case "attribute_mapping":
+				return ec.fieldContext_OrgSAMLConnection_attribute_mapping(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_OrgSAMLConnection_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_OrgSAMLConnection_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgSAMLConnection_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgSAMLConnection_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgSAMLConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__org_saml_connection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -27647,6 +28799,89 @@ func (ec *executionContext) unmarshalInputCreateOrgOIDCConnectionRequest(ctx con
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateOrgSAMLConnectionRequest(ctx context.Context, obj any) (model.CreateOrgSAMLConnectionRequest, error) {
+	var it model.CreateOrgSAMLConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "name", "idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id", "acs_url", "attribute_mapping", "allow_idp_initiated"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "idp_entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_entity_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpEntityID = data
+		case "idp_sso_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_sso_url"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpSsoURL = data
+		case "idp_certificate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_certificate"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpCertificate = data
+		case "sp_entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sp_entity_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpEntityID = data
+		case "acs_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("acs_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AcsURL = data
+		case "attribute_mapping":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attribute_mapping"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AttributeMapping = data
+		case "allow_idp_initiated":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_idp_initiated"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowIdpInitiated = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateOrganizationRequest(ctx context.Context, obj any) (model.CreateOrganizationRequest, error) {
 	var it model.CreateOrganizationRequest
 	asMap := map[string]any{}
@@ -28770,6 +30005,40 @@ func (ec *executionContext) unmarshalInputOAuthRevokeRequest(ctx context.Context
 
 func (ec *executionContext) unmarshalInputOrgOIDCConnectionRequest(ctx context.Context, obj any) (model.OrgOIDCConnectionRequest, error) {
 	var it model.OrgOIDCConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputOrgSAMLConnectionRequest(ctx context.Context, obj any) (model.OrgSAMLConnectionRequest, error) {
+	var it model.OrgSAMLConnectionRequest
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -30045,6 +31314,96 @@ func (ec *executionContext) unmarshalInputUpdateOrgOIDCConnectionRequest(ctx con
 				return it, err
 			}
 			it.RedirectURI = data
+		case "is_active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsActive = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateOrgSAMLConnectionRequest(ctx context.Context, obj any) (model.UpdateOrgSAMLConnectionRequest, error) {
+	var it model.UpdateOrgSAMLConnectionRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id", "acs_url", "attribute_mapping", "allow_idp_initiated", "is_active"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "idp_entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_entity_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpEntityID = data
+		case "idp_sso_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_sso_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpSsoURL = data
+		case "idp_certificate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idp_certificate"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdpCertificate = data
+		case "sp_entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sp_entity_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpEntityID = data
+		case "acs_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("acs_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AcsURL = data
+		case "attribute_mapping":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attribute_mapping"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AttributeMapping = data
+		case "allow_idp_initiated":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_idp_initiated"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowIdpInitiated = data
 		case "is_active":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -32320,6 +33679,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_org_saml_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_org_saml_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_org_saml_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_org_saml_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_org_saml_connection":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_org_saml_connection(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_create_organization":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__create_organization(ctx, field)
@@ -32606,6 +33986,82 @@ func (ec *executionContext) _OrgOIDCConnection(ctx context.Context, sel ast.Sele
 			out.Values[i] = ec._OrgOIDCConnection_created_at(ctx, field, obj)
 		case "updated_at":
 			out.Values[i] = ec._OrgOIDCConnection_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgSAMLConnectionImplementors = []string{"OrgSAMLConnection"}
+
+func (ec *executionContext) _OrgSAMLConnection(ctx context.Context, sel ast.SelectionSet, obj *model.OrgSAMLConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgSAMLConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgSAMLConnection")
+		case "id":
+			out.Values[i] = ec._OrgSAMLConnection_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._OrgSAMLConnection_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._OrgSAMLConnection_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "idp_entity_id":
+			out.Values[i] = ec._OrgSAMLConnection_idp_entity_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "idp_sso_url":
+			out.Values[i] = ec._OrgSAMLConnection_idp_sso_url(ctx, field, obj)
+		case "sp_entity_id":
+			out.Values[i] = ec._OrgSAMLConnection_sp_entity_id(ctx, field, obj)
+		case "acs_url":
+			out.Values[i] = ec._OrgSAMLConnection_acs_url(ctx, field, obj)
+		case "attribute_mapping":
+			out.Values[i] = ec._OrgSAMLConnection_attribute_mapping(ctx, field, obj)
+		case "allow_idp_initiated":
+			out.Values[i] = ec._OrgSAMLConnection_allow_idp_initiated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "is_active":
+			out.Values[i] = ec._OrgSAMLConnection_is_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._OrgSAMLConnection_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._OrgSAMLConnection_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -33300,6 +34756,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query__org_oidc_connection(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_org_saml_connection":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__org_saml_connection(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -34976,6 +36454,11 @@ func (ec *executionContext) unmarshalNCreateOrgOIDCConnectionRequest2githubᚗco
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNCreateOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrgSAMLConnectionRequest(ctx context.Context, v any) (model.CreateOrgSAMLConnectionRequest, error) {
+	res, err := ec.unmarshalInputCreateOrgSAMLConnectionRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateOrganizationRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateOrganizationRequest(ctx context.Context, v any) (model.CreateOrganizationRequest, error) {
 	res, err := ec.unmarshalInputCreateOrganizationRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -35495,6 +36978,25 @@ func (ec *executionContext) unmarshalNOrgOIDCConnectionRequest2githubᚗcomᚋau
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNOrgSAMLConnection2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnection(ctx context.Context, sel ast.SelectionSet, v model.OrgSAMLConnection) graphql.Marshaler {
+	return ec._OrgSAMLConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgSAMLConnection2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnection(ctx context.Context, sel ast.SelectionSet, v *model.OrgSAMLConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgSAMLConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgSAMLConnectionRequest(ctx context.Context, v any) (model.OrgSAMLConnectionRequest, error) {
+	res, err := ec.unmarshalInputOrgSAMLConnectionRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNOrganization2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrganization(ctx context.Context, sel ast.SelectionSet, v model.Organization) graphql.Marshaler {
 	return ec._Organization(ctx, sel, &v)
 }
@@ -35932,6 +37434,11 @@ func (ec *executionContext) unmarshalNUpdateEnvRequest2githubᚗcomᚋauthorizer
 
 func (ec *executionContext) unmarshalNUpdateOrgOIDCConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrgOIDCConnectionRequest(ctx context.Context, v any) (model.UpdateOrgOIDCConnectionRequest, error) {
 	res, err := ec.unmarshalInputUpdateOrgOIDCConnectionRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateOrgSAMLConnectionRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateOrgSAMLConnectionRequest(ctx context.Context, v any) (model.UpdateOrgSAMLConnectionRequest, error) {
+	res, err := ec.unmarshalInputUpdateOrgSAMLConnectionRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -133,6 +133,18 @@ type CreateOrgOIDCConnectionRequest struct {
 	RedirectURI  *string `json:"redirect_uri,omitempty"`
 }
 
+type CreateOrgSAMLConnectionRequest struct {
+	OrgID             string  `json:"org_id"`
+	Name              string  `json:"name"`
+	IdpEntityID       string  `json:"idp_entity_id"`
+	IdpSsoURL         string  `json:"idp_sso_url"`
+	IdpCertificate    string  `json:"idp_certificate"`
+	SpEntityID        *string `json:"sp_entity_id,omitempty"`
+	AcsURL            *string `json:"acs_url,omitempty"`
+	AttributeMapping  *string `json:"attribute_mapping,omitempty"`
+	AllowIdpInitiated *bool   `json:"allow_idp_initiated,omitempty"`
+}
+
 type CreateOrganizationRequest struct {
 	Name        string  `json:"name"`
 	DisplayName *string `json:"display_name,omitempty"`
@@ -500,6 +512,26 @@ type OrgOIDCConnectionRequest struct {
 	OrgID *string `json:"org_id,omitempty"`
 }
 
+type OrgSAMLConnection struct {
+	ID                string  `json:"id"`
+	OrgID             string  `json:"org_id"`
+	Name              string  `json:"name"`
+	IdpEntityID       string  `json:"idp_entity_id"`
+	IdpSsoURL         *string `json:"idp_sso_url,omitempty"`
+	SpEntityID        *string `json:"sp_entity_id,omitempty"`
+	AcsURL            *string `json:"acs_url,omitempty"`
+	AttributeMapping  *string `json:"attribute_mapping,omitempty"`
+	AllowIdpInitiated bool    `json:"allow_idp_initiated"`
+	IsActive          bool    `json:"is_active"`
+	CreatedAt         *int64  `json:"created_at,omitempty"`
+	UpdatedAt         *int64  `json:"updated_at,omitempty"`
+}
+
+type OrgSAMLConnectionRequest struct {
+	ID    *string `json:"id,omitempty"`
+	OrgID *string `json:"org_id,omitempty"`
+}
+
 type Organization struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name"`
@@ -754,6 +786,19 @@ type UpdateOrgOIDCConnectionRequest struct {
 	Scopes       *string `json:"scopes,omitempty"`
 	RedirectURI  *string `json:"redirect_uri,omitempty"`
 	IsActive     *bool   `json:"is_active,omitempty"`
+}
+
+type UpdateOrgSAMLConnectionRequest struct {
+	ID                string  `json:"id"`
+	Name              *string `json:"name,omitempty"`
+	IdpEntityID       *string `json:"idp_entity_id,omitempty"`
+	IdpSsoURL         *string `json:"idp_sso_url,omitempty"`
+	IdpCertificate    *string `json:"idp_certificate,omitempty"`
+	SpEntityID        *string `json:"sp_entity_id,omitempty"`
+	AcsURL            *string `json:"acs_url,omitempty"`
+	AttributeMapping  *string `json:"attribute_mapping,omitempty"`
+	AllowIdpInitiated *bool   `json:"allow_idp_initiated,omitempty"`
+	IsActive          *bool   `json:"is_active,omitempty"`
 }
 
 type UpdateOrganizationRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -363,6 +363,31 @@ type OrgOIDCConnection {
   updated_at: Int64
 }
 
+# OrgSAMLConnection is a per-organization upstream SAML 2.0 IdP for which
+# Authorizer acts as the Service Provider. The IdP signing certificate is
+# accepted on write but never projected back here.
+type OrgSAMLConnection {
+  id: ID!
+  org_id: String!
+  name: String!
+  # idp_entity_id: the upstream IdP entity ID (the assertion Issuer).
+  idp_entity_id: String!
+  # idp_sso_url: the IdP Single Sign-On endpoint the AuthnRequest is sent to.
+  idp_sso_url: String
+  # sp_entity_id / acs_url: the SP identity Authorizer advertises for this org.
+  # Empty means "derived from the request host". Register these at the IdP, or
+  # fetch the concrete SP metadata XML from /oauth/saml/{org}/metadata.
+  sp_entity_id: String
+  acs_url: String
+  # attribute_mapping: JSON mapping profile fields to SAML attribute names.
+  attribute_mapping: String
+  # allow_idp_initiated: whether IdP-initiated SSO is permitted (default false).
+  allow_idp_initiated: Boolean!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
 type Organization {
   id: ID!
   # name is a unique, URL-safe slug identifying the organization.
@@ -876,6 +901,46 @@ input OrgOIDCConnectionRequest {
   org_id: String
 }
 
+input CreateOrgSAMLConnectionRequest {
+  org_id: String!
+  name: String!
+  # idp_entity_id: the upstream IdP entity ID (matched against the assertion
+  # Issuer). Globally unique across all trusted issuers.
+  idp_entity_id: String!
+  # idp_sso_url: the IdP Single Sign-On endpoint (HTTP-Redirect binding).
+  idp_sso_url: String!
+  # idp_certificate: the IdP X.509 signing certificate (PEM). Assertion
+  # signatures are validated ONLY against this certificate.
+  idp_certificate: String!
+  # sp_entity_id / acs_url: override the host-derived SP identity. Optional.
+  sp_entity_id: String
+  acs_url: String
+  # attribute_mapping: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  attribute_mapping: String
+  # allow_idp_initiated: default false (SP-initiated only).
+  allow_idp_initiated: Boolean
+}
+
+input UpdateOrgSAMLConnectionRequest {
+  id: ID!
+  name: String
+  idp_entity_id: String
+  idp_sso_url: String
+  # Supplying idp_certificate replaces it; omitting leaves the stored cert intact.
+  idp_certificate: String
+  sp_entity_id: String
+  acs_url: String
+  attribute_mapping: String
+  allow_idp_initiated: Boolean
+  is_active: Boolean
+}
+
+input OrgSAMLConnectionRequest {
+  # Look up by connection id OR by org_id (supply exactly one).
+  id: ID
+  org_id: String
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -1111,6 +1176,10 @@ type Mutation {
   _create_org_oidc_connection(params: CreateOrgOIDCConnectionRequest!): OrgOIDCConnection!
   _update_org_oidc_connection(params: UpdateOrgOIDCConnectionRequest!): OrgOIDCConnection!
   _delete_org_oidc_connection(params: OrgOIDCConnectionRequest!): Response!
+  # Per-organization SSO SAML connections (Authorizer as Service Provider)
+  _create_org_saml_connection(params: CreateOrgSAMLConnectionRequest!): OrgSAMLConnection!
+  _update_org_saml_connection(params: UpdateOrgSAMLConnectionRequest!): OrgSAMLConnection!
+  _delete_org_saml_connection(params: OrgSAMLConnectionRequest!): Response!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -1158,6 +1227,7 @@ type Query {
   _trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
+  _org_saml_connection(params: OrgSAMLConnectionRequest!): OrgSAMLConnection!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -202,6 +202,21 @@ func (r *mutationResolver) DeleteOrgOidcConnection(ctx context.Context, params m
 	return r.GraphQLProvider.DeleteOrgOidcConnection(ctx, &params)
 }
 
+// CreateOrgSamlConnection is the resolver for the _create_org_saml_connection field.
+func (r *mutationResolver) CreateOrgSamlConnection(ctx context.Context, params model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	return r.GraphQLProvider.CreateOrgSamlConnection(ctx, &params)
+}
+
+// UpdateOrgSamlConnection is the resolver for the _update_org_saml_connection field.
+func (r *mutationResolver) UpdateOrgSamlConnection(ctx context.Context, params model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	return r.GraphQLProvider.UpdateOrgSamlConnection(ctx, &params)
+}
+
+// DeleteOrgSamlConnection is the resolver for the _delete_org_saml_connection field.
+func (r *mutationResolver) DeleteOrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteOrgSamlConnection(ctx, &params)
+}
+
 // CreateOrganization is the resolver for the _create_organization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error) {
 	return r.GraphQLProvider.CreateOrganization(ctx, &params)
@@ -375,6 +390,11 @@ func (r *queryResolver) TrustedIssuers(ctx context.Context, params *model.ListTr
 // OrgOidcConnection is the resolver for the _org_oidc_connection field.
 func (r *queryResolver) OrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error) {
 	return r.GraphQLProvider.OrgOidcConnection(ctx, &params)
+}
+
+// OrgSamlConnection is the resolver for the _org_saml_connection field.
+func (r *queryResolver) OrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	return r.GraphQLProvider.OrgSamlConnection(ctx, &params)
 }
 
 // Organization is the resolver for the _organization field.

--- a/internal/graphql/org_saml_connection.go
+++ b/internal/graphql/org_saml_connection.go
@@ -1,0 +1,66 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// CreateOrgSamlConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) CreateOrgSamlConnection(ctx context.Context, params *model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateOrgSAMLConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// UpdateOrgSamlConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) UpdateOrgSamlConnection(ctx context.Context, params *model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateOrgSAMLConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// DeleteOrgSamlConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) DeleteOrgSamlConnection(ctx context.Context, params *model.OrgSAMLConnectionRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteOrgSAMLConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// OrgSamlConnection delegates to the transport-agnostic service layer.
+//
+// Permissions: authorizer:admin
+func (g *graphqlProvider) OrgSamlConnection(ctx context.Context, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().OrgSAMLConnection(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -251,6 +251,18 @@ type Provider interface {
 	// OrgOidcConnection returns a per-org OIDC connection by id or org_id.
 	// Permissions: authorizer:admin
 	OrgOidcConnection(ctx context.Context, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
+	// CreateOrgSamlConnection registers a per-org upstream SAML IdP connection.
+	// Permissions: authorizer:admin
+	CreateOrgSamlConnection(ctx context.Context, params *model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	// UpdateOrgSamlConnection updates a per-org SAML connection.
+	// Permissions: authorizer:admin
+	UpdateOrgSamlConnection(ctx context.Context, params *model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	// DeleteOrgSamlConnection deletes a per-org SAML connection.
+	// Permissions: authorizer:admin
+	DeleteOrgSamlConnection(ctx context.Context, params *model.OrgSAMLConnectionRequest) (*model.Response, error)
+	// OrgSamlConnection returns a per-org SAML connection by id or org_id.
+	// Permissions: authorizer:admin
+	OrgSamlConnection(ctx context.Context, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
 	// CreateOrganization creates a new organization.
 	// Permissions: authorizer:admin
 	CreateOrganization(ctx context.Context, params *model.CreateOrganizationRequest) (*model.Organization, error)

--- a/internal/http_handlers/oauth_sso.go
+++ b/internal/http_handlers/oauth_sso.go
@@ -502,13 +502,48 @@ func (h *httpProvider) fetchSSOJWKS(ctx context.Context, jwksURI string) (*jose.
 // silently linked to that account.
 func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowState, claims jwt.MapClaims) (*schemas.User, bool, error) {
 	sub, _ := claims["sub"].(string)
-	sub = strings.TrimSpace(sub)
-	if sub == "" {
+	profile := federatedProfile{
+		Email:         strings.TrimSpace(claimString(claims, "email")),
+		EmailVerified: emailVerifiedClaim(claims),
+		GivenName:     claimString(claims, "given_name"),
+		FamilyName:    claimString(claims, "family_name"),
+		Nickname:      claimString(claims, "name"),
+		Picture:       claimString(claims, "picture"),
+	}
+	return h.jitProvisionFederatedUser(ctx, flow.OrgID, flow.ExpectedIssuer, sub, profile)
+}
+
+// federatedProfile carries the optional profile attributes extracted from an
+// upstream identity (OIDC ID-token claims or SAML assertion attributes) for JIT
+// provisioning. The subject (federated identity) is passed separately.
+type federatedProfile struct {
+	Email         string
+	EmailVerified bool
+	GivenName     string
+	FamilyName    string
+	Nickname      string
+	Picture       string
+}
+
+// jitProvisionFederatedUser is the shared JIT provisioning core for BOTH the
+// OIDC broker and the SAML SP. Federated principals are namespaced by
+// (orgID, issuer, subject); the security-critical invariants live here so the
+// two brokers cannot drift apart:
+//
+//   - a returning principal is resolved ONLY via the (orgID, issuer, subject)
+//     FederatedIdentity row;
+//   - a first-time principal whose email collides with ANY existing account is
+//     rejected fail-closed — never silently linked (account-takeover defense);
+//   - a partial provisioning (user created, federated-identity insert failed) is
+//     rolled back by deleting the orphaned user so a retry is clean.
+func (h *httpProvider) jitProvisionFederatedUser(ctx context.Context, orgID, issuer, subject string, profile federatedProfile) (*schemas.User, bool, error) {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
 		return nil, false, fmt.Errorf("missing subject")
 	}
 
 	// Returning principal?
-	if fi, err := h.StorageProvider.GetFederatedIdentity(ctx, flow.OrgID, flow.ExpectedIssuer, sub); err == nil && fi != nil {
+	if fi, err := h.StorageProvider.GetFederatedIdentity(ctx, orgID, issuer, subject); err == nil && fi != nil {
 		user, err := h.StorageProvider.GetUserByID(ctx, fi.UserID)
 		if err != nil || user == nil {
 			return nil, false, fmt.Errorf("federated identity references an unknown user")
@@ -523,7 +558,7 @@ func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowSta
 		return nil, false, fmt.Errorf("signup is disabled for this instance")
 	}
 
-	email := strings.TrimSpace(claimString(claims, "email"))
+	email := strings.TrimSpace(profile.Email)
 	// Account-takeover defense: never link to an existing account by email.
 	if email != "" {
 		if existing, err := h.StorageProvider.GetUserByEmail(ctx, email); err == nil && existing != nil {
@@ -538,21 +573,21 @@ func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowSta
 	}
 	if email != "" {
 		user.Email = refs.NewStringRef(email)
-		if emailVerifiedClaim(claims) {
+		if profile.EmailVerified {
 			user.EmailVerifiedAt = &now
 		}
 	}
-	if v := claimString(claims, "given_name"); v != "" {
-		user.GivenName = refs.NewStringRef(v)
+	if profile.GivenName != "" {
+		user.GivenName = refs.NewStringRef(profile.GivenName)
 	}
-	if v := claimString(claims, "family_name"); v != "" {
-		user.FamilyName = refs.NewStringRef(v)
+	if profile.FamilyName != "" {
+		user.FamilyName = refs.NewStringRef(profile.FamilyName)
 	}
-	if v := claimString(claims, "name"); v != "" {
-		user.Nickname = refs.NewStringRef(v)
+	if profile.Nickname != "" {
+		user.Nickname = refs.NewStringRef(profile.Nickname)
 	}
-	if v := claimString(claims, "picture"); v != "" {
-		user.Picture = refs.NewStringRef(v)
+	if profile.Picture != "" {
+		user.Picture = refs.NewStringRef(profile.Picture)
 	}
 
 	user, err := h.StorageProvider.AddUser(ctx, user)
@@ -560,9 +595,9 @@ func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowSta
 		return nil, false, fmt.Errorf("failed to provision user")
 	}
 	if _, err := h.StorageProvider.AddFederatedIdentity(ctx, &schemas.FederatedIdentity{
-		OrgID:   flow.OrgID,
-		Issuer:  flow.ExpectedIssuer,
-		Subject: sub,
+		OrgID:   orgID,
+		Issuer:  issuer,
+		Subject: subject,
 		UserID:  user.ID,
 	}); err != nil {
 		// Compensating action (LOW-1): the user we just created now has an email on
@@ -577,7 +612,7 @@ func (h *httpProvider) jitProvisionSSOUser(ctx context.Context, flow *ssoFlowSta
 	// Best-effort org membership: the (org_id, user_id) uniqueness guard tolerates
 	// a pre-existing row. A failure here must not block the login.
 	if _, err := h.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{
-		OrgID:  flow.OrgID,
+		OrgID:  orgID,
 		UserID: user.ID,
 	}); err != nil {
 		h.Log.Debug().Err(err).Msg("failed to add org membership (non-fatal)")

--- a/internal/http_handlers/provider.go
+++ b/internal/http_handlers/provider.go
@@ -111,6 +111,12 @@ type Provider interface {
 	SSOLoginHandler() gin.HandlerFunc
 	// SSOCallbackHandler completes a per-org enterprise OIDC SSO broker login.
 	SSOCallbackHandler() gin.HandlerFunc
+	// SAMLMetadataHandler serves a per-org SP SAML metadata document.
+	SAMLMetadataHandler() gin.HandlerFunc
+	// SAMLLoginHandler starts a per-org SP-initiated SAML SSO login.
+	SAMLLoginHandler() gin.HandlerFunc
+	// SAMLACSHandler consumes a per-org SAML assertion (Assertion Consumer Service).
+	SAMLACSHandler() gin.HandlerFunc
 	// OpenIDConfigurationHandler is the main handler that handels all the openid configuration requests
 	OpenIDConfigurationHandler() gin.HandlerFunc
 	// PlaygroundHandler is the main handler that handels all the playground requests

--- a/internal/http_handlers/saml_sp.go
+++ b/internal/http_handlers/saml_sp.go
@@ -214,27 +214,27 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 		ctx := c.Request.Context()
 		slug := strings.TrimSpace(c.Param("org_slug"))
 		if h.MemoryStoreProvider == nil {
-			samlFail(c, &log, slug, "internal_error", "server error")
+			h.samlFail(c, &log, slug, "internal_error", "server error")
 			return
 		}
 		if err := c.Request.ParseForm(); err != nil {
-			samlFail(c, &log, slug, "invalid_request", "malformed request")
+			h.samlFail(c, &log, slug, "invalid_request", "malformed request")
 			return
 		}
 		// Artifact binding performs an outbound resolution call (SSRF surface) and
 		// is not supported here — only the HTTP-POST assertion binding is accepted.
 		if strings.TrimSpace(c.Request.PostForm.Get("SAMLart")) != "" {
-			samlFail(c, &log, slug, "unsupported_binding", "artifact binding is not supported")
+			h.samlFail(c, &log, slug, "unsupported_binding", "artifact binding is not supported")
 			return
 		}
 		rawResponse := strings.TrimSpace(c.Request.PostForm.Get("SAMLResponse"))
 		if rawResponse == "" {
-			samlFail(c, &log, slug, "invalid_request", "missing SAMLResponse")
+			h.samlFail(c, &log, slug, "invalid_request", "missing SAMLResponse")
 			return
 		}
 		decoded, err := base64.StdEncoding.DecodeString(rawResponse)
 		if err != nil {
-			samlFail(c, &log, slug, "invalid_request", "malformed SAMLResponse")
+			h.samlFail(c, &log, slug, "invalid_request", "malformed SAMLResponse")
 			return
 		}
 
@@ -245,7 +245,7 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 		sp, err := buildSAMLServiceProvider(conn, parsers.GetHost(c), slug)
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to build SP for acs")
-			samlFail(c, &log, slug, "sso_config_error", "connection misconfigured")
+			h.samlFail(c, &log, slug, "sso_config_error", "connection misconfigured")
 			return
 		}
 
@@ -261,14 +261,14 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 			// crewjam wraps the real cause in InvalidResponseError.PrivateErr.
 			log.Debug().Err(err).Msg("saml assertion validation failed")
 			metrics.RecordSecurityEvent("saml_assertion_invalid", slug)
-			samlFail(c, &log, slug, "saml_assertion_invalid", "assertion validation failed")
+			h.samlFail(c, &log, slug, "saml_assertion_invalid", "assertion validation failed")
 			return
 		}
 
 		// Single-use AssertionID (replay defence). crewjam does not dedupe.
 		if err := h.consumeSAMLAssertionID(conn.OrgID, assertion); err != nil {
 			metrics.RecordSecurityEvent("saml_assertion_replay", slug)
-			samlFail(c, &log, slug, "saml_assertion_replay", "assertion already used")
+			h.samlFail(c, &log, slug, "saml_assertion_replay", "assertion already used")
 			return
 		}
 
@@ -277,7 +277,7 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 			subject = strings.TrimSpace(assertion.Subject.NameID.Value)
 		}
 		if subject == "" {
-			samlFail(c, &log, slug, "saml_assertion_invalid", "assertion has no subject NameID")
+			h.samlFail(c, &log, slug, "saml_assertion_invalid", "assertion has no subject NameID")
 			return
 		}
 
@@ -287,13 +287,15 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 		user, isSignUp, err := h.jitProvisionFederatedUser(ctx, conn.OrgID, conn.IssuerURL, subject, profile)
 		if err != nil {
 			log.Debug().Err(err).Msg("saml JIT provisioning rejected")
-			samlFail(c, &log, slug, "saml_provisioning_failed", err.Error())
+			// Do not echo the internal reason (e.g. "account with this email
+			// already exists") — an IdP-colluding actor could enumerate accounts.
+			h.samlFail(c, &log, slug, "saml_provisioning_failed", "provisioning failed")
 			return
 		}
 
 		if err := h.issueSAMLSession(c, slug, appRedirect, appState, user, isSignUp); err != nil {
 			log.Debug().Err(err).Msg("failed to issue session")
-			samlFail(c, &log, slug, "saml_session_failed", "could not establish session")
+			h.samlFail(c, &log, slug, "saml_session_failed", "could not establish session")
 			return
 		}
 	}
@@ -313,11 +315,11 @@ func (h *httpProvider) resolveSAMLResponseContext(c *gin.Context, sp *saml.Servi
 		if strings.TrimSpace(raw) != "" {
 			var flow samlFlowState
 			if err := json.Unmarshal([]byte(raw), &flow); err != nil {
-				samlFail(c, log, slug, "invalid_state", "corrupt state")
+				h.samlFail(c, log, slug, "invalid_state", "corrupt state")
 				return nil, "", "", false
 			}
 			if flow.OrgSlug != slug {
-				samlFail(c, log, slug, "invalid_state", "state/route mismatch")
+				h.samlFail(c, log, slug, "invalid_state", "state/route mismatch")
 				return nil, "", "", false
 			}
 			return []string{flow.RequestID}, flow.AppRedirect, flow.AppState, true
@@ -327,14 +329,14 @@ func (h *httpProvider) resolveSAMLResponseContext(c *gin.Context, sp *saml.Servi
 	// No pending SP-initiated request — this is an IdP-initiated response.
 	if !sp.AllowIDPInitiated {
 		metrics.RecordSecurityEvent("saml_idp_initiated_rejected", slug)
-		samlFail(c, log, slug, "idp_initiated_disabled", "IdP-initiated SSO is disabled for this connection")
+		h.samlFail(c, log, slug, "idp_initiated_disabled", "IdP-initiated SSO is disabled for this connection")
 		return nil, "", "", false
 	}
 	// The redirect target for an IdP-initiated flow must still be an explicit,
 	// AllowedOrigins-validated redirect_uri — RelayState is not trusted as a URL.
 	appRedirect := strings.TrimSpace(c.Request.PostForm.Get("redirect_uri"))
 	if appRedirect == "" || !validators.IsValidRedirectURI(appRedirect, h.Config.AllowedOrigins, parsers.GetHost(c)) {
-		samlFail(c, log, slug, "invalid_request", "invalid redirect_uri for IdP-initiated flow")
+		h.samlFail(c, log, slug, "invalid_request", "invalid redirect_uri for IdP-initiated flow")
 		return nil, "", "", false
 	}
 	return nil, appRedirect, "", true
@@ -573,8 +575,19 @@ func (h *httpProvider) issueSAMLSession(c *gin.Context, slug, appRedirect, appSt
 }
 
 // samlFail writes a uniform OAuth-style error response and records the failure.
-func samlFail(c *gin.Context, log *zerolog.Logger, slug, code, desc string) {
+// It emits the saml.acs_failed audit event so assertion-forgery attempts (invalid
+// signature, replay, cross-org, IdP-initiated-rejected) leave an audit trail, not
+// just a metric — successes are already audited in issueSAMLSession.
+func (h *httpProvider) samlFail(c *gin.Context, log *zerolog.Logger, slug, code, desc string) {
 	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusFailure)
 	log.Debug().Str("error", code).Str("org", slug).Msg("saml acs failed")
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditSAMLACSFailedEvent,
+		ActorType:    constants.AuditActorTypeUser,
+		ResourceType: constants.AuditResourceTypeSession,
+		Metadata:     slug + ":" + code,
+		IPAddress:    utils.GetIP(c.Request),
+		UserAgent:    utils.GetUserAgent(c.Request),
+	})
 	c.JSON(http.StatusBadRequest, gin.H{"error": code, "error_description": desc})
 }

--- a/internal/http_handlers/saml_sp.go
+++ b/internal/http_handlers/saml_sp.go
@@ -1,0 +1,580 @@
+package http_handlers
+
+// Per-organization enterprise SAML 2.0 SSO — Authorizer acting as the Service
+// Provider (SP). An org configures its upstream corporate IdP (Okta/Entra/ADFS)
+// as an sso_saml TrustedIssuer row; its users log in through that IdP, Authorizer
+// validates the signed assertion, JIT-provisions the user (namespaced by
+// (org_id, IdP-entity-id, NameID)) and issues a normal Authorizer session.
+//
+// This is the SAML sibling of the OIDC broker in oauth_sso.go.
+//
+// SECURITY MODEL (design §4.4 / CR3) — enforced by the vetted crewjam/saml
+// ServiceProvider.ParseXMLResponse plus the explicit checks below:
+//   - Signature over the consumed assertion: ParseXMLResponse validates the
+//     XML-DSIG on the SAME <Assertion> element it unmarshals and returns (or a
+//     Response signature that covers it), defeating XML Signature Wrapping (XSW).
+//     Signatures are validated ONLY against the org's configured IdP certificate.
+//   - Unsigned assertions are rejected (signatureRequired unless the Response is
+//     itself validly signed).
+//   - Audience == this org's SP entity ID; Recipient == this org's ACS URL;
+//     Destination == this org's ACS URL. The ServiceProvider is built per
+//     org_slug, so an assertion minted for Org B cannot be consumed at Org A.
+//   - NotBefore / NotOnOrAfter are validated with a bounded clock skew
+//     (saml.MaxClockSkew / saml.MaxIssueDelay, the library defaults).
+//   - Single-use AssertionID: consumed assertion IDs are cached in the shared
+//     memory store until expiry; a replay is rejected. (crewjam does NOT dedupe.)
+//   - InResponseTo: SP-initiated flows persist the AuthnRequest ID keyed by an
+//     opaque RelayState; the ACS binds the response to that pending request.
+//     IdP-initiated flow is disabled unless the connection opts in.
+//   - RelayState is an opaque, single-use handle into the shared store — never a
+//     raw redirect target. The final app redirect is validated against
+//     AllowedOrigins (mirror oauth_sso.go).
+//
+// ponytail: AuthnRequests are emitted UNSIGNED (HTTP-Redirect binding). Request
+// signing protects the IdP against forged requests, not the SP against forged
+// assertions (all SP-side security is at the ACS), and Authorizer has no SP
+// X.509 keypair. Upgrade path: set SignatureMethod + Key + Certificate on the
+// ServiceProvider and advertise AuthnRequestsSigned in metadata.
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/gin-gonic/gin"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/cookie"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/parsers"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+	"github.com/authorizerdev/authorizer/internal/utils"
+	"github.com/authorizerdev/authorizer/internal/validators"
+)
+
+const (
+	// samlFlowPrefix namespaces the pending SP-initiated AuthnRequest in the shared
+	// store. SetState applies the store's short OAuth-state TTL, so the pending
+	// request expires if the assertion never arrives.
+	samlFlowPrefix = "saml_flow:"
+	// samlAssertionPrefix namespaces the single-use AssertionID replay cache.
+	samlAssertionPrefix = "saml_assertion:"
+	// samlReplayFallbackTTL bounds the replay cache when an assertion carries no
+	// usable expiry (defence in depth; crewjam already rejects such assertions).
+	samlReplayFallbackTTL = int64(600)
+)
+
+// samlDefaultAttributeMapping maps Authorizer profile fields to the SAML
+// attribute names most IdPs emit by default. Overridable per connection.
+var samlDefaultAttributeMapping = map[string]string{
+	"email":       "email",
+	"given_name":  "firstName",
+	"family_name": "lastName",
+	"nickname":    "displayName",
+	"picture":     "picture",
+}
+
+// samlFlowState is the per-request SP-initiated context, stored single-use in the
+// shared store between login and ACS under an opaque RelayState. RequestID binds
+// the returned assertion's InResponseTo to the AuthnRequest we issued.
+type samlFlowState struct {
+	RequestID   string `json:"request_id"`
+	OrgSlug     string `json:"org_slug"`
+	AppRedirect string `json:"app_redirect"`
+	AppState    string `json:"app_state"`
+}
+
+// SAMLMetadataHandler serves this org's SP SAML metadata XML so the org admin can
+// register Authorizer at their IdP (entity ID + ACS URL).
+func (h *httpProvider) SAMLMetadataHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLMetadataHandler").Logger()
+	return func(c *gin.Context) {
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		conn, ok := h.resolveActiveSAMLConnection(c, slug, &log)
+		if !ok {
+			return
+		}
+		sp, err := buildSAMLServiceProvider(conn, parsers.GetHost(c), slug)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to build SP for metadata")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "sso_config_error", "error_description": "connection misconfigured"})
+			return
+		}
+		md := sp.Metadata()
+		body, err := xml.MarshalIndent(md, "", "  ")
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		out := append([]byte(xml.Header), body...)
+		c.Data(http.StatusOK, "application/samlmetadata+xml", out)
+	}
+}
+
+// SAMLLoginHandler starts an SP-initiated SAML login: it resolves the org's
+// sso_saml connection, builds an AuthnRequest, persists its ID under an opaque
+// RelayState, and redirects the browser to the IdP (HTTP-Redirect binding).
+func (h *httpProvider) SAMLLoginHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLLoginHandler").Logger()
+	return func(c *gin.Context) {
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		appRedirect := strings.TrimSpace(c.Query("redirect_uri"))
+		appState := strings.TrimSpace(c.Query("state"))
+		hostname := parsers.GetHost(c)
+
+		if appRedirect == "" || !validators.IsValidRedirectURI(appRedirect, h.Config.AllowedOrigins, hostname) {
+			log.Debug().Msg("invalid or missing redirect_uri")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "error_description": "invalid redirect_uri"})
+			return
+		}
+		if h.MemoryStoreProvider == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		conn, ok := h.resolveActiveSAMLConnection(c, slug, &log)
+		if !ok {
+			return
+		}
+		sp, err := buildSAMLServiceProvider(conn, hostname, slug)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to build SP for login")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "sso_config_error", "error_description": "connection misconfigured"})
+			return
+		}
+
+		authnReq, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(saml.HTTPRedirectBinding), saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to build AuthnRequest")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "sso_config_error", "error_description": "could not build authentication request"})
+			return
+		}
+
+		relayState, err := randURLString(32)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		flowJSON, err := json.Marshal(samlFlowState{
+			RequestID:   authnReq.ID,
+			OrgSlug:     slug,
+			AppRedirect: appRedirect,
+			AppState:    appState,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		if err := h.MemoryStoreProvider.SetState(samlFlowPrefix+relayState, string(flowJSON)); err != nil {
+			log.Debug().Err(err).Msg("failed to persist saml flow state")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		redirectURL, err := authnReq.Redirect(relayState, sp)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to encode AuthnRequest redirect")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "sso_config_error", "error_description": "could not build authentication request"})
+			return
+		}
+
+		metrics.RecordAuthEvent(metrics.EventOAuthLogin, metrics.StatusSuccess)
+		h.AuditProvider.LogEvent(audit.Event{
+			Action:       constants.AuditSAMLLoginInitiatedEvent,
+			ActorType:    constants.AuditActorTypeUser,
+			ResourceType: constants.AuditResourceTypeSession,
+			Metadata:     slug,
+			IPAddress:    utils.GetIP(c.Request),
+			UserAgent:    utils.GetUserAgent(c.Request),
+		})
+		c.Redirect(http.StatusFound, redirectURL.String())
+	}
+}
+
+// SAMLACSHandler is the Assertion Consumer Service — the security-critical
+// endpoint. It validates the signed assertion against the org's IdP config,
+// enforces single-use (replay) semantics, JIT-provisions, and issues a session.
+func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLACSHandler").Logger()
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		if h.MemoryStoreProvider == nil {
+			samlFail(c, &log, slug, "internal_error", "server error")
+			return
+		}
+		if err := c.Request.ParseForm(); err != nil {
+			samlFail(c, &log, slug, "invalid_request", "malformed request")
+			return
+		}
+		// Artifact binding performs an outbound resolution call (SSRF surface) and
+		// is not supported here — only the HTTP-POST assertion binding is accepted.
+		if strings.TrimSpace(c.Request.PostForm.Get("SAMLart")) != "" {
+			samlFail(c, &log, slug, "unsupported_binding", "artifact binding is not supported")
+			return
+		}
+		rawResponse := strings.TrimSpace(c.Request.PostForm.Get("SAMLResponse"))
+		if rawResponse == "" {
+			samlFail(c, &log, slug, "invalid_request", "missing SAMLResponse")
+			return
+		}
+		decoded, err := base64.StdEncoding.DecodeString(rawResponse)
+		if err != nil {
+			samlFail(c, &log, slug, "invalid_request", "malformed SAMLResponse")
+			return
+		}
+
+		conn, ok := h.resolveActiveSAMLConnection(c, slug, &log)
+		if !ok {
+			return
+		}
+		sp, err := buildSAMLServiceProvider(conn, parsers.GetHost(c), slug)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to build SP for acs")
+			samlFail(c, &log, slug, "sso_config_error", "connection misconfigured")
+			return
+		}
+
+		// Resolve the pending SP-initiated request (single-use) via the opaque
+		// RelayState, or fall back to the IdP-initiated path when permitted.
+		possibleRequestIDs, appRedirect, appState, ok := h.resolveSAMLResponseContext(c, sp, slug, &log)
+		if !ok {
+			return
+		}
+
+		assertion, err := sp.ParseXMLResponse(decoded, possibleRequestIDs, sp.AcsURL)
+		if err != nil {
+			// crewjam wraps the real cause in InvalidResponseError.PrivateErr.
+			log.Debug().Err(err).Msg("saml assertion validation failed")
+			metrics.RecordSecurityEvent("saml_assertion_invalid", slug)
+			samlFail(c, &log, slug, "saml_assertion_invalid", "assertion validation failed")
+			return
+		}
+
+		// Single-use AssertionID (replay defence). crewjam does not dedupe.
+		if err := h.consumeSAMLAssertionID(conn.OrgID, assertion); err != nil {
+			metrics.RecordSecurityEvent("saml_assertion_replay", slug)
+			samlFail(c, &log, slug, "saml_assertion_replay", "assertion already used")
+			return
+		}
+
+		subject := ""
+		if assertion.Subject != nil && assertion.Subject.NameID != nil {
+			subject = strings.TrimSpace(assertion.Subject.NameID.Value)
+		}
+		if subject == "" {
+			samlFail(c, &log, slug, "saml_assertion_invalid", "assertion has no subject NameID")
+			return
+		}
+
+		profile := extractSAMLProfile(assertion, conn.SAMLAttributeMapping)
+		// JIT provisioning namespaced by (org_id, IdP entity id, NameID). The IdP
+		// entity id is stored in conn.IssuerURL.
+		user, isSignUp, err := h.jitProvisionFederatedUser(ctx, conn.OrgID, conn.IssuerURL, subject, profile)
+		if err != nil {
+			log.Debug().Err(err).Msg("saml JIT provisioning rejected")
+			samlFail(c, &log, slug, "saml_provisioning_failed", err.Error())
+			return
+		}
+
+		if err := h.issueSAMLSession(c, slug, appRedirect, appState, user, isSignUp); err != nil {
+			log.Debug().Err(err).Msg("failed to issue session")
+			samlFail(c, &log, slug, "saml_session_failed", "could not establish session")
+			return
+		}
+	}
+}
+
+// resolveSAMLResponseContext binds the ACS response to a pending SP-initiated
+// request (via the opaque RelayState) or, when the connection opts in, accepts an
+// IdP-initiated response. RelayState is NEVER used as a redirect target — the
+// final redirect is always a server-side value validated against AllowedOrigins.
+func (h *httpProvider) resolveSAMLResponseContext(c *gin.Context, sp *saml.ServiceProvider, slug string, log *zerolog.Logger) ([]string, string, string, bool) {
+	relayState := strings.TrimSpace(c.Request.PostForm.Get("RelayState"))
+	if relayState != "" {
+		raw, err := h.MemoryStoreProvider.GetAndRemoveState(samlFlowPrefix + relayState)
+		if err != nil && err != goredis.Nil {
+			log.Debug().Err(err).Msg("failed to read saml flow state")
+		}
+		if strings.TrimSpace(raw) != "" {
+			var flow samlFlowState
+			if err := json.Unmarshal([]byte(raw), &flow); err != nil {
+				samlFail(c, log, slug, "invalid_state", "corrupt state")
+				return nil, "", "", false
+			}
+			if flow.OrgSlug != slug {
+				samlFail(c, log, slug, "invalid_state", "state/route mismatch")
+				return nil, "", "", false
+			}
+			return []string{flow.RequestID}, flow.AppRedirect, flow.AppState, true
+		}
+	}
+
+	// No pending SP-initiated request — this is an IdP-initiated response.
+	if !sp.AllowIDPInitiated {
+		metrics.RecordSecurityEvent("saml_idp_initiated_rejected", slug)
+		samlFail(c, log, slug, "idp_initiated_disabled", "IdP-initiated SSO is disabled for this connection")
+		return nil, "", "", false
+	}
+	// The redirect target for an IdP-initiated flow must still be an explicit,
+	// AllowedOrigins-validated redirect_uri — RelayState is not trusted as a URL.
+	appRedirect := strings.TrimSpace(c.Request.PostForm.Get("redirect_uri"))
+	if appRedirect == "" || !validators.IsValidRedirectURI(appRedirect, h.Config.AllowedOrigins, parsers.GetHost(c)) {
+		samlFail(c, log, slug, "invalid_request", "invalid redirect_uri for IdP-initiated flow")
+		return nil, "", "", false
+	}
+	return nil, appRedirect, "", true
+}
+
+// consumeSAMLAssertionID enforces single-use of an AssertionID within the org.
+// Returns an error if the assertion was already consumed (replay). The cache TTL
+// tracks the assertion's own expiry so the entry cannot outlive the replay window.
+//
+// ponytail: check-then-set (not atomic) — the memory-store interface exposes no
+// SetNX, so two requests replaying the same assertion within the same few
+// milliseconds could both pass. The assertion's own short NotOnOrAfter window
+// bounds this; upgrade path: add an atomic SetNX to the memory store.
+func (h *httpProvider) consumeSAMLAssertionID(orgID string, assertion *saml.Assertion) error {
+	id := strings.TrimSpace(assertion.ID)
+	if id == "" {
+		return fmt.Errorf("assertion has no ID")
+	}
+	key := samlAssertionPrefix + orgID + ":" + id
+	existing, err := h.MemoryStoreProvider.GetCache(key)
+	if err == nil && strings.TrimSpace(existing) != "" {
+		return fmt.Errorf("assertion replay detected")
+	}
+	ttl := samlReplayFallbackTTL
+	if assertion.Conditions != nil && !assertion.Conditions.NotOnOrAfter.IsZero() {
+		if secs := int64(time.Until(assertion.Conditions.NotOnOrAfter.Add(saml.MaxClockSkew)).Seconds()); secs > ttl {
+			ttl = secs
+		}
+	}
+	return h.MemoryStoreProvider.SetCache(key, "1", ttl)
+}
+
+// resolveActiveSAMLConnection looks up the org by slug and its active sso_saml
+// connection, writing an error response and returning ok=false on any failure.
+func (h *httpProvider) resolveActiveSAMLConnection(c *gin.Context, slug string, log *zerolog.Logger) (*schemas.TrustedIssuer, bool) {
+	ctx := c.Request.Context()
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "error_description": "missing organization"})
+		return nil, false
+	}
+	org, err := h.StorageProvider.GetOrganizationByName(ctx, slug)
+	if err != nil || org == nil {
+		log.Debug().Err(err).Str("org", slug).Msg("organization not found")
+		c.JSON(http.StatusNotFound, gin.H{"error": "sso_not_configured", "error_description": "unknown organization"})
+		return nil, false
+	}
+	if !org.Enabled {
+		c.JSON(http.StatusForbidden, gin.H{"error": "sso_not_configured", "error_description": "organization disabled"})
+		return nil, false
+	}
+	conn, err := h.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, org.ID, constants.TrustKindSSOSAML)
+	if err != nil || conn == nil || conn.EffectiveKind() != constants.TrustKindSSOSAML || !conn.IsActive {
+		log.Debug().Err(err).Str("org", slug).Msg("no active SAML connection for org")
+		c.JSON(http.StatusNotFound, gin.H{"error": "sso_not_configured", "error_description": "SAML SSO is not configured for this organization"})
+		return nil, false
+	}
+	return conn, true
+}
+
+// buildSAMLServiceProvider constructs a per-org saml.ServiceProvider from the
+// stored connection. The SP's EntityID (audience) and AcsURL (recipient) come
+// from THIS org's config, and the IDP metadata trusts ONLY this org's certificate
+// — the mechanism that keeps an Org B assertion from being consumed at Org A.
+func buildSAMLServiceProvider(conn *schemas.TrustedIssuer, hostname, slug string) (*saml.ServiceProvider, error) {
+	if conn.SAMLIDPCertPEM == nil || strings.TrimSpace(*conn.SAMLIDPCertPEM) == "" {
+		return nil, fmt.Errorf("connection has no IdP certificate")
+	}
+	if conn.SAMLSSOURL == nil || strings.TrimSpace(*conn.SAMLSSOURL) == "" {
+		return nil, fmt.Errorf("connection has no IdP SSO URL")
+	}
+	block, _ := pem.Decode([]byte(strings.TrimSpace(*conn.SAMLIDPCertPEM)))
+	if block == nil {
+		return nil, fmt.Errorf("IdP certificate is not valid PEM")
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return nil, fmt.Errorf("IdP certificate is not a valid X.509 certificate: %w", err)
+	}
+	certB64 := base64.StdEncoding.EncodeToString(block.Bytes)
+
+	spEntityID := samlDefaultSPEntityID(hostname, slug)
+	if conn.SAMLSPEntityID != nil && strings.TrimSpace(*conn.SAMLSPEntityID) != "" {
+		spEntityID = strings.TrimSpace(*conn.SAMLSPEntityID)
+	}
+	acsRaw := samlDefaultACSURL(hostname, slug)
+	if conn.SAMLACSURL != nil && strings.TrimSpace(*conn.SAMLACSURL) != "" {
+		acsRaw = strings.TrimSpace(*conn.SAMLACSURL)
+	}
+	acsURL, err := url.Parse(acsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ACS URL: %w", err)
+	}
+	metadataURL, err := url.Parse(spEntityID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SP entity ID: %w", err)
+	}
+
+	return &saml.ServiceProvider{
+		EntityID:    spEntityID,
+		MetadataURL: *metadataURL,
+		AcsURL:      *acsURL,
+		IDPMetadata: &saml.EntityDescriptor{
+			EntityID: conn.IssuerURL,
+			IDPSSODescriptors: []saml.IDPSSODescriptor{{
+				SSODescriptor: saml.SSODescriptor{
+					RoleDescriptor: saml.RoleDescriptor{
+						KeyDescriptors: []saml.KeyDescriptor{{
+							Use: "signing",
+							KeyInfo: saml.KeyInfo{
+								X509Data: saml.X509Data{
+									X509Certificates: []saml.X509Certificate{{Data: certB64}},
+								},
+							},
+						}},
+					},
+				},
+				SingleSignOnServices: []saml.Endpoint{{
+					Binding:  saml.HTTPRedirectBinding,
+					Location: strings.TrimSpace(*conn.SAMLSSOURL),
+				}},
+			}},
+		},
+		AllowIDPInitiated: conn.SAMLAllowIDPInitiated,
+	}, nil
+}
+
+func samlDefaultSPEntityID(hostname, slug string) string {
+	return strings.TrimRight(hostname, "/") + "/oauth/saml/" + url.PathEscape(slug) + "/metadata"
+}
+
+func samlDefaultACSURL(hostname, slug string) string {
+	return strings.TrimRight(hostname, "/") + "/oauth/saml/" + url.PathEscape(slug) + "/acs"
+}
+
+// extractSAMLProfile pulls optional profile attributes out of the assertion using
+// the connection's attribute mapping (or the built-in defaults). The NameID is
+// the federated subject and is handled by the caller, not here.
+func extractSAMLProfile(assertion *saml.Assertion, mappingJSON *string) federatedProfile {
+	mapping := samlDefaultAttributeMapping
+	if mappingJSON != nil && strings.TrimSpace(*mappingJSON) != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(*mappingJSON), &m); err == nil && len(m) > 0 {
+			mapping = m
+		}
+	}
+	return federatedProfile{
+		Email:         samlAttr(assertion, mapping["email"]),
+		EmailVerified: true, // an assertion from a trusted corporate IdP asserts the identity
+		GivenName:     samlAttr(assertion, mapping["given_name"]),
+		FamilyName:    samlAttr(assertion, mapping["family_name"]),
+		Nickname:      samlAttr(assertion, mapping["nickname"]),
+		Picture:       samlAttr(assertion, mapping["picture"]),
+	}
+}
+
+// samlAttr returns the first value of the assertion attribute whose Name or
+// FriendlyName matches (case-insensitively). Empty name yields empty string.
+func samlAttr(assertion *saml.Assertion, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	for _, stmt := range assertion.AttributeStatements {
+		for _, attr := range stmt.Attributes {
+			if strings.EqualFold(attr.Name, name) || strings.EqualFold(attr.FriendlyName, name) {
+				for _, v := range attr.Values {
+					if s := strings.TrimSpace(v.Value); s != "" {
+						return s
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// issueSAMLSession mints the Authorizer session/tokens, sets the session cookie,
+// records the session, and redirects to the app's redirect_uri. Mirrors
+// issueSSOSession but with SAML audit semantics and no upstream nonce.
+func (h *httpProvider) issueSAMLSession(c *gin.Context, slug, appRedirect, appState string, user *schemas.User, isSignUp bool) error {
+	hostname := parsers.GetHost(c)
+	roles := splitRoles(user.Roles)
+	authToken, err := h.TokenProvider.CreateAuthToken(c, &token.AuthTokenConfig{
+		User:        user,
+		Roles:       roles,
+		Scope:       []string{"openid", "profile", "email"},
+		LoginMethod: constants.AuthRecipeMethodSSO,
+		HostName:    hostname,
+	})
+	if err != nil {
+		return err
+	}
+
+	sessionKey := constants.AuthRecipeMethodSSO + ":" + user.ID
+	cookie.SetSession(c, authToken.FingerPrintHash, h.Config.AppCookieSecure, cookie.ParseSameSite(h.Config.AppCookieSameSite))
+	_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeSessionToken+"_"+authToken.FingerPrint, authToken.FingerPrintHash, authToken.SessionTokenExpiresAt)
+	_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeAccessToken+"_"+authToken.FingerPrint, authToken.AccessToken.Token, authToken.AccessToken.ExpiresAt)
+	if authToken.RefreshToken != nil {
+		_ = h.MemoryStoreProvider.SetUserSession(sessionKey, constants.TokenTypeRefreshToken+"_"+authToken.FingerPrint, authToken.RefreshToken.Token, authToken.RefreshToken.ExpiresAt)
+	}
+
+	bgCtx := context.WithoutCancel(c.Request.Context())
+	userAgent := utils.GetUserAgent(c.Request)
+	ip := utils.GetIP(c.Request)
+	go func() {
+		if isSignUp {
+			_ = h.EventsProvider.RegisterEvent(bgCtx, constants.UserSignUpWebhookEvent, constants.AuthRecipeMethodSSO, user)
+		}
+		_ = h.EventsProvider.RegisterEvent(bgCtx, constants.UserLoginWebhookEvent, constants.AuthRecipeMethodSSO, user)
+		if err := h.StorageProvider.AddSession(bgCtx, &schemas.Session{UserID: user.ID, UserAgent: userAgent, IP: ip}); err != nil {
+			h.Log.Debug().Err(err).Msg("failed to add session")
+		}
+	}()
+
+	params := "state=" + url.QueryEscape(appState)
+	redirectURL := appRedirect
+	if strings.Contains(redirectURL, "?") {
+		redirectURL = redirectURL + "&" + params
+	} else {
+		redirectURL = redirectURL + "?" + params
+	}
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusSuccess)
+	metrics.ActiveSessions.Inc()
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditSAMLACSSuccessEvent,
+		ActorID:      user.ID,
+		ActorType:    constants.AuditActorTypeUser,
+		ActorEmail:   refs.StringValue(user.Email),
+		ResourceType: constants.AuditResourceTypeSession,
+		ResourceID:   user.ID,
+		Metadata:     slug,
+		IPAddress:    ip,
+		UserAgent:    userAgent,
+	})
+	c.Redirect(http.StatusFound, redirectURL)
+	return nil
+}
+
+// samlFail writes a uniform OAuth-style error response and records the failure.
+func samlFail(c *gin.Context, log *zerolog.Logger, slug, code, desc string) {
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusFailure)
+	log.Debug().Str("error", code).Str("org", slug).Msg("saml acs failed")
+	c.JSON(http.StatusBadRequest, gin.H{"error": code, "error_description": desc})
+}

--- a/internal/http_handlers/saml_sp_jit_test.go
+++ b/internal/http_handlers/saml_sp_jit_test.go
@@ -1,0 +1,72 @@
+package http_handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/memory_store/in_memory"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// Profile attributes are extracted from the assertion using the connection's
+// custom attribute mapping; the NameID stays the federated subject.
+func TestSAML_ProfileExtractionWithCustomMapping(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.attributes = map[string]string{"mail": "custom@corp.example.com", "gn": "Ada"}
+	assertion := parseValidAssertion(t, idp, p)
+
+	prof := extractSAMLProfile(assertion, refs.NewStringRef(`{"email":"mail","given_name":"gn"}`))
+	assert.Equal(t, "custom@corp.example.com", prof.Email)
+	assert.Equal(t, "Ada", prof.GivenName)
+}
+
+// With the default mapping, the standard "email" attribute is picked up.
+func TestSAML_ProfileExtractionDefaultMapping(t *testing.T) {
+	idp := newSAMLIdP(t)
+	assertion := parseValidAssertion(t, idp, defaultAssertionParams())
+	prof := extractSAMLProfile(assertion, nil)
+	assert.Equal(t, samlTestEmail, prof.Email)
+}
+
+// SAML email-collision: a first-time NameID whose mapped email collides with an
+// existing account is rejected fail-closed and never linked (account takeover).
+func TestSAML_EmailCollisionNotLinked(t *testing.T) {
+	store := newJITStore()
+	existing := &schemas.User{ID: "existing-1", Email: refs.NewStringRef(samlTestEmail)}
+	store.usersByID[existing.ID] = existing
+	store.usersByEmail[samlTestEmail] = existing
+	h := newJITProvider(store, true)
+
+	profile := federatedProfile{Email: samlTestEmail, EmailVerified: true}
+	user, isSignUp, err := h.jitProvisionFederatedUser(context.Background(), samlOrgAID, samlIdPEntityID, samlTestNameID, profile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Nil(t, user)
+	assert.False(t, isSignUp)
+	assert.Equal(t, 0, store.addFedCalls, "no federated identity may be created on collision")
+}
+
+// SAML replay: a second presentation of the same AssertionID within an org is
+// rejected by the single-use cache; a different org is independent (namespaced).
+func TestSAML_AssertionReplayRejected(t *testing.T) {
+	logger := zerolog.Nop()
+	mem, err := in_memory.NewInMemoryProvider(&config.Config{}, &in_memory.Dependencies{Log: &logger})
+	require.NoError(t, err)
+	h := &httpProvider{
+		Config:       &config.Config{},
+		Dependencies: Dependencies{Log: &logger, MemoryStoreProvider: mem},
+	}
+	idp := newSAMLIdP(t)
+	assertion := parseValidAssertion(t, idp, defaultAssertionParams())
+
+	require.NoError(t, h.consumeSAMLAssertionID(samlOrgAID, assertion))
+	require.Error(t, h.consumeSAMLAssertionID(samlOrgAID, assertion))
+	require.NoError(t, h.consumeSAMLAssertionID("other-org", assertion))
+}

--- a/internal/http_handlers/saml_sp_verify_test.go
+++ b/internal/http_handlers/saml_sp_verify_test.go
@@ -1,0 +1,318 @@
+package http_handlers
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/beevik/etree"
+	"github.com/crewjam/saml"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// SAML test fixtures. The org-A connection is the "victim" SP; org-B is a
+// separate SP used to prove cross-org rejection.
+const (
+	samlTestHost       = "https://auth.example.com"
+	samlOrgASlug       = "org-a"
+	samlOrgAID         = "org-a-id"
+	samlIdPEntityID    = "https://idp.example.com/saml/metadata"
+	samlIdPSSOURL      = "https://idp.example.com/sso"
+	samlTestNameID     = "corp-user-42"
+	samlTestEmail      = "user@corp.example.com"
+	samlTestRequestID  = "id-authnrequest-abc123"
+	samlTimeFmt        = "2006-01-02T15:04:05Z07:00"
+	samlOrgBSPEntityID = "https://auth.example.com/oauth/saml/org-b/metadata"
+	samlOrgBACSURL     = "https://auth.example.com/oauth/saml/org-b/acs"
+)
+
+// samlNow is the fixed "current" time the tests pin saml.TimeNow to.
+var samlNow = time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+// samlIdP is a generated test IdP signing keypair + self-signed certificate.
+type samlIdP struct {
+	key     *rsa.PrivateKey
+	certDER []byte
+	certPEM string
+}
+
+func newSAMLIdP(t *testing.T) *samlIdP {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-idp"},
+		// Wide validity window: goxmldsig checks the cert against the real wall
+		// clock (not saml.TimeNow), so this must bracket the actual test run time.
+		NotBefore: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:  time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	pemStr := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	return &samlIdP{key: key, certDER: der, certPEM: pemStr}
+}
+
+// assertionParams control how a test assertion is built and (optionally) tampered.
+type assertionParams struct {
+	assertionID  string
+	issuer       string
+	nameID       string
+	audience     string
+	recipient    string
+	destination  string
+	inResponseTo string
+	notBefore    time.Time
+	notOnOrAfter time.Time
+	email        string
+	// attributes, when non-nil, replaces the default single "email" attribute.
+	attributes map[string]string
+	sign       bool
+	// tamperAfterSign flips a byte in the signed NameID to simulate a broken /
+	// wrapped signature (the consumed element differs from what was signed).
+	tamperAfterSign bool
+}
+
+func defaultAssertionParams() assertionParams {
+	return assertionParams{
+		assertionID:  "id-assertion-0001",
+		issuer:       samlIdPEntityID,
+		nameID:       samlTestNameID,
+		audience:     samlTestHost + "/oauth/saml/" + samlOrgASlug + "/metadata",
+		recipient:    samlTestHost + "/oauth/saml/" + samlOrgASlug + "/acs",
+		destination:  samlTestHost + "/oauth/saml/" + samlOrgASlug + "/acs",
+		inResponseTo: samlTestRequestID,
+		notBefore:    samlNow.Add(-2 * time.Minute),
+		notOnOrAfter: samlNow.Add(5 * time.Minute),
+		email:        samlTestEmail,
+		sign:         true,
+	}
+}
+
+// buildAssertionElement builds the (unsigned) <saml:Assertion> element using the
+// crewjam struct Element() methods so timestamps/namespaces are well-formed.
+func buildAssertionElement(p assertionParams) *etree.Element {
+	a := saml.Assertion{
+		ID:           p.assertionID,
+		IssueInstant: samlNow,
+		Version:      "2.0",
+		Issuer:       saml.Issuer{Value: p.issuer},
+		Subject: &saml.Subject{
+			NameID: &saml.NameID{Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", Value: p.nameID},
+			SubjectConfirmations: []saml.SubjectConfirmation{{
+				Method: "urn:oasis:names:tc:SAML:2.0:cm:bearer",
+				SubjectConfirmationData: &saml.SubjectConfirmationData{
+					InResponseTo: p.inResponseTo,
+					Recipient:    p.recipient,
+					NotOnOrAfter: p.notOnOrAfter,
+				},
+			}},
+		},
+		Conditions: &saml.Conditions{
+			NotBefore:            p.notBefore,
+			NotOnOrAfter:         p.notOnOrAfter,
+			AudienceRestrictions: []saml.AudienceRestriction{{Audience: saml.Audience{Value: p.audience}}},
+		},
+		AuthnStatements: []saml.AuthnStatement{{AuthnInstant: samlNow}},
+	}
+	attrs := p.attributes
+	if attrs == nil && p.email != "" {
+		attrs = map[string]string{"email": p.email}
+	}
+	if len(attrs) > 0 {
+		stmt := saml.AttributeStatement{}
+		for name, val := range attrs {
+			stmt.Attributes = append(stmt.Attributes, saml.Attribute{
+				Name:   name,
+				Values: []saml.AttributeValue{{Type: "xs:string", Value: val}},
+			})
+		}
+		a.AttributeStatements = []saml.AttributeStatement{stmt}
+	}
+	return a.Element()
+}
+
+// parseValidAssertion builds, signs, and validates a response, returning the
+// consumed assertion (fails the test if validation does not succeed).
+func parseValidAssertion(t *testing.T, idp *samlIdP, p assertionParams) *saml.Assertion {
+	t.Helper()
+	raw := makeSAMLResponse(t, idp, p)
+	a, err := parseWith(t, samlTestConn(idp), raw, []string{p.inResponseTo})
+	require.NoError(t, err)
+	return a
+}
+
+// makeSAMLResponse builds a base64-encoded <samlp:Response> wrapping the (optionally
+// signed) assertion, ready to POST to the ACS.
+func makeSAMLResponse(t *testing.T, idp *samlIdP, p assertionParams) string {
+	t.Helper()
+	assertionEl := buildAssertionElement(p)
+
+	if p.sign {
+		sctx, err := dsig.NewSigningContext(idp.key, [][]byte{idp.certDER})
+		require.NoError(t, err)
+		sctx.Hash = crypto.SHA256
+		sctx.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+		signed, err := sctx.SignEnveloped(assertionEl)
+		require.NoError(t, err)
+		assertionEl = signed
+	}
+	if p.tamperAfterSign {
+		// Mutate the signed subtree AFTER signing: the digest no longer matches the
+		// consumed element (the essence of XML Signature Wrapping / integrity breaks).
+		if nameID := assertionEl.FindElement("//NameID"); nameID != nil {
+			nameID.SetText("attacker-substituted-subject")
+		}
+	}
+
+	respEl := etree.NewElement("samlp:Response")
+	respEl.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+	respEl.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
+	respEl.CreateAttr("ID", "id-response-0001")
+	respEl.CreateAttr("Version", "2.0")
+	respEl.CreateAttr("IssueInstant", samlNow.Format(samlTimeFmt))
+	if p.inResponseTo != "" {
+		respEl.CreateAttr("InResponseTo", p.inResponseTo)
+	}
+	if p.destination != "" {
+		respEl.CreateAttr("Destination", p.destination)
+	}
+	respEl.CreateElement("saml:Issuer").SetText(p.issuer)
+	status := respEl.CreateElement("samlp:Status")
+	status.CreateElement("samlp:StatusCode").CreateAttr("Value", saml.StatusSuccess)
+	respEl.AddChild(assertionEl)
+
+	doc := etree.NewDocument()
+	doc.SetRoot(respEl)
+	xmlBytes, err := doc.WriteToBytes()
+	require.NoError(t, err)
+	return string(xmlBytes)
+}
+
+// samlTestConn builds an sso_saml TrustedIssuer row for org A trusting idp.
+func samlTestConn(idp *samlIdP) *schemas.TrustedIssuer {
+	return &schemas.TrustedIssuer{
+		Kind:           "sso_saml",
+		OrgID:          samlOrgAID,
+		IssuerURL:      samlIdPEntityID,
+		SAMLSSOURL:     refs.NewStringRef(samlIdPSSOURL),
+		SAMLIDPCertPEM: refs.NewStringRef(idp.certPEM),
+		IsActive:       true,
+	}
+}
+
+// parseWith runs buildSAMLServiceProvider + ParseXMLResponse under pinned time.
+func parseWith(t *testing.T, conn *schemas.TrustedIssuer, rawXML string, requestIDs []string) (*saml.Assertion, error) {
+	t.Helper()
+	restore := saml.TimeNow
+	saml.TimeNow = func() time.Time { return samlNow }
+	defer func() { saml.TimeNow = restore }()
+
+	sp, err := buildSAMLServiceProvider(conn, samlTestHost, samlOrgASlug)
+	require.NoError(t, err)
+	return sp.ParseXMLResponse([]byte(rawXML), requestIDs, sp.AcsURL)
+}
+
+func TestSAML_ValidSignedAssertionAccepted(t *testing.T) {
+	idp := newSAMLIdP(t)
+	raw := makeSAMLResponse(t, idp, defaultAssertionParams())
+	assertion, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.NoError(t, err)
+	require.NotNil(t, assertion.Subject)
+	require.NotNil(t, assertion.Subject.NameID)
+	assert.Equal(t, samlTestNameID, assertion.Subject.NameID.Value)
+	assert.Equal(t, samlTestEmail, samlAttr(assertion, "email"))
+}
+
+func TestSAML_UnsignedAssertionRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.sign = false
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+func TestSAML_TamperedSignatureRejected_XSW(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.tamperAfterSign = true
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+func TestSAML_WrongSigningKeyRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	attacker := newSAMLIdP(t) // signs with a different key than the conn trusts
+	raw := makeSAMLResponse(t, attacker, defaultAssertionParams())
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+// Cross-org: an assertion whose Audience/Recipient target Org B, presented at
+// Org A's ACS, must be rejected (per-org audience + recipient binding).
+func TestSAML_CrossOrgAudienceRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.audience = samlOrgBSPEntityID
+	p.recipient = samlOrgBACSURL
+	p.destination = samlOrgBACSURL
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+func TestSAML_WrongRecipientRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.recipient = "https://auth.example.com/oauth/saml/other/acs"
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+func TestSAML_ExpiredAssertionRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.notBefore = samlNow.Add(-2 * time.Hour)
+	p.notOnOrAfter = samlNow.Add(-1 * time.Hour) // well beyond MaxClockSkew
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+func TestSAML_InResponseToMismatchRejected(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.inResponseTo = "id-some-other-request"
+	raw := makeSAMLResponse(t, idp, p)
+	_, err := parseWith(t, samlTestConn(idp), raw, []string{samlTestRequestID})
+	require.Error(t, err)
+}
+
+// IdP-initiated (no pending AuthnRequest) is rejected when the connection does
+// not opt in: with an empty possibleRequestIDs and AllowIDPInitiated=false the
+// library cannot bind the response to any request.
+func TestSAML_IdPInitiatedRejectedWhenFlagOff(t *testing.T) {
+	idp := newSAMLIdP(t)
+	p := defaultAssertionParams()
+	p.inResponseTo = "" // IdP-initiated: no InResponseTo
+	raw := makeSAMLResponse(t, idp, p)
+	conn := samlTestConn(idp)
+	conn.SAMLAllowIDPInitiated = false
+	_, err := parseWith(t, conn, raw, nil)
+	require.Error(t, err)
+}

--- a/internal/server/http_routes.go
+++ b/internal/server/http_routes.go
@@ -67,6 +67,10 @@ func (s *server) NewRouter() *gin.Engine {
 	// Per-organization enterprise OIDC SSO broker (Authorizer as Relying Party)
 	router.GET("/oauth/sso/:org_slug/login", s.Dependencies.HTTPProvider.SSOLoginHandler())
 	router.GET("/oauth/sso/:org_slug/callback", s.Dependencies.HTTPProvider.SSOCallbackHandler())
+	// Per-organization enterprise SAML 2.0 SSO (Authorizer as Service Provider)
+	router.GET("/oauth/saml/:org_slug/metadata", s.Dependencies.HTTPProvider.SAMLMetadataHandler())
+	router.GET("/oauth/saml/:org_slug/login", s.Dependencies.HTTPProvider.SAMLLoginHandler())
+	router.POST("/oauth/saml/:org_slug/acs", s.Dependencies.HTTPProvider.SAMLACSHandler())
 	router.GET("/verify_email", s.Dependencies.HTTPProvider.VerifyEmailHandler())
 	// OPEN ID routes
 	router.GET("/.well-known/openid-configuration", s.Dependencies.HTTPProvider.OpenIDConfigurationHandler())

--- a/internal/service/admin_org_saml.go
+++ b/internal/service/admin_org_saml.go
@@ -1,0 +1,360 @@
+package service
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// asAPIOrgSAMLConnection projects a sso_saml TrustedIssuer row onto the GraphQL
+// model. The IdP signing certificate (SAMLIDPCertPEM) is intentionally NOT
+// surfaced — the model has no certificate field.
+func asAPIOrgSAMLConnection(t *schemas.TrustedIssuer) *model.OrgSAMLConnection {
+	id := t.ID
+	if strings.Contains(id, schemas.Collections.TrustedIssuer+"/") {
+		id = strings.TrimPrefix(id, schemas.Collections.TrustedIssuer+"/")
+	}
+	return &model.OrgSAMLConnection{
+		ID:                id,
+		OrgID:             t.OrgID,
+		Name:              t.Name,
+		IdpEntityID:       t.IssuerURL,
+		IdpSsoURL:         t.SAMLSSOURL,
+		SpEntityID:        t.SAMLSPEntityID,
+		AcsURL:            t.SAMLACSURL,
+		AttributeMapping:  t.SAMLAttributeMapping,
+		AllowIdpInitiated: t.SAMLAllowIDPInitiated,
+		IsActive:          t.IsActive,
+		CreatedAt:         refs.NewInt64Ref(t.CreatedAt),
+		UpdatedAt:         refs.NewInt64Ref(t.UpdatedAt),
+	}
+}
+
+// validateSAMLHTTPSURL rejects a non-https or opaque URL. Used for the IdP SSO
+// endpoint and the optional SP entity ID / ACS URL overrides.
+func validateSAMLHTTPSURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("must be a valid https URL")
+	}
+	return nil
+}
+
+// validateSAMLCertPEM ensures the supplied string is a parseable PEM-encoded
+// X.509 certificate. This is a trust-boundary check: an unparseable cert would
+// mean every assertion for the org fails signature validation, so reject early.
+func validateSAMLCertPEM(raw string) error {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(raw)))
+	if block == nil {
+		return fmt.Errorf("idp_certificate must be a PEM-encoded X.509 certificate")
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return fmt.Errorf("idp_certificate is not a valid X.509 certificate: %w", err)
+	}
+	return nil
+}
+
+// validateSAMLAttributeMapping ensures the mapping, when present, is a JSON
+// object of string→string. Empty/whitespace is allowed (defaults are used).
+func validateSAMLAttributeMapping(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return fmt.Errorf("attribute_mapping must be a JSON object of string values: %w", err)
+	}
+	return nil
+}
+
+// CreateOrgSAMLConnection registers a per-org upstream SAML IdP (kind=sso_saml).
+// Requires super-admin auth.
+//
+// ponytail: super-admin gated for now — an org-scoped admin permission model
+// (design H1) is a separate PR; mirror requireSuperAdmin like the OIDC op.
+func (p *provider) CreateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateOrgSAMLConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	orgID := strings.TrimSpace(params.OrgID)
+	name := strings.TrimSpace(params.Name)
+	idpEntityID := strings.TrimSpace(params.IdpEntityID)
+	idpSSOURL := strings.TrimSpace(params.IdpSsoURL)
+	idpCert := strings.TrimSpace(params.IdpCertificate)
+	if orgID == "" || name == "" || idpEntityID == "" || idpSSOURL == "" || idpCert == "" {
+		return nil, nil, fmt.Errorf("org_id, name, idp_entity_id, idp_sso_url and idp_certificate are required")
+	}
+	if err := validateSAMLHTTPSURL(idpSSOURL); err != nil {
+		return nil, nil, fmt.Errorf("idp_sso_url %w", err)
+	}
+	if err := validateSAMLCertPEM(idpCert); err != nil {
+		return nil, nil, err
+	}
+	spEntityID, acsURL, attrMap, err := validateOptionalSAMLFields(params.SpEntityID, params.AcsURL, params.AttributeMapping)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The organization must exist.
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Str("org_id", orgID).Msg("organization not found")
+		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+	}
+	// At most one SAML connection per org.
+	if existing, _ := p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOSAML); existing != nil {
+		return nil, nil, fmt.Errorf("a SAML connection already exists for this organization")
+	}
+	// idp_entity_id is stored in the globally-unique IssuerURL column — this also
+	// prevents a SAML row from shadowing an OIDC/client_assertion_trust row at the
+	// same issuer value, and vice-versa.
+	if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, idpEntityID); existing != nil {
+		return nil, nil, fmt.Errorf("idp_entity_id already registered: %s", idpEntityID)
+	}
+
+	allowIDPInitiated := params.AllowIdpInitiated != nil && *params.AllowIdpInitiated
+
+	issuer, err := p.StorageProvider.AddTrustedIssuer(ctx, &schemas.TrustedIssuer{
+		Kind:                  constants.TrustKindSSOSAML,
+		OrgID:                 orgID,
+		Name:                  name,
+		IssuerURL:             idpEntityID,
+		KeySourceType:         "saml_idp_certificate",
+		IssuerType:            "saml",
+		AuthMethod:            "saml_assertion",
+		SAMLSSOURL:            refs.NewStringRef(idpSSOURL),
+		SAMLIDPCertPEM:        refs.NewStringRef(idpCert),
+		SAMLSPEntityID:        spEntityID,
+		SAMLACSURL:            acsURL,
+		SAMLAttributeMapping:  attrMap,
+		SAMLAllowIDPInitiated: allowIDPInitiated,
+		IsActive:              true,
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("failed AddTrustedIssuer (sso_saml)")
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgSAMLConnectionCreatedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgSAMLConnection,
+		ResourceID:   issuer.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return asAPIOrgSAMLConnection(issuer), nil, nil
+}
+
+// validateOptionalSAMLFields validates and normalises the optional SP entity ID,
+// ACS URL and attribute mapping. Returns nil pointers for omitted fields.
+func validateOptionalSAMLFields(spEntityID, acsURL, attrMap *string) (*string, *string, *string, error) {
+	var outSP, outACS, outAttr *string
+	if spEntityID != nil {
+		v := strings.TrimSpace(*spEntityID)
+		if v != "" {
+			if err := validateSAMLHTTPSURL(v); err != nil {
+				return nil, nil, nil, fmt.Errorf("sp_entity_id %w", err)
+			}
+			outSP = refs.NewStringRef(v)
+		}
+	}
+	if acsURL != nil {
+		v := strings.TrimSpace(*acsURL)
+		if v != "" {
+			if err := validateSAMLHTTPSURL(v); err != nil {
+				return nil, nil, nil, fmt.Errorf("acs_url %w", err)
+			}
+			outACS = refs.NewStringRef(v)
+		}
+	}
+	if attrMap != nil {
+		v := strings.TrimSpace(*attrMap)
+		if v != "" {
+			if err := validateSAMLAttributeMapping(v); err != nil {
+				return nil, nil, nil, err
+			}
+			outAttr = refs.NewStringRef(v)
+		}
+	}
+	return outSP, outACS, outAttr, nil
+}
+
+// UpdateOrgSAMLConnection mutates only the fields present in params (load-then-
+// mutate). Kind and OrgID are immutable. Supplying idp_certificate replaces it.
+// Requires super-admin auth.
+func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "UpdateOrgSAMLConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+
+	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
+		return nil, nil, err
+	}
+	// Guard: this op only edits sso_saml rows — never a client_assertion row.
+	if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
+		return nil, nil, fmt.Errorf("not a SAML connection")
+	}
+
+	if params.Name != nil {
+		issuer.Name = strings.TrimSpace(*params.Name)
+	}
+	if params.IdpEntityID != nil {
+		v := strings.TrimSpace(*params.IdpEntityID)
+		if v == "" {
+			return nil, nil, fmt.Errorf("idp_entity_id cannot be empty")
+		}
+		// Preserve global issuer_url (idp_entity_id) uniqueness on change.
+		if v != issuer.IssuerURL {
+			if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, v); existing != nil {
+				return nil, nil, fmt.Errorf("idp_entity_id already registered: %s", v)
+			}
+		}
+		issuer.IssuerURL = v
+	}
+	if params.IdpSsoURL != nil {
+		v := strings.TrimSpace(*params.IdpSsoURL)
+		if err := validateSAMLHTTPSURL(v); err != nil {
+			return nil, nil, fmt.Errorf("idp_sso_url %w", err)
+		}
+		issuer.SAMLSSOURL = refs.NewStringRef(v)
+	}
+	if params.IdpCertificate != nil && strings.TrimSpace(*params.IdpCertificate) != "" {
+		v := strings.TrimSpace(*params.IdpCertificate)
+		if err := validateSAMLCertPEM(v); err != nil {
+			return nil, nil, err
+		}
+		issuer.SAMLIDPCertPEM = refs.NewStringRef(v)
+	}
+	if params.SpEntityID != nil {
+		v := strings.TrimSpace(*params.SpEntityID)
+		if v != "" {
+			if err := validateSAMLHTTPSURL(v); err != nil {
+				return nil, nil, fmt.Errorf("sp_entity_id %w", err)
+			}
+			issuer.SAMLSPEntityID = refs.NewStringRef(v)
+		} else {
+			issuer.SAMLSPEntityID = nil
+		}
+	}
+	if params.AcsURL != nil {
+		v := strings.TrimSpace(*params.AcsURL)
+		if v != "" {
+			if err := validateSAMLHTTPSURL(v); err != nil {
+				return nil, nil, fmt.Errorf("acs_url %w", err)
+			}
+			issuer.SAMLACSURL = refs.NewStringRef(v)
+		} else {
+			issuer.SAMLACSURL = nil
+		}
+	}
+	if params.AttributeMapping != nil {
+		v := strings.TrimSpace(*params.AttributeMapping)
+		if v != "" {
+			if err := validateSAMLAttributeMapping(v); err != nil {
+				return nil, nil, err
+			}
+			issuer.SAMLAttributeMapping = refs.NewStringRef(v)
+		} else {
+			issuer.SAMLAttributeMapping = nil
+		}
+	}
+	if params.AllowIdpInitiated != nil {
+		issuer.SAMLAllowIDPInitiated = *params.AllowIdpInitiated
+	}
+	if params.IsActive != nil {
+		issuer.IsActive = *params.IsActive
+	}
+
+	updated, err := p.StorageProvider.UpdateTrustedIssuer(ctx, issuer)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed UpdateTrustedIssuer (sso_saml)")
+		return nil, nil, err
+	}
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgSAMLConnectionUpdatedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgSAMLConnection,
+		ResourceID:   updated.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return asAPIOrgSAMLConnection(updated), nil, nil
+}
+
+// resolveOrgSAMLConnection loads the connection by id or org_id (exactly one).
+func (p *provider) resolveOrgSAMLConnection(ctx context.Context, id, orgID *string) (*schemas.TrustedIssuer, error) {
+	switch {
+	case id != nil && strings.TrimSpace(*id) != "":
+		issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, strings.TrimSpace(*id))
+		if err != nil {
+			return nil, err
+		}
+		if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
+			return nil, fmt.Errorf("not a SAML connection")
+		}
+		return issuer, nil
+	case orgID != nil && strings.TrimSpace(*orgID) != "":
+		return p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, strings.TrimSpace(*orgID), constants.TrustKindSSOSAML)
+	default:
+		return nil, fmt.Errorf("supply either id or org_id")
+	}
+}
+
+// DeleteOrgSAMLConnection removes an org's SAML connection. Requires super-admin.
+func (p *provider) DeleteOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteOrgSAMLConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to resolve SAML connection")
+		return nil, nil, err
+	}
+	if err := p.StorageProvider.DeleteTrustedIssuer(ctx, issuer); err != nil {
+		log.Debug().Err(err).Msg("failed DeleteTrustedIssuer (sso_saml)")
+		return nil, nil, err
+	}
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgSAMLConnectionDeletedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgSAMLConnection,
+		ResourceID:   issuer.ID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.Response{Message: "SAML connection deleted"}, nil, nil
+}
+
+// OrgSAMLConnection fetches an org's SAML connection by id or org_id. Requires
+// super-admin auth. The IdP certificate is never projected.
+func (p *provider) OrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "OrgSAMLConnection").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to resolve SAML connection")
+		return nil, nil, err
+	}
+	return asAPIOrgSAMLConnection(issuer), nil, nil
+}

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -68,6 +68,10 @@ type AdminProvider interface {
 	UpdateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error)
 	DeleteOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.Response, *ResponseSideEffects, error)
 	OrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error)
+	CreateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error)
+	UpdateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error)
+	DeleteOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.Response, *ResponseSideEffects, error)
+	OrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error)
 
 	// Organizations and per-org membership.
 	CreateOrganization(ctx context.Context, meta RequestMetadata, params *model.CreateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -412,7 +412,7 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.Client, "client_id", 30*time.Second)
 
 	// TrustedIssuer table and indexes
-	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, allowed_subjects text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, kind text, org_id text, sso_client_id text, sso_client_secret_enc text, sso_scopes text, sso_redirect_uri text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
+	trustedIssuerCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, client_id text, name text, issuer_url text, key_source_type text, jwks_url text, expected_aud text, subject_claim text, allowed_subjects text, issuer_type text, auth_method text, is_active boolean, enable_token_review boolean, kubernetes_api_server_url text, spiffe_refresh_hint_seconds bigint, trusted_proxy_header text, trusted_proxy_cidrs text, kind text, org_id text, sso_client_id text, sso_client_secret_enc text, sso_scopes text, sso_redirect_uri text, saml_sso_url text, saml_idp_cert_pem text, saml_sp_entity_id text, saml_acs_url text, saml_attribute_mapping text, saml_allow_idp_initiated boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.TrustedIssuer)
 	err = session.Query(trustedIssuerCollectionQuery).Exec()
 	if err != nil {
 		return nil, err
@@ -429,6 +429,13 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	trustedIssuerSSOAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD (kind text, org_id text, sso_client_id text, sso_client_secret_enc text, sso_scopes text, sso_redirect_uri text);`, KeySpace, schemas.Collections.TrustedIssuer)
 	if err = session.Query(trustedIssuerSSOAlterQuery).Exec(); err != nil {
 		deps.Log.Debug().Err(err).Msg("Failed to alter trusted_issuers table as SSO broker columns exist")
+		// continue
+	}
+	// Add SAML SP columns for keyspaces created before the sso_saml kind (§4.4)
+	// landed. Tolerated if the columns already exist.
+	trustedIssuerSAMLAlterQuery := fmt.Sprintf(`ALTER TABLE %s.%s ADD (saml_sso_url text, saml_idp_cert_pem text, saml_sp_entity_id text, saml_acs_url text, saml_attribute_mapping text, saml_allow_idp_initiated boolean);`, KeySpace, schemas.Collections.TrustedIssuer)
+	if err = session.Query(trustedIssuerSAMLAlterQuery).Exec(); err != nil {
+		deps.Log.Debug().Err(err).Msg("Failed to alter trusted_issuers table as SAML SP columns exist")
 		// continue
 	}
 	trustedIssuerIssuerURLIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_trusted_issuer_issuer_url ON %s.%s (issuer_url)", KeySpace, schemas.Collections.TrustedIssuer)

--- a/internal/storage/db/cassandradb/trusted_issuer.go
+++ b/internal/storage/db/cassandradb/trusted_issuer.go
@@ -13,11 +13,11 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const trustedIssuerColumns = "id, client_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, kind, org_id, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, created_at, updated_at"
+const trustedIssuerColumns = "id, client_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, kind, org_id, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, saml_sso_url, saml_idp_cert_pem, saml_sp_entity_id, saml_acs_url, saml_attribute_mapping, saml_allow_idp_initiated, created_at, updated_at"
 
 // scanTrustedIssuer maps the trustedIssuerColumns projection onto a struct.
 func scanTrustedIssuer(scan func(...interface{}) error, issuer *schemas.TrustedIssuer) error {
-	return scan(&issuer.ID, &issuer.ClientID, &issuer.Name, &issuer.IssuerURL, &issuer.KeySourceType, &issuer.JWKSUrl, &issuer.ExpectedAud, &issuer.SubjectClaim, &issuer.AllowedSubjects, &issuer.IssuerType, &issuer.AuthMethod, &issuer.IsActive, &issuer.EnableTokenReview, &issuer.KubernetesAPIServerURL, &issuer.SpiffeRefreshHintSeconds, &issuer.TrustedProxyHeader, &issuer.TrustedProxyCIDRs, &issuer.Kind, &issuer.OrgID, &issuer.SSOClientID, &issuer.SSOClientSecretEnc, &issuer.SSOScopes, &issuer.SSORedirectURI, &issuer.CreatedAt, &issuer.UpdatedAt)
+	return scan(&issuer.ID, &issuer.ClientID, &issuer.Name, &issuer.IssuerURL, &issuer.KeySourceType, &issuer.JWKSUrl, &issuer.ExpectedAud, &issuer.SubjectClaim, &issuer.AllowedSubjects, &issuer.IssuerType, &issuer.AuthMethod, &issuer.IsActive, &issuer.EnableTokenReview, &issuer.KubernetesAPIServerURL, &issuer.SpiffeRefreshHintSeconds, &issuer.TrustedProxyHeader, &issuer.TrustedProxyCIDRs, &issuer.Kind, &issuer.OrgID, &issuer.SSOClientID, &issuer.SSOClientSecretEnc, &issuer.SSOScopes, &issuer.SSORedirectURI, &issuer.SAMLSSOURL, &issuer.SAMLIDPCertPEM, &issuer.SAMLSPEntityID, &issuer.SAMLACSURL, &issuer.SAMLAttributeMapping, &issuer.SAMLAllowIDPInitiated, &issuer.CreatedAt, &issuer.UpdatedAt)
 }
 
 // AddTrustedIssuer creates a new trusted issuer record.
@@ -41,8 +41,8 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.Trusted
 	if existing, _ := p.GetTrustedIssuerByIssuerURL(ctx, issuer.IssuerURL); existing != nil {
 		return nil, fmt.Errorf("trusted issuer with %s issuer_url already exists", issuer.IssuerURL)
 	}
-	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.TrustedIssuer, trustedIssuerColumns)
-	err := p.db.Query(insertQuery, issuer.ID, issuer.ClientID, issuer.Name, issuer.IssuerURL, issuer.KeySourceType, issuer.JWKSUrl, issuer.ExpectedAud, issuer.SubjectClaim, issuer.AllowedSubjects, issuer.IssuerType, issuer.AuthMethod, issuer.IsActive, issuer.EnableTokenReview, issuer.KubernetesAPIServerURL, issuer.SpiffeRefreshHintSeconds, issuer.TrustedProxyHeader, issuer.TrustedProxyCIDRs, issuer.Kind, issuer.OrgID, issuer.SSOClientID, issuer.SSOClientSecretEnc, issuer.SSOScopes, issuer.SSORedirectURI, issuer.CreatedAt, issuer.UpdatedAt).Exec()
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.TrustedIssuer, trustedIssuerColumns)
+	err := p.db.Query(insertQuery, issuer.ID, issuer.ClientID, issuer.Name, issuer.IssuerURL, issuer.KeySourceType, issuer.JWKSUrl, issuer.ExpectedAud, issuer.SubjectClaim, issuer.AllowedSubjects, issuer.IssuerType, issuer.AuthMethod, issuer.IsActive, issuer.EnableTokenReview, issuer.KubernetesAPIServerURL, issuer.SpiffeRefreshHintSeconds, issuer.TrustedProxyHeader, issuer.TrustedProxyCIDRs, issuer.Kind, issuer.OrgID, issuer.SSOClientID, issuer.SSOClientSecretEnc, issuer.SSOScopes, issuer.SSORedirectURI, issuer.SAMLSSOURL, issuer.SAMLIDPCertPEM, issuer.SAMLSPEntityID, issuer.SAMLACSURL, issuer.SAMLAttributeMapping, issuer.SAMLAllowIDPInitiated, issuer.CreatedAt, issuer.UpdatedAt).Exec()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/couchbase/trusted_issuer.go
+++ b/internal/storage/db/couchbase/trusted_issuer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-const trustedIssuerColumns = "_id, client_id, kind, org_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, created_at, updated_at"
+const trustedIssuerColumns = "_id, client_id, kind, org_id, name, issuer_url, key_source_type, jwks_url, expected_aud, subject_claim, allowed_subjects, issuer_type, auth_method, is_active, enable_token_review, kubernetes_api_server_url, spiffe_refresh_hint_seconds, trusted_proxy_header, trusted_proxy_cidrs, sso_client_id, sso_client_secret_enc, sso_scopes, sso_redirect_uri, saml_sso_url, saml_idp_cert_pem, saml_sp_entity_id, saml_acs_url, saml_attribute_mapping, saml_allow_idp_initiated, created_at, updated_at"
 
 // AddTrustedIssuer creates a new trusted issuer record.
 func (p *provider) AddTrustedIssuer(ctx context.Context, issuer *schemas.TrustedIssuer) (*schemas.TrustedIssuer, error) {

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -200,6 +200,10 @@ func TestStorageProvider(t *testing.T) {
 				testOrgOIDCAndFederatedOperations(t, ctx, provider, dbType)
 			})
 
+			t.Run("Org SAML Connection Operations", func(t *testing.T) {
+				testOrgSAMLOperations(t, ctx, provider, dbType)
+			})
+
 			t.Run("SCIM Endpoint Operations", func(t *testing.T) {
 				testScimEndpointOperations(t, ctx, provider)
 			})
@@ -1715,6 +1719,70 @@ func testOrgOIDCAndFederatedOperations(t *testing.T, ctx context.Context, provid
 	// A different subject at the same (org, issuer) is a distinct identity.
 	_, err = provider.GetFederatedIdentity(ctx, orgID, issuerURL, "unknown-sub")
 	assert.Error(t, err, "unknown federated identity must not resolve")
+}
+
+// testOrgSAMLOperations exercises the sso_saml TrustedIssuer fields (nullable
+// SAML SP config) round-tripping across every backend, plus the
+// GetTrustedIssuerByOrgIDAndKind lookup and an UpdateTrustedIssuer mutation.
+func testOrgSAMLOperations(t *testing.T, ctx context.Context, provider Provider, dbType string) {
+	orgID := "org-" + uuid.New().String()
+	idpEntityID := "https://idp-" + uuid.New().String() + ".example.com/metadata"
+	const certPEM = "-----BEGIN CERTIFICATE-----\nMIIBsomethingfakebutstable==\n-----END CERTIFICATE-----"
+	const attrMap = `{"email":"mail","given_name":"gn"}`
+
+	conn, err := provider.AddTrustedIssuer(ctx, &schemas.TrustedIssuer{
+		Kind:                  constants.TrustKindSSOSAML,
+		OrgID:                 orgID,
+		Name:                  "saml_" + uuid.New().String(),
+		IssuerURL:             idpEntityID,
+		KeySourceType:         "saml_idp_certificate",
+		IssuerType:            "saml",
+		AuthMethod:            "saml_assertion",
+		SAMLSSOURL:            refs.NewStringRef("https://idp.example.com/sso"),
+		SAMLIDPCertPEM:        refs.NewStringRef(certPEM),
+		SAMLSPEntityID:        refs.NewStringRef("https://authorizer.example.com/oauth/saml/x/metadata"),
+		SAMLACSURL:            refs.NewStringRef("https://authorizer.example.com/oauth/saml/x/acs"),
+		SAMLAttributeMapping:  refs.NewStringRef(attrMap),
+		SAMLAllowIDPInitiated: true,
+		IsActive:              true,
+	})
+	require.NoError(t, err)
+	connID := conn.AsAPITrustedIssuer().ID
+	require.NotEmpty(t, connID)
+
+	// Round-trip: every SAML field must persist across write->read.
+	fetched, err := provider.GetTrustedIssuerByID(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, constants.TrustKindSSOSAML, fetched.EffectiveKind())
+	assert.Equal(t, orgID, fetched.OrgID)
+	assert.Equal(t, idpEntityID, fetched.IssuerURL)
+	require.NotNil(t, fetched.SAMLSSOURL)
+	assert.Equal(t, "https://idp.example.com/sso", *fetched.SAMLSSOURL)
+	require.NotNil(t, fetched.SAMLIDPCertPEM)
+	assert.Equal(t, certPEM, *fetched.SAMLIDPCertPEM, "IdP certificate must persist on "+dbType)
+	require.NotNil(t, fetched.SAMLSPEntityID)
+	assert.Equal(t, "https://authorizer.example.com/oauth/saml/x/metadata", *fetched.SAMLSPEntityID)
+	require.NotNil(t, fetched.SAMLACSURL)
+	assert.Equal(t, "https://authorizer.example.com/oauth/saml/x/acs", *fetched.SAMLACSURL)
+	require.NotNil(t, fetched.SAMLAttributeMapping)
+	assert.Equal(t, attrMap, *fetched.SAMLAttributeMapping)
+	assert.True(t, fetched.SAMLAllowIDPInitiated)
+
+	// GetTrustedIssuerByOrgIDAndKind resolves the org's SAML connection.
+	byOrg, err := provider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOSAML)
+	require.NoError(t, err)
+	assert.Equal(t, connID, byOrg.AsAPITrustedIssuer().ID)
+
+	// Update mutates SAML fields (load-then-mutate); the bool must flip to false.
+	fetched.SAMLAllowIDPInitiated = false
+	fetched.SAMLSSOURL = refs.NewStringRef("https://idp.example.com/sso2")
+	_, err = provider.UpdateTrustedIssuer(ctx, fetched)
+	require.NoError(t, err)
+	reFetched, err := provider.GetTrustedIssuerByID(ctx, connID)
+	require.NoError(t, err)
+	assert.False(t, reFetched.SAMLAllowIDPInitiated, "SAMLAllowIDPInitiated must persist as false on "+dbType)
+	require.NotNil(t, reFetched.SAMLSSOURL)
+	assert.Equal(t, "https://idp.example.com/sso2", *reFetched.SAMLSSOURL)
 }
 
 // testScimEndpointOperations exercises ScimEndpoint CRUD including that the

--- a/internal/storage/schemas/trusted_issuer.go
+++ b/internal/storage/schemas/trusted_issuer.go
@@ -207,7 +207,10 @@ type TrustedIssuer struct {
 	// matching pending AuthnRequest). DEFAULT FALSE — SP-initiated only, with
 	// InResponseTo bound to a pending request. Enable only if the org's IdP does
 	// not support SP-initiated flows and the operator accepts the reduced CSRF
-	// protection.
+	// protection. NOTE: enabling this disables InResponseTo validation for ALL
+	// responses on this connection (crewjam limitation), including SP-initiated
+	// ones — the assertion then relies solely on the single-use AssertionID cache
+	// for replay defence.
 	SAMLAllowIDPInitiated bool `json:"saml_allow_idp_initiated" bson:"saml_allow_idp_initiated" cql:"saml_allow_idp_initiated" dynamo:"saml_allow_idp_initiated"`
 
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`

--- a/internal/storage/schemas/trusted_issuer.go
+++ b/internal/storage/schemas/trusted_issuer.go
@@ -170,6 +170,46 @@ type TrustedIssuer struct {
 	// {scheme}://{host}/oauth/sso/{org}/callback from the request host.
 	SSORedirectURI string `json:"sso_redirect_uri" bson:"sso_redirect_uri" cql:"sso_redirect_uri" dynamo:"sso_redirect_uri"`
 
+	// --- SSO SAML SP (kind = sso_saml) ---
+	// These fields hold the upstream corporate IdP configuration Authorizer uses
+	// as a SAML 2.0 Service Provider. They are empty on non-sso_saml rows. The IdP
+	// entity ID (the assertion Issuer and the FederatedIdentity issuer) reuses the
+	// globally-unique IssuerURL field, so a SAML IdP cannot shadow an OIDC/client-
+	// assertion issuer at the same value and vice-versa.
+
+	// SAMLSSOURL is the upstream IdP Single Sign-On endpoint the signed
+	// AuthnRequest is sent to (HTTP-Redirect binding).
+	SAMLSSOURL *string `json:"saml_sso_url" bson:"saml_sso_url" cql:"saml_sso_url" dynamo:"saml_sso_url"`
+
+	// SAMLIDPCertPEM is the IdP's X.509 signing certificate (PEM). Assertion
+	// signatures are validated ONLY against this certificate — the sole trust
+	// anchor for this org's connection.
+	SAMLIDPCertPEM *string `json:"saml_idp_cert_pem" bson:"saml_idp_cert_pem" cql:"saml_idp_cert_pem" dynamo:"saml_idp_cert_pem"`
+
+	// SAMLSPEntityID is the SP entity ID Authorizer advertises for this org (the
+	// assertion Audience an incoming assertion MUST target). When empty the SP
+	// derives {scheme}://{host}/oauth/saml/{org}/metadata from the request host.
+	SAMLSPEntityID *string `json:"saml_sp_entity_id" bson:"saml_sp_entity_id" cql:"saml_sp_entity_id" dynamo:"saml_sp_entity_id"`
+
+	// SAMLACSURL is the Assertion Consumer Service URL for this org (the
+	// Recipient/Destination an incoming assertion MUST target). When empty the SP
+	// derives {scheme}://{host}/oauth/saml/{org}/acs from the request host.
+	SAMLACSURL *string `json:"saml_acs_url" bson:"saml_acs_url" cql:"saml_acs_url" dynamo:"saml_acs_url"`
+
+	// SAMLAttributeMapping is a JSON object mapping Authorizer profile fields to
+	// upstream SAML attribute names, e.g.
+	// {"email":"email","given_name":"firstName","family_name":"lastName"}.
+	// The NameID is ALWAYS the federated-identity subject; this map only governs
+	// optional profile-attribute extraction. Empty means "use default names".
+	SAMLAttributeMapping *string `json:"saml_attribute_mapping" bson:"saml_attribute_mapping" cql:"saml_attribute_mapping" dynamo:"saml_attribute_mapping"`
+
+	// SAMLAllowIDPInitiated permits IdP-initiated SSO (a POST to ACS with no
+	// matching pending AuthnRequest). DEFAULT FALSE — SP-initiated only, with
+	// InResponseTo bound to a pending request. Enable only if the org's IdP does
+	// not support SP-initiated flows and the operator accepts the reduced CSRF
+	// protection.
+	SAMLAllowIDPInitiated bool `json:"saml_allow_idp_initiated" bson:"saml_allow_idp_initiated" cql:"saml_allow_idp_initiated" dynamo:"saml_allow_idp_initiated"`
+
 	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
 	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
 }


### PR DESCRIPTION
## Per-organization SAML 2.0 Service Provider SSO

The final PR of the machine-agent-identity program. Authorizer acts as a SAML **Service Provider**: an org configures its upstream corporate IdP (Okta/Entra/ADFS) as an `sso_saml` TrustedIssuer row; its users log in through that IdP, Authorizer validates the signed assertion, JIT-provisions the user (namespaced by `(org_id, IdP-entity-id, NameID)`), and issues a normal Authorizer session. This is the SAML sibling of the merged OIDC broker (`oauth_sso.go`).

**Library:** `github.com/crewjam/saml v0.5.1` — no hand-rolled XML-signature / C14N code.

### Security invariants (design §4.4 / CR3) — enforced + tested
- **Signature over the consumed assertion (XSW):** `ParseXMLResponse` validates XML-DSIG on the same `<Assertion>` element it unmarshals and returns; fields are read only off that returned object. Validated **only** against the org's configured IdP cert.
- **Unsigned / wrong-key rejected**, **per-org Audience/Recipient/Destination** (SP built per `org_slug`), **NotBefore/NotOnOrAfter** with bounded skew.
- **Single-use AssertionID** replay cache in the shared memory store, per-org namespaced.
- **InResponseTo** binding on SP-initiated flows via an opaque single-use RelayState.
- **IdP-initiated off by default**; when enabled, the redirect target is still `AllowedOrigins`-validated (open-redirect defense).
- **No email-only account linking:** returning principal resolved only via the federated-identity row; email collision fails closed. OIDC and SAML share `jitProvisionFederatedUser` so the two brokers cannot drift.
- Admin CRUD is super-admin gated; IdP cert never projected back; no SP private key exists (unsigned AuthnRequests).

### Security review
`security-engineer` adversarial pass: **no CRITICAL/HIGH**. Two required MEDIUMs fixed in `dea0f759`:
- **MEDIUM-1:** wired up the defined-but-unused `saml.acs_failed` audit event — every ACS rejection now leaves an audit trail.
- **MEDIUM-2:** stopped echoing the internal JIT error to the client (account-enumeration vector); generic reason to client, cause to debug log only.
- **MEDIUM-3:** documented that enabling IdP-initiated drops InResponseTo binding for all responses (crewjam limitation).

### Deferred (follow-ups, non-blocking; code verified correct at source level)
- The XSW regression test asserts digest integrity, not a wrapping-injection fixture; the code path is XSW-resistant (verified against crewjam source) — a dedicated wrapping fixture is a fast follow-up.
- Handler-level tests (RelayState single-use, IdP-initiated open-redirect) — currently asserted by inspection.
- Org-scoped (non-super-admin) connection management — separate PR (design H1).

### Verification
- `go build` / `go vet` / `gofmt` / `make lint-go` (0 issues) clean; zero codegen drift.
- Full SQLite integration suite green (run twice).
- `make test-all-db` green across all 7 backends (postgres, sqlite, mongodb, arangodb, scylladb, dynamodb, couchbase) — storage round-trip incl. `testOrgSAMLOperations`.

### Storage
6 new nullable `sso_saml` fields on `TrustedIssuer` across all providers (explicit column adds for cassandra + couchbase; SQL/mongo/arango/dynamo auto-marshal). IdP entity id reuses the globally-unique `IssuerURL`.
