### PR TITLE
feat(dashboard): clients and trusted issuers admin pages

### DIFF
--- a/web/dashboard/src/components/ClientSecretDialog.tsx
+++ b/web/dashboard/src/components/ClientSecretDialog.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Copy, Check, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { copyTextToClipboard } from '../utils';
+import { Button } from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from './ui/dialog';
+
+interface ClientSecretDialogProps {
+	// Plaintext secret returned once by _create_client / _rotate_client_secret.
+	secret: string | null;
+	onClose: () => void;
+}
+
+// One-time display of a client secret. The server never returns it again.
+const ClientSecretDialog = ({ secret, onClose }: ClientSecretDialogProps) => {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		if (!secret) return;
+		await copyTextToClipboard(secret);
+		setCopied(true);
+		toast.success('Client secret copied');
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<Dialog
+			open={!!secret}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) onClose();
+			}}
+		>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Client Secret</DialogTitle>
+					<DialogDescription>
+						Copy this secret and store it securely.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+					<p className="flex items-start gap-2 text-sm text-yellow-800">
+						<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+						This secret is shown only once. You won&apos;t be able to see it
+						again after closing this dialog.
+					</p>
+				</div>
+				<div className="flex items-center gap-2 rounded-md bg-gray-100 p-3">
+					<code className="flex-1 break-all font-mono text-sm">{secret}</code>
+					<button
+						type="button"
+						onClick={handleCopy}
+						className="text-gray-400 hover:text-gray-600"
+						aria-label="Copy client secret"
+					>
+						{copied ? (
+							<Check className="h-4 w-4 text-green-500" />
+						) : (
+							<Copy className="h-4 w-4" />
+						)}
+					</button>
+				</div>
+				<DialogFooter>
+					<Button onClick={onClose}>I have stored the secret</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default ClientSecretDialog;

--- a/web/dashboard/src/components/DeleteClientModal.tsx
+++ b/web/dashboard/src/components/DeleteClientModal.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useClient } from 'urql';
+import { Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { DeleteClient } from '../graphql/mutation';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { Button } from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog';
+
+interface DeleteClientModalProps {
+	clientId: string;
+	clientName: string;
+	fetchClients: () => void;
+}
+
+const DeleteClientModal = ({
+	clientId,
+	clientName,
+	fetchClients,
+}: DeleteClientModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+
+	const deleteHandler = async () => {
+		const res = await client
+			.mutation(DeleteClient, { params: { id: clientId } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete client'),
+				),
+			);
+			return;
+		} else if (res.data?._delete_client) {
+			toast.success(capitalizeFirstLetter(res.data._delete_client.message));
+		}
+		setOpen(false);
+		fetchClients();
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<button className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm">
+					Delete
+				</button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete Client</DialogTitle>
+					<DialogDescription>Are you sure?</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-red-300 bg-red-50 p-4">
+					<p className="text-sm">
+						Client <strong>{clientName}</strong> will be deleted permanently!
+						Any workload authenticating with its credentials will stop working.
+					</p>
+				</div>
+				<DialogFooter>
+					<Button variant="destructive" onClick={deleteHandler}>
+						<Trash2 className="mr-2 h-4 w-4" />
+						Delete
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default DeleteClientModal;

--- a/web/dashboard/src/components/DeleteTrustedIssuerModal.tsx
+++ b/web/dashboard/src/components/DeleteTrustedIssuerModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useClient } from 'urql';
+import { Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { DeleteTrustedIssuer } from '../graphql/mutation';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { Button } from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog';
+
+interface DeleteTrustedIssuerModalProps {
+	issuerId: string;
+	issuerName: string;
+	fetchIssuers: () => void;
+}
+
+const DeleteTrustedIssuerModal = ({
+	issuerId,
+	issuerName,
+	fetchIssuers,
+}: DeleteTrustedIssuerModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+
+	const deleteHandler = async () => {
+		const res = await client
+			.mutation(DeleteTrustedIssuer, { params: { id: issuerId } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete trusted issuer'),
+				),
+			);
+			return;
+		} else if (res.data?._delete_trusted_issuer) {
+			toast.success(
+				capitalizeFirstLetter(res.data._delete_trusted_issuer.message),
+			);
+		}
+		setOpen(false);
+		fetchIssuers();
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<button className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm">
+					Delete
+				</button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete Trusted Issuer</DialogTitle>
+					<DialogDescription>Are you sure?</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-red-300 bg-red-50 p-4">
+					<p className="text-sm">
+						Trusted issuer <strong>{issuerName}</strong> will be deleted
+						permanently! Workloads authenticating via this issuer will be
+						rejected.
+					</p>
+				</div>
+				<DialogFooter>
+					<Button variant="destructive" onClick={deleteHandler}>
+						<Trash2 className="mr-2 h-4 w-4" />
+						Delete
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default DeleteTrustedIssuerModal;

--- a/web/dashboard/src/components/RotateClientSecretModal.tsx
+++ b/web/dashboard/src/components/RotateClientSecretModal.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { useClient } from 'urql';
+import { RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { RotateClientSecret } from '../graphql/mutation';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import type { CreateClientResponse } from '../types';
+import ClientSecretDialog from './ClientSecretDialog';
+import { Button } from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog';
+
+interface RotateClientSecretModalProps {
+	clientId: string;
+	clientName: string;
+}
+
+const RotateClientSecretModal = ({
+	clientId,
+	clientName,
+}: RotateClientSecretModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	// Plaintext secret returned once by _rotate_client_secret.
+	const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+
+	const rotateHandler = async () => {
+		setLoading(true);
+		const res = await client
+			.mutation<{
+				_rotate_client_secret: CreateClientResponse;
+			}>(RotateClientSecret, { params: { id: clientId } })
+			.toPromise();
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to rotate client secret'),
+				),
+			);
+			return;
+		}
+		toast.success('Client secret rotated');
+		setOpen(false);
+		setRotatedSecret(res.data?._rotate_client_secret?.client_secret || null);
+	};
+
+	return (
+		<>
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogTrigger asChild>
+					<button className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm">
+						Rotate Secret
+					</button>
+				</DialogTrigger>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Rotate Client Secret</DialogTitle>
+						<DialogDescription>Are you sure?</DialogDescription>
+					</DialogHeader>
+					<div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+						<p className="text-sm">
+							The current secret for <strong>{clientName}</strong> will stop
+							working immediately. The new secret is shown only once.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button onClick={rotateHandler} isLoading={loading}>
+							<RefreshCw className="mr-2 h-4 w-4" />
+							Rotate Secret
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<ClientSecretDialog
+				secret={rotatedSecret}
+				onClose={() => setRotatedSecret(null)}
+			/>
+		</>
+	);
+};
+
+export default RotateClientSecretModal;

--- a/web/dashboard/src/components/Sidebar.tsx
+++ b/web/dashboard/src/components/Sidebar.tsx
@@ -16,6 +16,9 @@ import {
 	Network,
 	SearchCheck,
 	ChevronDown,
+	Fingerprint,
+	KeyRound,
+	BadgeCheck,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
@@ -61,6 +64,23 @@ const navGroups: NavGroupConfig[] = [
 				name: 'Relationship Tuples',
 				icon: Network,
 				route: '/authorization/tuples',
+			},
+		],
+	},
+	{
+		name: 'Identity',
+		icon: Fingerprint,
+		basePath: '/identity',
+		items: [
+			{
+				name: 'Clients',
+				icon: KeyRound,
+				route: '/identity/clients',
+			},
+			{
+				name: 'Trusted Issuers',
+				icon: BadgeCheck,
+				route: '/identity/trusted-issuers',
 			},
 		],
 	},

--- a/web/dashboard/src/components/UpdateClientModal.tsx
+++ b/web/dashboard/src/components/UpdateClientModal.tsx
@@ -1,0 +1,240 @@
+import React, { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { CreateClient, UpdateClient } from '../graphql/mutation';
+import type { Client, CreateClientResponse } from '../types';
+import ClientSecretDialog from './ClientSecretDialog';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+interface UpdateClientModalProps {
+	view: UpdateModalViews;
+	selectedClient?: Client;
+	fetchClients: () => void;
+}
+
+interface ClientFormData {
+	name: string;
+	description: string;
+	// Raw comma/space separated scopes input; parsed on save.
+	allowedScopes: string;
+	isActive: boolean;
+}
+
+const initFormData: ClientFormData = {
+	name: '',
+	description: '',
+	allowedScopes: '',
+	isActive: true,
+};
+
+const parseScopes = (value: string): string[] =>
+	value
+		.split(/[\s,]+/)
+		.map((scope) => scope.trim())
+		.filter(Boolean);
+
+const UpdateClientModal = ({
+	view,
+	selectedClient,
+	fetchClients,
+}: UpdateClientModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<ClientFormData>({ ...initFormData });
+	// Plaintext secret returned once by _create_client; shown in one-time dialog.
+	const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (open && view === UpdateModalViews.Edit && selectedClient) {
+			setFormData({
+				name: selectedClient.name,
+				description: selectedClient.description || '',
+				allowedScopes: selectedClient.allowed_scopes.join(' '),
+				isActive: selectedClient.is_active,
+			});
+		}
+	}, [open]);
+
+	const validateData = () =>
+		!loading &&
+		formData.name.trim().length > 0 &&
+		parseScopes(formData.allowedScopes).length > 0;
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		if (view === UpdateModalViews.Edit && selectedClient?.id) {
+			const res = await client
+				.mutation(UpdateClient, {
+					params: {
+						id: selectedClient.id,
+						name: formData.name.trim(),
+						description: formData.description,
+						allowed_scopes: parseScopes(formData.allowedScopes),
+						is_active: formData.isActive,
+					},
+				})
+				.toPromise();
+			setLoading(false);
+			if (res.error) {
+				toast.error(
+					capitalizeFirstLetter(
+						getGraphQLErrorMessage(res.error, 'Failed to update client'),
+					),
+				);
+				return;
+			}
+			toast.success('Client updated');
+		} else {
+			const res = await client
+				.mutation<{ _create_client: CreateClientResponse }>(CreateClient, {
+					params: {
+						name: formData.name.trim(),
+						description: formData.description,
+						allowed_scopes: parseScopes(formData.allowedScopes),
+					},
+				})
+				.toPromise();
+			setLoading(false);
+			if (res.error) {
+				toast.error(
+					capitalizeFirstLetter(
+						getGraphQLErrorMessage(res.error, 'Failed to create client'),
+					),
+				);
+				return;
+			}
+			toast.success('Client created');
+			setCreatedSecret(res.data?._create_client?.client_secret || null);
+		}
+		setFormData({ ...initFormData });
+		setOpen(false);
+		fetchClients();
+	};
+
+	return (
+		<>
+			{view === UpdateModalViews.ADD ? (
+				<Button size="sm" onClick={() => setOpen(true)}>
+					<Plus className="mr-2 h-4 w-4" />
+					Add Client
+				</Button>
+			) : (
+				<button
+					className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm"
+					onClick={() => setOpen(true)}
+				>
+					Edit
+				</button>
+			)}
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>
+							{view === UpdateModalViews.ADD ? 'Add New Client' : 'Edit Client'}
+						</SheetTitle>
+						<SheetDescription>
+							OAuth clients are machine/workload identities with their own
+							credentials and allowed scopes.
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">Name</label>
+							<Input
+								placeholder="my-service"
+								value={formData.name}
+								isInvalid={formData.name.trim().length === 0}
+								onChange={(e) =>
+									setFormData({ ...formData, name: e.currentTarget.value })
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Description
+							</label>
+							<Input
+								placeholder="What this client is used for"
+								value={formData.description}
+								onChange={(e) =>
+									setFormData({
+										...formData,
+										description: e.currentTarget.value,
+									})
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Allowed Scopes
+							</label>
+							<Input
+								placeholder="read:users write:users (space or comma separated)"
+								value={formData.allowedScopes}
+								isInvalid={parseScopes(formData.allowedScopes).length === 0}
+								onChange={(e) =>
+									setFormData({
+										...formData,
+										allowedScopes: e.currentTarget.value,
+									})
+								}
+							/>
+						</div>
+
+						{view === UpdateModalViews.Edit && (
+							<div className="flex items-center gap-4">
+								<label className="w-32 text-sm font-medium shrink-0">
+									Active
+								</label>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium">Off</span>
+									<Switch
+										checked={formData.isActive}
+										onCheckedChange={(checked: boolean) =>
+											setFormData({ ...formData, isActive: checked })
+										}
+									/>
+									<span className="text-sm font-medium">On</span>
+								</div>
+							</div>
+						)}
+					</div>
+
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={saveData}
+							isLoading={loading}
+							disabled={!validateData()}
+						>
+							Save
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+			<ClientSecretDialog
+				secret={createdSecret}
+				onClose={() => setCreatedSecret(null)}
+			/>
+		</>
+	);
+};
+
+export default UpdateClientModal;

--- a/web/dashboard/src/components/UpdateTrustedIssuerModal.tsx
+++ b/web/dashboard/src/components/UpdateTrustedIssuerModal.tsx
@@ -1,0 +1,373 @@
+import React, { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { AddTrustedIssuer, UpdateTrustedIssuer } from '../graphql/mutation';
+import type { TrustedIssuer } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Select } from './ui/select';
+import { Switch } from './ui/switch';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+const keySourceTypes = [
+	'oidc_discovery',
+	'static_jwks_url',
+	'spiffe_bundle_endpoint',
+];
+
+const issuerTypes = ['kubernetes_sa', 'spiffe_jwt', 'oidc', 'cloud_oidc'];
+
+interface UpdateTrustedIssuerModalProps {
+	view: UpdateModalViews;
+	selectedIssuer?: TrustedIssuer;
+	fetchIssuers: () => void;
+}
+
+interface IssuerFormData {
+	serviceAccountId: string;
+	name: string;
+	issuerUrl: string;
+	keySourceType: string;
+	jwksUrl: string;
+	expectedAud: string;
+	subjectClaim: string;
+	allowedSubjects: string;
+	issuerType: string;
+	spiffeRefreshHintSeconds: string;
+	isActive: boolean;
+}
+
+const initFormData: IssuerFormData = {
+	serviceAccountId: '',
+	name: '',
+	issuerUrl: '',
+	keySourceType: keySourceTypes[0],
+	jwksUrl: '',
+	expectedAud: '',
+	subjectClaim: '',
+	allowedSubjects: '',
+	issuerType: issuerTypes[0],
+	spiffeRefreshHintSeconds: '',
+	isActive: true,
+};
+
+const UpdateTrustedIssuerModal = ({
+	view,
+	selectedIssuer,
+	fetchIssuers,
+}: UpdateTrustedIssuerModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<IssuerFormData>({ ...initFormData });
+
+	const isEdit = view === UpdateModalViews.Edit;
+
+	useEffect(() => {
+		if (open && isEdit && selectedIssuer) {
+			setFormData({
+				serviceAccountId: selectedIssuer.service_account_id,
+				name: selectedIssuer.name,
+				issuerUrl: selectedIssuer.issuer_url,
+				keySourceType: selectedIssuer.key_source_type,
+				jwksUrl: selectedIssuer.jwks_url || '',
+				expectedAud: selectedIssuer.expected_aud,
+				subjectClaim: selectedIssuer.subject_claim,
+				allowedSubjects: selectedIssuer.allowed_subjects || '',
+				issuerType: selectedIssuer.issuer_type,
+				spiffeRefreshHintSeconds:
+					selectedIssuer.spiffe_refresh_hint_seconds != null
+						? String(selectedIssuer.spiffe_refresh_hint_seconds)
+						: '',
+				isActive: selectedIssuer.is_active,
+			});
+		}
+	}, [open]);
+
+	const setField = (field: keyof IssuerFormData, value: string | boolean) =>
+		setFormData({ ...formData, [field]: value });
+
+	const validateData = () => {
+		if (loading) return false;
+		if (isEdit) {
+			return (
+				formData.name.trim().length > 0 &&
+				formData.expectedAud.trim().length > 0
+			);
+		}
+		return (
+			formData.serviceAccountId.trim().length > 0 &&
+			formData.name.trim().length > 0 &&
+			formData.issuerUrl.trim().length > 0 &&
+			formData.expectedAud.trim().length > 0
+		);
+	};
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		const refreshHint = formData.spiffeRefreshHintSeconds.trim()
+			? parseInt(formData.spiffeRefreshHintSeconds, 10)
+			: undefined;
+		let res: { error?: unknown };
+		if (isEdit && selectedIssuer?.id) {
+			res = await client
+				.mutation(UpdateTrustedIssuer, {
+					params: {
+						id: selectedIssuer.id,
+						name: formData.name.trim(),
+						jwks_url: formData.jwksUrl.trim() || undefined,
+						expected_aud: formData.expectedAud.trim(),
+						allowed_subjects: formData.allowedSubjects.trim(),
+						is_active: formData.isActive,
+						spiffe_refresh_hint_seconds: refreshHint,
+					},
+				})
+				.toPromise();
+		} else {
+			res = await client
+				.mutation(AddTrustedIssuer, {
+					params: {
+						service_account_id: formData.serviceAccountId.trim(),
+						name: formData.name.trim(),
+						issuer_url: formData.issuerUrl.trim(),
+						key_source_type: formData.keySourceType,
+						jwks_url: formData.jwksUrl.trim() || undefined,
+						expected_aud: formData.expectedAud.trim(),
+						subject_claim: formData.subjectClaim.trim() || undefined,
+						allowed_subjects: formData.allowedSubjects.trim() || undefined,
+						issuer_type: formData.issuerType,
+						spiffe_refresh_hint_seconds: refreshHint,
+					},
+				})
+				.toPromise();
+		}
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to save trusted issuer'),
+				),
+			);
+			return;
+		}
+		toast.success(isEdit ? 'Trusted issuer updated' : 'Trusted issuer added');
+		setFormData({ ...initFormData });
+		setOpen(false);
+		fetchIssuers();
+	};
+
+	return (
+		<>
+			{view === UpdateModalViews.ADD ? (
+				<Button size="sm" onClick={() => setOpen(true)}>
+					<Plus className="mr-2 h-4 w-4" />
+					Add Trusted Issuer
+				</Button>
+			) : (
+				<button
+					className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm"
+					onClick={() => setOpen(true)}
+				>
+					Edit
+				</button>
+			)}
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>
+							{isEdit ? 'Edit Trusted Issuer' : 'Add Trusted Issuer'}
+						</SheetTitle>
+						<SheetDescription>
+							External JWT issuers bound to a service account for workload
+							authentication.
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Service Account ID
+							</label>
+							<Input
+								placeholder="service account (client) id"
+								value={formData.serviceAccountId}
+								isInvalid={
+									!isEdit && formData.serviceAccountId.trim().length === 0
+								}
+								disabled={isEdit}
+								onChange={(e) =>
+									setField('serviceAccountId', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">Name</label>
+							<Input
+								placeholder="prod-cluster"
+								value={formData.name}
+								isInvalid={formData.name.trim().length === 0}
+								onChange={(e) => setField('name', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Issuer URL
+							</label>
+							<Input
+								placeholder="https://kubernetes.default.svc"
+								value={formData.issuerUrl}
+								isInvalid={!isEdit && formData.issuerUrl.trim().length === 0}
+								disabled={isEdit}
+								onChange={(e) => setField('issuerUrl', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Issuer Type
+							</label>
+							<Select
+								value={formData.issuerType}
+								disabled={isEdit}
+								onChange={(e) => setField('issuerType', e.currentTarget.value)}
+							>
+								{issuerTypes.map((type) => (
+									<option key={type} value={type}>
+										{type}
+									</option>
+								))}
+							</Select>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Key Source
+							</label>
+							<Select
+								value={formData.keySourceType}
+								disabled={isEdit}
+								onChange={(e) =>
+									setField('keySourceType', e.currentTarget.value)
+								}
+							>
+								{keySourceTypes.map((type) => (
+									<option key={type} value={type}>
+										{type}
+									</option>
+								))}
+							</Select>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								JWKS URL
+							</label>
+							<Input
+								placeholder="https://issuer.example.com/jwks (optional)"
+								value={formData.jwksUrl}
+								onChange={(e) => setField('jwksUrl', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Expected Audience
+							</label>
+							<Input
+								placeholder="https://authorizer.example.com"
+								value={formData.expectedAud}
+								isInvalid={formData.expectedAud.trim().length === 0}
+								onChange={(e) => setField('expectedAud', e.currentTarget.value)}
+							/>
+						</div>
+
+						{!isEdit && (
+							<div className="flex items-center gap-4">
+								<label className="w-40 text-sm font-medium shrink-0">
+									Subject Claim
+								</label>
+								<Input
+									placeholder="sub (default)"
+									value={formData.subjectClaim}
+									onChange={(e) =>
+										setField('subjectClaim', e.currentTarget.value)
+									}
+								/>
+							</div>
+						)}
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								Allowed Subjects
+							</label>
+							<Input
+								placeholder="comma-separated subjects; empty = deny all"
+								value={formData.allowedSubjects}
+								onChange={(e) =>
+									setField('allowedSubjects', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-40 text-sm font-medium shrink-0">
+								SPIFFE Refresh Hint (s)
+							</label>
+							<Input
+								type="number"
+								placeholder="optional"
+								value={formData.spiffeRefreshHintSeconds}
+								onChange={(e) =>
+									setField('spiffeRefreshHintSeconds', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						{isEdit && (
+							<div className="flex items-center gap-4">
+								<label className="w-40 text-sm font-medium shrink-0">
+									Active
+								</label>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium">Off</span>
+									<Switch
+										checked={formData.isActive}
+										onCheckedChange={(checked: boolean) =>
+											setField('isActive', checked)
+										}
+									/>
+									<span className="text-sm font-medium">On</span>
+								</div>
+							</div>
+						)}
+					</div>
+
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={saveData}
+							isLoading={loading}
+							disabled={!validateData()}
+						>
+							Save
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+		</>
+	);
+};
+
+export default UpdateTrustedIssuerModal;

--- a/web/dashboard/src/graphql/mutation/index.ts
+++ b/web/dashboard/src/graphql/mutation/index.ts
@@ -161,3 +161,70 @@ export const FgaReset = `
     }
   }
 `;
+
+export const CreateClient = `
+  mutation createClient($params: CreateClientRequest!) {
+    _create_client(params: $params) {
+      client {
+        id
+        name
+      }
+      client_secret
+    }
+  }
+`;
+
+export const UpdateClient = `
+  mutation updateClient($params: UpdateClientRequest!) {
+    _update_client(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteClient = `
+  mutation deleteClient($params: ClientRequest!) {
+    _delete_client(params: $params) {
+      message
+    }
+  }
+`;
+
+export const RotateClientSecret = `
+  mutation rotateClientSecret($params: ClientRequest!) {
+    _rotate_client_secret(params: $params) {
+      client {
+        id
+        name
+      }
+      client_secret
+    }
+  }
+`;
+
+export const AddTrustedIssuer = `
+  mutation addTrustedIssuer($params: AddTrustedIssuerRequest!) {
+    _add_trusted_issuer(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const UpdateTrustedIssuer = `
+  mutation updateTrustedIssuer($params: UpdateTrustedIssuerRequest!) {
+    _update_trusted_issuer(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteTrustedIssuer = `
+  mutation deleteTrustedIssuer($params: TrustedIssuerRequest!) {
+    _delete_trusted_issuer(params: $params) {
+      message
+    }
+  }
+`;

--- a/web/dashboard/src/graphql/queries/index.ts
+++ b/web/dashboard/src/graphql/queries/index.ts
@@ -185,3 +185,54 @@ export const AdminRolesQuery = `
     }
   }
 `;
+
+export const ClientsQuery = `
+  query getClients($params: ListClientsRequest) {
+    _clients(params: $params) {
+      clients {
+        id
+        name
+        description
+        allowed_scopes
+        is_active
+        created_at
+        updated_at
+      }
+      pagination {
+        limit
+        page
+        offset
+        total
+      }
+    }
+  }
+`;
+
+export const TrustedIssuersQuery = `
+  query getTrustedIssuers($params: ListTrustedIssuersRequest) {
+    _trusted_issuers(params: $params) {
+      trusted_issuers {
+        id
+        service_account_id
+        name
+        issuer_url
+        key_source_type
+        jwks_url
+        expected_aud
+        subject_claim
+        allowed_subjects
+        issuer_type
+        is_active
+        spiffe_refresh_hint_seconds
+        created_at
+        updated_at
+      }
+      pagination {
+        limit
+        page
+        offset
+        total
+      }
+    }
+  }
+`;

--- a/web/dashboard/src/pages/Clients.tsx
+++ b/web/dashboard/src/pages/Clients.tsx
@@ -1,0 +1,331 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import {
+	ChevronsLeft,
+	ChevronsRight,
+	ChevronLeft,
+	ChevronRight,
+	ChevronDown,
+	AlertCircle,
+	Copy,
+} from 'lucide-react';
+import dayjs from 'dayjs';
+import { toast } from 'sonner';
+import UpdateClientModal from '../components/UpdateClientModal';
+import DeleteClientModal from '../components/DeleteClientModal';
+import RotateClientSecretModal from '../components/RotateClientSecretModal';
+import { pageLimitsExtended, UpdateModalViews } from '../constants';
+import { ClientsQuery } from '../graphql/queries';
+import { copyTextToClipboard } from '../utils';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { Select } from '../components/ui/select';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+	DropdownMenu,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+} from '../components/ui/dropdown-menu';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from '../components/ui/table';
+import type { Client, ClientsResponse } from '../types';
+
+interface PaginationProps {
+	limit: number;
+	page: number;
+	offset: number;
+	total: number;
+	maxPages: number;
+}
+
+const Clients = () => {
+	const client = useClient();
+	const [loading, setLoading] = useState<boolean>(false);
+	const [clientData, setClientData] = useState<Client[]>([]);
+	const [paginationProps, setPaginationProps] = useState<PaginationProps>({
+		limit: 10,
+		page: 1,
+		offset: 0,
+		total: 0,
+		maxPages: 1,
+	});
+
+	const getMaxPages = (pagination: PaginationProps) => {
+		const { limit, total } = pagination;
+		if (total > 1) {
+			return total % limit === 0
+				? total / limit
+				: Math.floor(total / limit) + 1;
+		}
+		return 1;
+	};
+
+	const fetchClientData = async () => {
+		setLoading(true);
+		const res = await client
+			.query<ClientsResponse>(ClientsQuery, {
+				params: {
+					pagination: {
+						pagination: {
+							limit: paginationProps.limit,
+							page: paginationProps.page,
+						},
+					},
+				},
+			})
+			.toPromise();
+		if (res.data?._clients) {
+			const { pagination, clients } = res.data._clients;
+			const maxPages = getMaxPages(pagination as unknown as PaginationProps);
+			if (clients?.length) {
+				setClientData(clients);
+				setPaginationProps({
+					...paginationProps,
+					...pagination,
+					maxPages,
+				});
+			} else {
+				setClientData([]);
+				if (paginationProps.page !== 1) {
+					setPaginationProps({
+						...paginationProps,
+						...pagination,
+						maxPages,
+						page: 1,
+					});
+				}
+			}
+		}
+		setLoading(false);
+	};
+
+	const paginationHandler = (value: Record<string, number>) => {
+		setPaginationProps({ ...paginationProps, ...value });
+	};
+
+	useEffect(() => {
+		fetchClientData();
+	}, [paginationProps.page, paginationProps.limit]);
+
+	const copyClientId = async (id: string) => {
+		await copyTextToClipboard(id);
+		toast.success('Client ID copied');
+	};
+
+	return (
+		<div className="m-5 rounded-md bg-white py-5 px-10">
+			<div className="flex items-center justify-between my-4">
+				<div>
+					<h1 className="text-2xl font-semibold text-gray-900">Clients</h1>
+					<p className="mt-1 text-sm text-gray-500">
+						Manage OAuth clients (machine and workload identities).
+					</p>
+				</div>
+				<UpdateClientModal
+					view={UpdateModalViews.ADD}
+					fetchClients={fetchClientData}
+				/>
+			</div>
+			{loading ? (
+				<div className="min-h-[25vh] space-y-3">
+					{[1, 2, 3].map((i) => (
+						<Skeleton key={i} className="h-10 w-full" />
+					))}
+				</div>
+			) : clientData.length ? (
+				<>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Client ID</TableHead>
+								<TableHead>Name</TableHead>
+								<TableHead>Allowed Scopes</TableHead>
+								<TableHead>Active</TableHead>
+								<TableHead>Created</TableHead>
+								<TableHead>Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{clientData.map((clientItem) => (
+								<TableRow key={clientItem.id}>
+									<TableCell className="max-w-[220px] text-sm">
+										<div className="flex items-center gap-2">
+											<span className="truncate font-mono text-xs">
+												{clientItem.id}
+											</span>
+											<button
+												type="button"
+												onClick={() => copyClientId(clientItem.id)}
+												className="text-gray-400 hover:text-gray-600"
+												aria-label="Copy client ID"
+											>
+												<Copy className="h-3 w-3" />
+											</button>
+										</div>
+									</TableCell>
+									<TableCell className="max-w-[220px] text-sm">
+										{clientItem.name}
+									</TableCell>
+									<TableCell className="max-w-[300px]">
+										<div className="flex flex-wrap gap-1">
+											{clientItem.allowed_scopes.map((scope) => (
+												<Badge key={scope} variant="secondary">
+													{scope}
+												</Badge>
+											))}
+										</div>
+									</TableCell>
+									<TableCell>
+										<Badge
+											variant={clientItem.is_active ? 'success' : 'warning'}
+										>
+											{clientItem.is_active.toString()}
+										</Badge>
+									</TableCell>
+									<TableCell className="text-sm whitespace-nowrap">
+										{clientItem.created_at
+											? dayjs.unix(clientItem.created_at).format('MMM D, YYYY')
+											: '—'}
+									</TableCell>
+									<TableCell>
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button variant="ghost" size="sm">
+													<span className="text-sm font-light">Menu</span>
+													<ChevronDown className="ml-2 h-3 w-3" />
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end">
+												<UpdateClientModal
+													view={UpdateModalViews.Edit}
+													selectedClient={clientItem}
+													fetchClients={fetchClientData}
+												/>
+												<RotateClientSecretModal
+													clientId={clientItem.id}
+													clientName={clientItem.name}
+												/>
+												<DeleteClientModal
+													clientId={clientItem.id}
+													clientName={clientItem.name}
+													fetchClients={fetchClientData}
+												/>
+											</DropdownMenuContent>
+										</DropdownMenu>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+
+					{/* Pagination */}
+					{(paginationProps.maxPages > 1 || paginationProps.total >= 5) && (
+						<div className="mt-4 flex items-center justify-between">
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() => paginationHandler({ page: 1 })}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronsLeft className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page - 1,
+										})
+									}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronLeft className="h-4 w-4" />
+								</Button>
+							</div>
+
+							<div className="flex items-center gap-4 text-sm">
+								<span>
+									Page <strong>{paginationProps.page}</strong> of{' '}
+									<strong>{paginationProps.maxPages}</strong>
+								</span>
+								<div className="flex items-center gap-1">
+									<span>Go to:</span>
+									<Input
+										type="number"
+										min={1}
+										max={paginationProps.maxPages}
+										value={paginationProps.page}
+										onChange={(e) =>
+											paginationHandler({
+												page: parseInt(e.target.value) || 1,
+											})
+										}
+										className="h-8 w-16"
+									/>
+								</div>
+								<Select
+									value={paginationProps.limit}
+									onChange={(e) =>
+										paginationHandler({
+											page: 1,
+											limit: parseInt(e.target.value),
+										})
+									}
+									className="h-8 w-28"
+								>
+									{pageLimitsExtended.map((pageSize) => (
+										<option key={pageSize} value={pageSize}>
+											Show {pageSize}
+										</option>
+									))}
+								</Select>
+							</div>
+
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page + 1,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronRight className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.maxPages,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronsRight className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					)}
+				</>
+			) : (
+				<div className="flex min-h-[25vh] flex-col items-center justify-center text-gray-300">
+					<AlertCircle className="h-16 w-16 mb-2" />
+					<p className="text-2xl font-bold">No Data</p>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Clients;

--- a/web/dashboard/src/pages/Overview.tsx
+++ b/web/dashboard/src/pages/Overview.tsx
@@ -156,7 +156,7 @@ const Overview = () => {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between pb-2">
 						<CardTitle className="text-sm font-medium text-gray-500">
-							Client ID
+							Default Client ID
 						</CardTitle>
 						<button
 							onClick={handleCopyClientId}
@@ -174,7 +174,13 @@ const Overview = () => {
 						<div className="text-sm font-mono text-gray-900 truncate">
 							{meta?.client_id || '—'}
 						</div>
-						<p className="mt-1 text-xs text-gray-500">Click icon to copy</p>
+						<button
+							type="button"
+							onClick={() => navigate('/identity/clients')}
+							className="mt-1 text-xs text-blue-600 hover:text-blue-700"
+						>
+							Manage clients →
+						</button>
 					</CardContent>
 				</Card>
 			</div>

--- a/web/dashboard/src/pages/TrustedIssuers.tsx
+++ b/web/dashboard/src/pages/TrustedIssuers.tsx
@@ -1,0 +1,329 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import {
+	ChevronsLeft,
+	ChevronsRight,
+	ChevronLeft,
+	ChevronRight,
+	ChevronDown,
+	AlertCircle,
+} from 'lucide-react';
+import UpdateTrustedIssuerModal from '../components/UpdateTrustedIssuerModal';
+import DeleteTrustedIssuerModal from '../components/DeleteTrustedIssuerModal';
+import { pageLimitsExtended, UpdateModalViews } from '../constants';
+import { TrustedIssuersQuery } from '../graphql/queries';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { Select } from '../components/ui/select';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+} from '../components/ui/tooltip';
+import {
+	DropdownMenu,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+} from '../components/ui/dropdown-menu';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from '../components/ui/table';
+import type { TrustedIssuer, TrustedIssuersResponse } from '../types';
+
+interface PaginationProps {
+	limit: number;
+	page: number;
+	offset: number;
+	total: number;
+	maxPages: number;
+}
+
+const TrustedIssuers = () => {
+	const client = useClient();
+	const [loading, setLoading] = useState<boolean>(false);
+	const [issuerData, setIssuerData] = useState<TrustedIssuer[]>([]);
+	const [paginationProps, setPaginationProps] = useState<PaginationProps>({
+		limit: 10,
+		page: 1,
+		offset: 0,
+		total: 0,
+		maxPages: 1,
+	});
+
+	const getMaxPages = (pagination: PaginationProps) => {
+		const { limit, total } = pagination;
+		if (total > 1) {
+			return total % limit === 0
+				? total / limit
+				: Math.floor(total / limit) + 1;
+		}
+		return 1;
+	};
+
+	const fetchIssuerData = async () => {
+		setLoading(true);
+		const res = await client
+			.query<TrustedIssuersResponse>(TrustedIssuersQuery, {
+				params: {
+					pagination: {
+						pagination: {
+							limit: paginationProps.limit,
+							page: paginationProps.page,
+						},
+					},
+				},
+			})
+			.toPromise();
+		if (res.data?._trusted_issuers) {
+			const { pagination, trusted_issuers } = res.data._trusted_issuers;
+			const maxPages = getMaxPages(pagination as unknown as PaginationProps);
+			if (trusted_issuers?.length) {
+				setIssuerData(trusted_issuers);
+				setPaginationProps({
+					...paginationProps,
+					...pagination,
+					maxPages,
+				});
+			} else {
+				setIssuerData([]);
+				if (paginationProps.page !== 1) {
+					setPaginationProps({
+						...paginationProps,
+						...pagination,
+						maxPages,
+						page: 1,
+					});
+				}
+			}
+		}
+		setLoading(false);
+	};
+
+	const paginationHandler = (value: Record<string, number>) => {
+		setPaginationProps({ ...paginationProps, ...value });
+	};
+
+	useEffect(() => {
+		fetchIssuerData();
+	}, [paginationProps.page, paginationProps.limit]);
+
+	return (
+		<div className="m-5 rounded-md bg-white py-5 px-10">
+			<div className="flex items-center justify-between my-4">
+				<div>
+					<h1 className="text-2xl font-semibold text-gray-900">
+						Trusted Issuers
+					</h1>
+					<p className="mt-1 text-sm text-gray-500">
+						External JWT issuers bound to service accounts for workload
+						authentication.
+					</p>
+				</div>
+				<UpdateTrustedIssuerModal
+					view={UpdateModalViews.ADD}
+					fetchIssuers={fetchIssuerData}
+				/>
+			</div>
+			{loading ? (
+				<div className="min-h-[25vh] space-y-3">
+					{[1, 2, 3].map((i) => (
+						<Skeleton key={i} className="h-10 w-full" />
+					))}
+				</div>
+			) : issuerData.length ? (
+				<>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Issuer URL</TableHead>
+								<TableHead>Type</TableHead>
+								<TableHead>Expected Audience</TableHead>
+								<TableHead>Allowed Subjects</TableHead>
+								<TableHead>Active</TableHead>
+								<TableHead>Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{issuerData.map((issuer) => (
+								<TableRow key={issuer.id}>
+									<TableCell className="max-w-[200px] text-sm">
+										{issuer.name}
+									</TableCell>
+									<TableCell className="max-w-[260px] truncate text-sm">
+										{issuer.issuer_url}
+									</TableCell>
+									<TableCell>
+										<Badge variant="secondary">{issuer.issuer_type}</Badge>
+									</TableCell>
+									<TableCell className="max-w-[220px] truncate text-sm">
+										{issuer.expected_aud}
+									</TableCell>
+									<TableCell>
+										<Tooltip>
+											<TooltipTrigger>
+												<Badge variant="secondary">
+													{issuer.allowed_subjects
+														? issuer.allowed_subjects
+																.split(',')
+																.filter((s) => s.trim())
+																.length.toString()
+														: '0'}
+												</Badge>
+											</TooltipTrigger>
+											<TooltipContent>
+												<pre className="text-xs">
+													{issuer.allowed_subjects
+														? issuer.allowed_subjects
+																.split(',')
+																.map((s) => s.trim())
+																.filter(Boolean)
+																.join('\n')
+														: 'No subjects allowed (deny-all)'}
+												</pre>
+											</TooltipContent>
+										</Tooltip>
+									</TableCell>
+									<TableCell>
+										<Badge variant={issuer.is_active ? 'success' : 'warning'}>
+											{issuer.is_active.toString()}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button variant="ghost" size="sm">
+													<span className="text-sm font-light">Menu</span>
+													<ChevronDown className="ml-2 h-3 w-3" />
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end">
+												<UpdateTrustedIssuerModal
+													view={UpdateModalViews.Edit}
+													selectedIssuer={issuer}
+													fetchIssuers={fetchIssuerData}
+												/>
+												<DeleteTrustedIssuerModal
+													issuerId={issuer.id}
+													issuerName={issuer.name}
+													fetchIssuers={fetchIssuerData}
+												/>
+											</DropdownMenuContent>
+										</DropdownMenu>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+
+					{/* Pagination */}
+					{(paginationProps.maxPages > 1 || paginationProps.total >= 5) && (
+						<div className="mt-4 flex items-center justify-between">
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() => paginationHandler({ page: 1 })}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronsLeft className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page - 1,
+										})
+									}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronLeft className="h-4 w-4" />
+								</Button>
+							</div>
+
+							<div className="flex items-center gap-4 text-sm">
+								<span>
+									Page <strong>{paginationProps.page}</strong> of{' '}
+									<strong>{paginationProps.maxPages}</strong>
+								</span>
+								<div className="flex items-center gap-1">
+									<span>Go to:</span>
+									<Input
+										type="number"
+										min={1}
+										max={paginationProps.maxPages}
+										value={paginationProps.page}
+										onChange={(e) =>
+											paginationHandler({
+												page: parseInt(e.target.value) || 1,
+											})
+										}
+										className="h-8 w-16"
+									/>
+								</div>
+								<Select
+									value={paginationProps.limit}
+									onChange={(e) =>
+										paginationHandler({
+											page: 1,
+											limit: parseInt(e.target.value),
+										})
+									}
+									className="h-8 w-28"
+								>
+									{pageLimitsExtended.map((pageSize) => (
+										<option key={pageSize} value={pageSize}>
+											Show {pageSize}
+										</option>
+									))}
+								</Select>
+							</div>
+
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page + 1,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronRight className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.maxPages,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronsRight className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					)}
+				</>
+			) : (
+				<div className="flex min-h-[25vh] flex-col items-center justify-center text-gray-300">
+					<AlertCircle className="h-16 w-16 mb-2" />
+					<p className="text-2xl font-bold">No Data</p>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default TrustedIssuers;

--- a/web/dashboard/src/routes/index.tsx
+++ b/web/dashboard/src/routes/index.tsx
@@ -12,6 +12,8 @@ const EmailTemplates = lazy(() => import('../pages/EmailTemplates'));
 const AuditLogs = lazy(() => import('../pages/AuditLogs'));
 const AuthorizationModel = lazy(() => import('../pages/authorization/Model'));
 const AuthorizationTuples = lazy(() => import('../pages/authorization/Tuples'));
+const Clients = lazy(() => import('../pages/Clients'));
+const TrustedIssuers = lazy(() => import('../pages/TrustedIssuers'));
 
 export const AppRoutes = () => {
 	const { isLoggedIn } = useAuthContext();
@@ -40,6 +42,11 @@ export const AppRoutes = () => {
 							<Route
 								path="authorization/tuples"
 								element={<AuthorizationTuples />}
+							/>
+							<Route path="identity/clients" element={<Clients />} />
+							<Route
+								path="identity/trusted-issuers"
+								element={<TrustedIssuers />}
 							/>
 							<Route path="*" element={<Overview />} />
 						</Route>

--- a/web/dashboard/src/types.ts
+++ b/web/dashboard/src/types.ts
@@ -185,3 +185,50 @@ export interface AdminRolesResponse {
 		roles?: string[] | null;
 	} | null;
 }
+
+export interface Client {
+	id: string;
+	name: string;
+	description?: string | null;
+	allowed_scopes: string[];
+	is_active: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface ClientsResponse {
+	_clients: {
+		pagination: PaginationInfo;
+		clients: Client[];
+	};
+}
+
+export interface CreateClientResponse {
+	client: Client;
+	// Returned exactly once at creation/rotation; never retrievable again.
+	client_secret: string;
+}
+
+export interface TrustedIssuer {
+	id: string;
+	service_account_id: string;
+	name: string;
+	issuer_url: string;
+	key_source_type: string;
+	jwks_url?: string | null;
+	expected_aud: string;
+	subject_claim: string;
+	allowed_subjects?: string | null;
+	issuer_type: string;
+	is_active: boolean;
+	spiffe_refresh_hint_seconds?: number | null;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface TrustedIssuersResponse {
+	_trusted_issuers: {
+		pagination: PaginationInfo;
+		trusted_issuers: TrustedIssuer[];
+	};
+}


### PR DESCRIPTION
## What

Admin UI for the MAI client registry and trusted issuers (first of two dashboard PRs; orgs/SSO/SCIM UI follows).

- **Clients page** (`/identity/clients`): paginated list, create/edit/delete, rotate secret. `client_secret` plaintext is surfaced exactly once (create + rotate) in a one-time copy dialog with an explicit warning, matching the server's secret-shown-once contract.
- **Trusted Issuers page** (`/identity/trusted-issuers`): full CRUD; edit form limited to the fields `UpdateTrustedIssuerRequest` actually accepts.
- **Overview**: legacy global "Client ID" card relabeled **Default Client ID** with a "Manage clients →" link to the new page — the global `meta.client_id` is now just the default/seeded client, not "the" client.
- New collapsible **Identity** sidebar group.

All GraphQL op/field names verified against `internal/graph/schema.graphqls` (Client type intentionally has no `client_secret`/`kind` fields).

## Testing
- `npm ci && npm run build` passes
- `npx tsc --noEmit` clean (strict)
- Prettier clean on all touched files (pre-existing drift on 4 untouched files left alone)