### PR TITLE
feat(dashboard): organizations admin pages

### DIFF
--- a/web/dashboard/src/components/ClientSecretDialog.tsx
+++ b/web/dashboard/src/components/ClientSecretDialog.tsx
@@ -13,20 +13,26 @@ import {
 } from './ui/dialog';
 
 interface ClientSecretDialogProps {
-	// Plaintext secret returned once by _create_client / _rotate_client_secret.
+	// Plaintext secret returned once by the server (client secret, SCIM token).
 	secret: string | null;
 	onClose: () => void;
+	// Label used in the dialog title, copy toast and aria-label.
+	label?: string;
 }
 
-// One-time display of a client secret. The server never returns it again.
-const ClientSecretDialog = ({ secret, onClose }: ClientSecretDialogProps) => {
+// One-time display of a secret. The server never returns it again.
+const ClientSecretDialog = ({
+	secret,
+	onClose,
+	label = 'Client Secret',
+}: ClientSecretDialogProps) => {
 	const [copied, setCopied] = useState(false);
 
 	const handleCopy = async () => {
 		if (!secret) return;
 		await copyTextToClipboard(secret);
 		setCopied(true);
-		toast.success('Client secret copied');
+		toast.success(`${label} copied`);
 		setTimeout(() => setCopied(false), 2000);
 	};
 
@@ -39,7 +45,7 @@ const ClientSecretDialog = ({ secret, onClose }: ClientSecretDialogProps) => {
 		>
 			<DialogContent>
 				<DialogHeader>
-					<DialogTitle>Client Secret</DialogTitle>
+					<DialogTitle>{label}</DialogTitle>
 					<DialogDescription>
 						Copy this secret and store it securely.
 					</DialogDescription>
@@ -57,7 +63,7 @@ const ClientSecretDialog = ({ secret, onClose }: ClientSecretDialogProps) => {
 						type="button"
 						onClick={handleCopy}
 						className="text-gray-400 hover:text-gray-600"
-						aria-label="Copy client secret"
+						aria-label={`Copy ${label.toLowerCase()}`}
 					>
 						{copied ? (
 							<Check className="h-4 w-4 text-green-500" />

--- a/web/dashboard/src/components/DeleteOrganizationModal.tsx
+++ b/web/dashboard/src/components/DeleteOrganizationModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useClient } from 'urql';
+import { Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { DeleteOrganization } from '../graphql/mutation';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { Button } from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog';
+
+interface DeleteOrganizationModalProps {
+	organizationId: string;
+	organizationName: string;
+	fetchOrganizations: () => void;
+}
+
+const DeleteOrganizationModal = ({
+	organizationId,
+	organizationName,
+	fetchOrganizations,
+}: DeleteOrganizationModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+
+	const deleteHandler = async () => {
+		const res = await client
+			.mutation(DeleteOrganization, { params: { id: organizationId } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete organization'),
+				),
+			);
+			return;
+		} else if (res.data?._delete_organization) {
+			toast.success(
+				capitalizeFirstLetter(res.data._delete_organization.message),
+			);
+		}
+		setOpen(false);
+		fetchOrganizations();
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<button className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm">
+					Delete
+				</button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete Organization</DialogTitle>
+					<DialogDescription>Are you sure?</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-red-300 bg-red-50 p-4">
+					<p className="text-sm">
+						Organization <strong>{organizationName}</strong> will be deleted
+						permanently! Its memberships, SSO connections and SCIM endpoint will
+						stop working.
+					</p>
+				</div>
+				<DialogFooter>
+					<Button variant="destructive" onClick={deleteHandler}>
+						<Trash2 className="mr-2 h-4 w-4" />
+						Delete
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default DeleteOrganizationModal;

--- a/web/dashboard/src/components/Sidebar.tsx
+++ b/web/dashboard/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
 	Fingerprint,
 	KeyRound,
 	BadgeCheck,
+	Building2,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
@@ -81,6 +82,11 @@ const navGroups: NavGroupConfig[] = [
 				name: 'Trusted Issuers',
 				icon: BadgeCheck,
 				route: '/identity/trusted-issuers',
+			},
+			{
+				name: 'Organizations',
+				icon: Building2,
+				route: '/identity/organizations',
 			},
 		],
 	},

--- a/web/dashboard/src/components/UpdateOrgOIDCConnectionModal.tsx
+++ b/web/dashboard/src/components/UpdateOrgOIDCConnectionModal.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import {
+	CreateOrgOIDCConnection,
+	UpdateOrgOIDCConnection,
+} from '../graphql/mutation';
+import type { OrgOIDCConnection } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+interface UpdateOrgOIDCConnectionModalProps {
+	view: UpdateModalViews;
+	orgId: string;
+	selectedConnection?: OrgOIDCConnection;
+	fetchConnection: () => void;
+}
+
+interface OIDCFormData {
+	name: string;
+	issuerUrl: string;
+	clientId: string;
+	// Required at creation; on edit, filling it rotates the stored secret.
+	clientSecret: string;
+	scopes: string;
+	redirectUri: string;
+	isActive: boolean;
+}
+
+const initFormData: OIDCFormData = {
+	name: '',
+	issuerUrl: '',
+	clientId: '',
+	clientSecret: '',
+	scopes: '',
+	redirectUri: '',
+	isActive: true,
+};
+
+const UpdateOrgOIDCConnectionModal = ({
+	view,
+	orgId,
+	selectedConnection,
+	fetchConnection,
+}: UpdateOrgOIDCConnectionModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<OIDCFormData>({ ...initFormData });
+
+	const isEdit = view === UpdateModalViews.Edit;
+
+	useEffect(() => {
+		if (open && isEdit && selectedConnection) {
+			setFormData({
+				name: selectedConnection.name,
+				issuerUrl: selectedConnection.issuer_url,
+				clientId: selectedConnection.sso_client_id,
+				clientSecret: '',
+				scopes: selectedConnection.scopes || '',
+				redirectUri: selectedConnection.redirect_uri || '',
+				isActive: selectedConnection.is_active,
+			});
+		}
+	}, [open]);
+
+	const setField = (field: keyof OIDCFormData, value: string | boolean) =>
+		setFormData({ ...formData, [field]: value });
+
+	const validateData = () => {
+		if (loading) return false;
+		if (isEdit) {
+			return (
+				formData.name.trim().length > 0 &&
+				formData.issuerUrl.trim().length > 0 &&
+				formData.clientId.trim().length > 0
+			);
+		}
+		return (
+			formData.name.trim().length > 0 &&
+			formData.issuerUrl.trim().length > 0 &&
+			formData.clientId.trim().length > 0 &&
+			formData.clientSecret.trim().length > 0
+		);
+	};
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		let res: { error?: unknown };
+		if (isEdit && selectedConnection?.id) {
+			res = await client
+				.mutation(UpdateOrgOIDCConnection, {
+					params: {
+						id: selectedConnection.id,
+						name: formData.name.trim(),
+						issuer_url: formData.issuerUrl.trim(),
+						client_id: formData.clientId.trim(),
+						// Omitting client_secret leaves the stored secret intact.
+						client_secret: formData.clientSecret.trim() || undefined,
+						scopes: formData.scopes.trim() || undefined,
+						redirect_uri: formData.redirectUri.trim() || undefined,
+						is_active: formData.isActive,
+					},
+				})
+				.toPromise();
+		} else {
+			res = await client
+				.mutation(CreateOrgOIDCConnection, {
+					params: {
+						org_id: orgId,
+						name: formData.name.trim(),
+						issuer_url: formData.issuerUrl.trim(),
+						client_id: formData.clientId.trim(),
+						client_secret: formData.clientSecret.trim(),
+						scopes: formData.scopes.trim() || undefined,
+						redirect_uri: formData.redirectUri.trim() || undefined,
+					},
+				})
+				.toPromise();
+		}
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						isEdit
+							? 'Failed to update OIDC connection'
+							: 'Failed to create OIDC connection',
+					),
+				),
+			);
+			return;
+		}
+		toast.success(
+			isEdit ? 'OIDC connection updated' : 'OIDC connection created',
+		);
+		setFormData({ ...initFormData });
+		setOpen(false);
+		fetchConnection();
+	};
+
+	return (
+		<>
+			{view === UpdateModalViews.ADD ? (
+				<Button size="sm" onClick={() => setOpen(true)}>
+					<Plus className="mr-2 h-4 w-4" />
+					Configure OIDC
+				</Button>
+			) : (
+				<Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+					Edit
+				</Button>
+			)}
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>
+							{view === UpdateModalViews.ADD
+								? 'Configure OIDC Connection'
+								: 'Edit OIDC Connection'}
+						</SheetTitle>
+						<SheetDescription>
+							Upstream OIDC identity provider brokered for this organization.
+							The client secret is stored encrypted and never shown again.
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">Name</label>
+							<Input
+								placeholder="okta-prod"
+								value={formData.name}
+								isInvalid={formData.name.trim().length === 0}
+								onChange={(e) => setField('name', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Issuer URL
+							</label>
+							<Input
+								placeholder="https://idp.example.com"
+								value={formData.issuerUrl}
+								isInvalid={formData.issuerUrl.trim().length === 0}
+								onChange={(e) => setField('issuerUrl', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Client ID
+							</label>
+							<Input
+								placeholder="Client ID at the upstream IdP"
+								value={formData.clientId}
+								isInvalid={formData.clientId.trim().length === 0}
+								onChange={(e) => setField('clientId', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Client Secret
+							</label>
+							<Input
+								type="password"
+								placeholder={
+									isEdit
+										? 'Leave empty to keep the current secret'
+										: 'Client secret at the upstream IdP'
+								}
+								value={formData.clientSecret}
+								isInvalid={!isEdit && formData.clientSecret.trim().length === 0}
+								onChange={(e) =>
+									setField('clientSecret', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Scopes
+							</label>
+							<Input
+								placeholder="openid profile email (space separated)"
+								value={formData.scopes}
+								onChange={(e) => setField('scopes', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Redirect URI
+							</label>
+							<Input
+								placeholder="Derived from request host when empty"
+								value={formData.redirectUri}
+								onChange={(e) => setField('redirectUri', e.currentTarget.value)}
+							/>
+						</div>
+
+						{isEdit && (
+							<div className="flex items-center gap-4">
+								<label className="w-32 text-sm font-medium shrink-0">
+									Active
+								</label>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium">Off</span>
+									<Switch
+										checked={formData.isActive}
+										onCheckedChange={(checked: boolean) =>
+											setField('isActive', checked)
+										}
+									/>
+									<span className="text-sm font-medium">On</span>
+								</div>
+							</div>
+						)}
+					</div>
+
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={saveData}
+							isLoading={loading}
+							disabled={!validateData()}
+						>
+							Save
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+		</>
+	);
+};
+
+export default UpdateOrgOIDCConnectionModal;

--- a/web/dashboard/src/components/UpdateOrgSAMLConnectionModal.tsx
+++ b/web/dashboard/src/components/UpdateOrgSAMLConnectionModal.tsx
@@ -1,0 +1,334 @@
+import React, { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import {
+	CreateOrgSAMLConnection,
+	UpdateOrgSAMLConnection,
+} from '../graphql/mutation';
+import type { OrgSAMLConnection } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import { Textarea } from './ui/textarea';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+interface UpdateOrgSAMLConnectionModalProps {
+	view: UpdateModalViews;
+	orgId: string;
+	selectedConnection?: OrgSAMLConnection;
+	fetchConnection: () => void;
+}
+
+interface SAMLFormData {
+	name: string;
+	idpEntityId: string;
+	idpSsoUrl: string;
+	// Required at creation; on edit, filling it replaces the stored certificate.
+	idpCertificate: string;
+	spEntityId: string;
+	acsUrl: string;
+	attributeMapping: string;
+	allowIdpInitiated: boolean;
+	isActive: boolean;
+}
+
+const initFormData: SAMLFormData = {
+	name: '',
+	idpEntityId: '',
+	idpSsoUrl: '',
+	idpCertificate: '',
+	spEntityId: '',
+	acsUrl: '',
+	attributeMapping: '',
+	allowIdpInitiated: false,
+	isActive: true,
+};
+
+const UpdateOrgSAMLConnectionModal = ({
+	view,
+	orgId,
+	selectedConnection,
+	fetchConnection,
+}: UpdateOrgSAMLConnectionModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<SAMLFormData>({ ...initFormData });
+
+	const isEdit = view === UpdateModalViews.Edit;
+
+	useEffect(() => {
+		if (open && isEdit && selectedConnection) {
+			setFormData({
+				name: selectedConnection.name,
+				idpEntityId: selectedConnection.idp_entity_id,
+				idpSsoUrl: selectedConnection.idp_sso_url || '',
+				idpCertificate: '',
+				spEntityId: selectedConnection.sp_entity_id || '',
+				acsUrl: selectedConnection.acs_url || '',
+				attributeMapping: selectedConnection.attribute_mapping || '',
+				allowIdpInitiated: selectedConnection.allow_idp_initiated,
+				isActive: selectedConnection.is_active,
+			});
+		}
+	}, [open]);
+
+	const setField = (field: keyof SAMLFormData, value: string | boolean) =>
+		setFormData({ ...formData, [field]: value });
+
+	const validateData = () => {
+		if (loading) return false;
+		if (isEdit) {
+			return (
+				formData.name.trim().length > 0 &&
+				formData.idpEntityId.trim().length > 0
+			);
+		}
+		return (
+			formData.name.trim().length > 0 &&
+			formData.idpEntityId.trim().length > 0 &&
+			formData.idpSsoUrl.trim().length > 0 &&
+			formData.idpCertificate.trim().length > 0
+		);
+	};
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		let res: { error?: unknown };
+		if (isEdit && selectedConnection?.id) {
+			res = await client
+				.mutation(UpdateOrgSAMLConnection, {
+					params: {
+						id: selectedConnection.id,
+						name: formData.name.trim(),
+						idp_entity_id: formData.idpEntityId.trim(),
+						idp_sso_url: formData.idpSsoUrl.trim() || undefined,
+						// Omitting idp_certificate leaves the stored cert intact.
+						idp_certificate: formData.idpCertificate.trim() || undefined,
+						sp_entity_id: formData.spEntityId.trim() || undefined,
+						acs_url: formData.acsUrl.trim() || undefined,
+						attribute_mapping: formData.attributeMapping.trim() || undefined,
+						allow_idp_initiated: formData.allowIdpInitiated,
+						is_active: formData.isActive,
+					},
+				})
+				.toPromise();
+		} else {
+			res = await client
+				.mutation(CreateOrgSAMLConnection, {
+					params: {
+						org_id: orgId,
+						name: formData.name.trim(),
+						idp_entity_id: formData.idpEntityId.trim(),
+						idp_sso_url: formData.idpSsoUrl.trim(),
+						idp_certificate: formData.idpCertificate.trim(),
+						sp_entity_id: formData.spEntityId.trim() || undefined,
+						acs_url: formData.acsUrl.trim() || undefined,
+						attribute_mapping: formData.attributeMapping.trim() || undefined,
+						allow_idp_initiated: formData.allowIdpInitiated,
+					},
+				})
+				.toPromise();
+		}
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						isEdit
+							? 'Failed to update SAML connection'
+							: 'Failed to create SAML connection',
+					),
+				),
+			);
+			return;
+		}
+		toast.success(
+			isEdit ? 'SAML connection updated' : 'SAML connection created',
+		);
+		setFormData({ ...initFormData });
+		setOpen(false);
+		fetchConnection();
+	};
+
+	return (
+		<>
+			{view === UpdateModalViews.ADD ? (
+				<Button size="sm" onClick={() => setOpen(true)}>
+					<Plus className="mr-2 h-4 w-4" />
+					Configure SAML
+				</Button>
+			) : (
+				<Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+					Edit
+				</Button>
+			)}
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>
+							{view === UpdateModalViews.ADD
+								? 'Configure SAML Connection'
+								: 'Edit SAML Connection'}
+						</SheetTitle>
+						<SheetDescription>
+							Upstream SAML 2.0 identity provider for this organization.
+							Authorizer acts as the Service Provider. The IdP certificate is
+							never shown again after saving.
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">Name</label>
+							<Input
+								placeholder="okta-saml"
+								value={formData.name}
+								isInvalid={formData.name.trim().length === 0}
+								onChange={(e) => setField('name', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								IdP Entity ID
+							</label>
+							<Input
+								placeholder="https://idp.example.com/saml/metadata"
+								value={formData.idpEntityId}
+								isInvalid={formData.idpEntityId.trim().length === 0}
+								onChange={(e) => setField('idpEntityId', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								IdP SSO URL
+							</label>
+							<Input
+								placeholder="https://idp.example.com/saml/sso"
+								value={formData.idpSsoUrl}
+								isInvalid={!isEdit && formData.idpSsoUrl.trim().length === 0}
+								onChange={(e) => setField('idpSsoUrl', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-start gap-4">
+							<label className="w-32 text-sm font-medium shrink-0 pt-2">
+								IdP Certificate
+							</label>
+							<Textarea
+								rows={5}
+								className="font-mono text-xs"
+								placeholder={
+									isEdit
+										? 'Leave empty to keep the current certificate'
+										: '-----BEGIN CERTIFICATE----- (PEM)'
+								}
+								value={formData.idpCertificate}
+								onChange={(e) =>
+									setField('idpCertificate', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								SP Entity ID
+							</label>
+							<Input
+								placeholder="Derived from request host when empty"
+								value={formData.spEntityId}
+								onChange={(e) => setField('spEntityId', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								ACS URL
+							</label>
+							<Input
+								placeholder="Derived from request host when empty"
+								value={formData.acsUrl}
+								onChange={(e) => setField('acsUrl', e.currentTarget.value)}
+							/>
+						</div>
+
+						<div className="flex items-start gap-4">
+							<label className="w-32 text-sm font-medium shrink-0 pt-2">
+								Attribute Mapping
+							</label>
+							<Textarea
+								rows={3}
+								className="font-mono text-xs"
+								placeholder='{"email":"email","given_name":"firstName"}'
+								value={formData.attributeMapping}
+								onChange={(e) =>
+									setField('attributeMapping', e.currentTarget.value)
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Allow IdP Initiated
+							</label>
+							<div className="flex items-center gap-2">
+								<span className="text-sm font-medium">Off</span>
+								<Switch
+									checked={formData.allowIdpInitiated}
+									onCheckedChange={(checked: boolean) =>
+										setField('allowIdpInitiated', checked)
+									}
+								/>
+								<span className="text-sm font-medium">On</span>
+							</div>
+						</div>
+
+						{isEdit && (
+							<div className="flex items-center gap-4">
+								<label className="w-32 text-sm font-medium shrink-0">
+									Active
+								</label>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium">Off</span>
+									<Switch
+										checked={formData.isActive}
+										onCheckedChange={(checked: boolean) =>
+											setField('isActive', checked)
+										}
+									/>
+									<span className="text-sm font-medium">On</span>
+								</div>
+							</div>
+						)}
+					</div>
+
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={saveData}
+							isLoading={loading}
+							disabled={!validateData()}
+						>
+							Save
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+		</>
+	);
+};
+
+export default UpdateOrgSAMLConnectionModal;

--- a/web/dashboard/src/components/UpdateOrganizationModal.tsx
+++ b/web/dashboard/src/components/UpdateOrganizationModal.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import { CreateOrganization, UpdateOrganization } from '../graphql/mutation';
+import type { Organization } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+interface UpdateOrganizationModalProps {
+	view: UpdateModalViews;
+	selectedOrganization?: Organization;
+	fetchOrganizations: () => void;
+}
+
+interface OrganizationFormData {
+	name: string;
+	displayName: string;
+	enabled: boolean;
+}
+
+const initFormData: OrganizationFormData = {
+	name: '',
+	displayName: '',
+	enabled: true,
+};
+
+const UpdateOrganizationModal = ({
+	view,
+	selectedOrganization,
+	fetchOrganizations,
+}: UpdateOrganizationModalProps) => {
+	const client = useClient();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<OrganizationFormData>({
+		...initFormData,
+	});
+
+	const isEdit = view === UpdateModalViews.Edit;
+
+	useEffect(() => {
+		if (open && isEdit && selectedOrganization) {
+			setFormData({
+				name: selectedOrganization.name,
+				displayName: selectedOrganization.display_name || '',
+				enabled: selectedOrganization.enabled,
+			});
+		}
+	}, [open]);
+
+	const validateData = () => !loading && formData.name.trim().length > 0;
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		let res: { error?: unknown };
+		if (isEdit && selectedOrganization?.id) {
+			res = await client
+				.mutation(UpdateOrganization, {
+					params: {
+						id: selectedOrganization.id,
+						name: formData.name.trim(),
+						display_name: formData.displayName,
+						enabled: formData.enabled,
+					},
+				})
+				.toPromise();
+		} else {
+			res = await client
+				.mutation(CreateOrganization, {
+					params: {
+						name: formData.name.trim(),
+						display_name: formData.displayName,
+					},
+				})
+				.toPromise();
+		}
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						isEdit
+							? 'Failed to update organization'
+							: 'Failed to create organization',
+					),
+				),
+			);
+			return;
+		}
+		toast.success(isEdit ? 'Organization updated' : 'Organization created');
+		setFormData({ ...initFormData });
+		setOpen(false);
+		fetchOrganizations();
+	};
+
+	return (
+		<>
+			{view === UpdateModalViews.ADD ? (
+				<Button size="sm" onClick={() => setOpen(true)}>
+					<Plus className="mr-2 h-4 w-4" />
+					Add Organization
+				</Button>
+			) : (
+				<button
+					className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm"
+					onClick={() => setOpen(true)}
+				>
+					Edit
+				</button>
+			)}
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>
+							{view === UpdateModalViews.ADD
+								? 'Add New Organization'
+								: 'Edit Organization'}
+						</SheetTitle>
+						<SheetDescription>
+							Organizations group users for per-org SSO connections and SCIM
+							provisioning.
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">Name</label>
+							<Input
+								placeholder="acme-corp (unique, URL-safe slug)"
+								value={formData.name}
+								isInvalid={formData.name.trim().length === 0}
+								onChange={(e) =>
+									setFormData({ ...formData, name: e.currentTarget.value })
+								}
+							/>
+						</div>
+
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Display Name
+							</label>
+							<Input
+								placeholder="Acme Corp"
+								value={formData.displayName}
+								onChange={(e) =>
+									setFormData({
+										...formData,
+										displayName: e.currentTarget.value,
+									})
+								}
+							/>
+						</div>
+
+						{isEdit && (
+							<div className="flex items-center gap-4">
+								<label className="w-32 text-sm font-medium shrink-0">
+									Enabled
+								</label>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium">Off</span>
+									<Switch
+										checked={formData.enabled}
+										onCheckedChange={(checked: boolean) =>
+											setFormData({ ...formData, enabled: checked })
+										}
+									/>
+									<span className="text-sm font-medium">On</span>
+								</div>
+							</div>
+						)}
+					</div>
+
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={saveData}
+							isLoading={loading}
+							disabled={!validateData()}
+						>
+							Save
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+		</>
+	);
+};
+
+export default UpdateOrganizationModal;

--- a/web/dashboard/src/graphql/mutation/index.ts
+++ b/web/dashboard/src/graphql/mutation/index.ts
@@ -228,3 +228,132 @@ export const DeleteTrustedIssuer = `
     }
   }
 `;
+
+export const CreateOrganization = `
+  mutation createOrganization($params: CreateOrganizationRequest!) {
+    _create_organization(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const UpdateOrganization = `
+  mutation updateOrganization($params: UpdateOrganizationRequest!) {
+    _update_organization(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteOrganization = `
+  mutation deleteOrganization($params: OrganizationRequest!) {
+    _delete_organization(params: $params) {
+      message
+    }
+  }
+`;
+
+export const AddOrgMember = `
+  mutation addOrgMember($params: AddOrgMemberRequest!) {
+    _add_org_member(params: $params) {
+      id
+      user_id
+    }
+  }
+`;
+
+export const RemoveOrgMember = `
+  mutation removeOrgMember($params: RemoveOrgMemberRequest!) {
+    _remove_org_member(params: $params) {
+      message
+    }
+  }
+`;
+
+export const CreateOrgOIDCConnection = `
+  mutation createOrgOIDCConnection($params: CreateOrgOIDCConnectionRequest!) {
+    _create_org_oidc_connection(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const UpdateOrgOIDCConnection = `
+  mutation updateOrgOIDCConnection($params: UpdateOrgOIDCConnectionRequest!) {
+    _update_org_oidc_connection(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteOrgOIDCConnection = `
+  mutation deleteOrgOIDCConnection($params: OrgOIDCConnectionRequest!) {
+    _delete_org_oidc_connection(params: $params) {
+      message
+    }
+  }
+`;
+
+export const CreateOrgSAMLConnection = `
+  mutation createOrgSAMLConnection($params: CreateOrgSAMLConnectionRequest!) {
+    _create_org_saml_connection(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const UpdateOrgSAMLConnection = `
+  mutation updateOrgSAMLConnection($params: UpdateOrgSAMLConnectionRequest!) {
+    _update_org_saml_connection(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteOrgSAMLConnection = `
+  mutation deleteOrgSAMLConnection($params: OrgSAMLConnectionRequest!) {
+    _delete_org_saml_connection(params: $params) {
+      message
+    }
+  }
+`;
+
+export const CreateScimEndpoint = `
+  mutation createScimEndpoint($params: CreateScimEndpointRequest!) {
+    _create_scim_endpoint(params: $params) {
+      scim_endpoint {
+        id
+        org_id
+        enabled
+      }
+      token
+    }
+  }
+`;
+
+export const RotateScimToken = `
+  mutation rotateScimToken($params: ScimEndpointRequest!) {
+    _rotate_scim_token(params: $params) {
+      scim_endpoint {
+        id
+        org_id
+        enabled
+      }
+      token
+    }
+  }
+`;
+
+export const DeleteScimEndpoint = `
+  mutation deleteScimEndpoint($params: ScimEndpointRequest!) {
+    _delete_scim_endpoint(params: $params) {
+      message
+    }
+  }
+`;

--- a/web/dashboard/src/graphql/queries/index.ts
+++ b/web/dashboard/src/graphql/queries/index.ts
@@ -236,3 +236,105 @@ export const TrustedIssuersQuery = `
     }
   }
 `;
+
+export const OrganizationsQuery = `
+  query getOrganizations($params: ListOrganizationsRequest) {
+    _organizations(params: $params) {
+      organizations {
+        id
+        name
+        display_name
+        enabled
+        created_at
+        updated_at
+      }
+      pagination {
+        limit
+        page
+        offset
+        total
+      }
+    }
+  }
+`;
+
+export const OrganizationQuery = `
+  query getOrganization($params: OrganizationRequest!) {
+    _organization(params: $params) {
+      id
+      name
+      display_name
+      enabled
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export const OrgMembersQuery = `
+  query getOrgMembers($params: ListOrgMembersRequest!) {
+    _org_members(params: $params) {
+      org_members {
+        id
+        org_id
+        user_id
+        roles
+        created_at
+      }
+      pagination {
+        limit
+        page
+        offset
+        total
+      }
+    }
+  }
+`;
+
+export const OrgOIDCConnectionQuery = `
+  query getOrgOIDCConnection($params: OrgOIDCConnectionRequest!) {
+    _org_oidc_connection(params: $params) {
+      id
+      org_id
+      name
+      issuer_url
+      sso_client_id
+      scopes
+      redirect_uri
+      is_active
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export const OrgSAMLConnectionQuery = `
+  query getOrgSAMLConnection($params: OrgSAMLConnectionRequest!) {
+    _org_saml_connection(params: $params) {
+      id
+      org_id
+      name
+      idp_entity_id
+      idp_sso_url
+      sp_entity_id
+      acs_url
+      attribute_mapping
+      allow_idp_initiated
+      is_active
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export const ScimEndpointQuery = `
+  query getScimEndpoint($params: ScimEndpointRequest!) {
+    _scim_endpoint(params: $params) {
+      id
+      org_id
+      enabled
+      created_at
+      updated_at
+    }
+  }
+`;

--- a/web/dashboard/src/pages/OrganizationDetail.tsx
+++ b/web/dashboard/src/pages/OrganizationDetail.tsx
@@ -1,0 +1,879 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import { Link, useParams } from 'react-router-dom';
+import {
+	ArrowLeft,
+	ChevronLeft,
+	ChevronRight,
+	Plus,
+	RefreshCw,
+	Trash2,
+} from 'lucide-react';
+import dayjs from 'dayjs';
+import { toast } from 'sonner';
+import UpdateOrgOIDCConnectionModal from '../components/UpdateOrgOIDCConnectionModal';
+import UpdateOrgSAMLConnectionModal from '../components/UpdateOrgSAMLConnectionModal';
+import ClientSecretDialog from '../components/ClientSecretDialog';
+import { UpdateModalViews } from '../constants';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import {
+	OrganizationQuery,
+	OrgMembersQuery,
+	OrgOIDCConnectionQuery,
+	OrgSAMLConnectionQuery,
+	ScimEndpointQuery,
+} from '../graphql/queries';
+import {
+	AddOrgMember,
+	RemoveOrgMember,
+	DeleteOrgOIDCConnection,
+	DeleteOrgSAMLConnection,
+	CreateScimEndpoint,
+	RotateScimToken,
+	DeleteScimEndpoint,
+} from '../graphql/mutation';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '../components/ui/card';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '../components/ui/dialog';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from '../components/ui/table';
+import type {
+	CreateScimEndpointResponse,
+	Organization,
+	OrgMember,
+	OrgOIDCConnection,
+	OrgSAMLConnection,
+	ScimEndpoint,
+} from '../types';
+
+const MEMBERS_PAGE_LIMIT = 10;
+
+// ponytail: one local confirm dialog instead of a modal file per action.
+interface ConfirmDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	body: React.ReactNode;
+	actionLabel: string;
+	destructive?: boolean;
+	onConfirm: () => void;
+}
+
+const ConfirmDialog = ({
+	open,
+	onOpenChange,
+	title,
+	body,
+	actionLabel,
+	destructive,
+	onConfirm,
+}: ConfirmDialogProps) => (
+	<Dialog open={open} onOpenChange={onOpenChange}>
+		<DialogContent>
+			<DialogHeader>
+				<DialogTitle>{title}</DialogTitle>
+				<DialogDescription>Are you sure?</DialogDescription>
+			</DialogHeader>
+			<div
+				className={
+					destructive
+						? 'rounded-md border border-red-300 bg-red-50 p-4'
+						: 'rounded-md border border-yellow-300 bg-yellow-50 p-4'
+				}
+			>
+				<p className="text-sm">{body}</p>
+			</div>
+			<DialogFooter>
+				<Button
+					variant={destructive ? 'destructive' : 'default'}
+					onClick={onConfirm}
+				>
+					{destructive ? (
+						<Trash2 className="mr-2 h-4 w-4" />
+					) : (
+						<RefreshCw className="mr-2 h-4 w-4" />
+					)}
+					{actionLabel}
+				</Button>
+			</DialogFooter>
+		</DialogContent>
+	</Dialog>
+);
+
+const parseRoles = (value: string): string[] =>
+	value
+		.split(/[\s,]+/)
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+const OrganizationDetail = () => {
+	const { id } = useParams<{ id: string }>();
+	const client = useClient();
+
+	const [org, setOrg] = useState<Organization | null>(null);
+	const [orgLoading, setOrgLoading] = useState(true);
+
+	// Members
+	const [members, setMembers] = useState<OrgMember[]>([]);
+	const [membersPage, setMembersPage] = useState(1);
+	const [membersTotal, setMembersTotal] = useState(0);
+	const [newMemberUserId, setNewMemberUserId] = useState('');
+	const [newMemberRoles, setNewMemberRoles] = useState('');
+	const [addingMember, setAddingMember] = useState(false);
+	const [memberToRemove, setMemberToRemove] = useState<OrgMember | null>(null);
+
+	// SSO connections (at most one of each per org)
+	const [oidcConnection, setOidcConnection] =
+		useState<OrgOIDCConnection | null>(null);
+	const [samlConnection, setSamlConnection] =
+		useState<OrgSAMLConnection | null>(null);
+	const [deleteOidcOpen, setDeleteOidcOpen] = useState(false);
+	const [deleteSamlOpen, setDeleteSamlOpen] = useState(false);
+
+	// SCIM
+	const [scimEndpoint, setScimEndpoint] = useState<ScimEndpoint | null>(null);
+	const [scimToken, setScimToken] = useState<string | null>(null);
+	const [rotateScimOpen, setRotateScimOpen] = useState(false);
+	const [deleteScimOpen, setDeleteScimOpen] = useState(false);
+	const [scimLoading, setScimLoading] = useState(false);
+
+	const orgId = org?.id || '';
+
+	const fetchOrg = async () => {
+		if (!id) return;
+		setOrgLoading(true);
+		const res = await client
+			.query<{ _organization: Organization }>(OrganizationQuery, {
+				params: { id },
+			})
+			.toPromise();
+		setOrg(res.data?._organization || null);
+		setOrgLoading(false);
+	};
+
+	const fetchMembers = async (page = membersPage) => {
+		if (!id) return;
+		const res = await client
+			.query<{
+				_org_members: {
+					org_members: OrgMember[];
+					pagination: { total: number };
+				};
+			}>(OrgMembersQuery, {
+				params: {
+					org_id: id,
+					pagination: {
+						pagination: { limit: MEMBERS_PAGE_LIMIT, page },
+					},
+				},
+			})
+			.toPromise();
+		setMembers(res.data?._org_members?.org_members || []);
+		setMembersTotal(res.data?._org_members?.pagination?.total || 0);
+	};
+
+	// Fetching a missing connection/endpoint errors on the server; treat any
+	// error as "not configured".
+	const fetchOidcConnection = async () => {
+		if (!id) return;
+		const res = await client
+			.query<{
+				_org_oidc_connection: OrgOIDCConnection;
+			}>(OrgOIDCConnectionQuery, { params: { org_id: id } })
+			.toPromise();
+		setOidcConnection(res.data?._org_oidc_connection || null);
+	};
+
+	const fetchSamlConnection = async () => {
+		if (!id) return;
+		const res = await client
+			.query<{
+				_org_saml_connection: OrgSAMLConnection;
+			}>(OrgSAMLConnectionQuery, { params: { org_id: id } })
+			.toPromise();
+		setSamlConnection(res.data?._org_saml_connection || null);
+	};
+
+	const fetchScimEndpoint = async () => {
+		if (!id) return;
+		const res = await client
+			.query<{ _scim_endpoint: ScimEndpoint }>(ScimEndpointQuery, {
+				params: { org_id: id },
+			})
+			.toPromise();
+		setScimEndpoint(res.data?._scim_endpoint || null);
+	};
+
+	useEffect(() => {
+		fetchOrg();
+		fetchOidcConnection();
+		fetchSamlConnection();
+		fetchScimEndpoint();
+	}, [id]);
+
+	useEffect(() => {
+		fetchMembers();
+	}, [id, membersPage]);
+
+	const maxMembersPages = Math.max(
+		1,
+		Math.ceil(membersTotal / MEMBERS_PAGE_LIMIT),
+	);
+
+	const addMemberHandler = async () => {
+		if (!newMemberUserId.trim()) return;
+		setAddingMember(true);
+		const res = await client
+			.mutation(AddOrgMember, {
+				params: {
+					org_id: id,
+					user_id: newMemberUserId.trim(),
+					roles: parseRoles(newMemberRoles),
+				},
+			})
+			.toPromise();
+		setAddingMember(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to add member'),
+				),
+			);
+			return;
+		}
+		toast.success('Member added');
+		setNewMemberUserId('');
+		setNewMemberRoles('');
+		fetchMembers();
+	};
+
+	const removeMemberHandler = async () => {
+		if (!memberToRemove) return;
+		const res = await client
+			.mutation(RemoveOrgMember, {
+				params: { org_id: id, user_id: memberToRemove.user_id },
+			})
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to remove member'),
+				),
+			);
+			return;
+		}
+		toast.success('Member removed');
+		setMemberToRemove(null);
+		fetchMembers();
+	};
+
+	const deleteOidcHandler = async () => {
+		const res = await client
+			.mutation(DeleteOrgOIDCConnection, { params: { org_id: id } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete OIDC connection'),
+				),
+			);
+			return;
+		}
+		toast.success('OIDC connection deleted');
+		setDeleteOidcOpen(false);
+		setOidcConnection(null);
+	};
+
+	const deleteSamlHandler = async () => {
+		const res = await client
+			.mutation(DeleteOrgSAMLConnection, { params: { org_id: id } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete SAML connection'),
+				),
+			);
+			return;
+		}
+		toast.success('SAML connection deleted');
+		setDeleteSamlOpen(false);
+		setSamlConnection(null);
+	};
+
+	const createScimHandler = async () => {
+		setScimLoading(true);
+		const res = await client
+			.mutation<{
+				_create_scim_endpoint: CreateScimEndpointResponse;
+			}>(CreateScimEndpoint, { params: { org_id: id } })
+			.toPromise();
+		setScimLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to create SCIM endpoint'),
+				),
+			);
+			return;
+		}
+		toast.success('SCIM endpoint created');
+		setScimToken(res.data?._create_scim_endpoint?.token || null);
+		fetchScimEndpoint();
+	};
+
+	const rotateScimHandler = async () => {
+		const res = await client
+			.mutation<{
+				_rotate_scim_token: CreateScimEndpointResponse;
+			}>(RotateScimToken, { params: { org_id: id } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to rotate SCIM token'),
+				),
+			);
+			return;
+		}
+		toast.success('SCIM token rotated');
+		setRotateScimOpen(false);
+		setScimToken(res.data?._rotate_scim_token?.token || null);
+	};
+
+	const deleteScimHandler = async () => {
+		const res = await client
+			.mutation(DeleteScimEndpoint, { params: { org_id: id } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete SCIM endpoint'),
+				),
+			);
+			return;
+		}
+		toast.success('SCIM endpoint deleted');
+		setDeleteScimOpen(false);
+		setScimEndpoint(null);
+	};
+
+	if (orgLoading) {
+		return (
+			<div className="m-5 rounded-md bg-white py-5 px-10 min-h-[25vh] space-y-3">
+				{[1, 2, 3].map((i) => (
+					<Skeleton key={i} className="h-10 w-full" />
+				))}
+			</div>
+		);
+	}
+
+	if (!org) {
+		return (
+			<div className="m-5 rounded-md bg-white py-5 px-10">
+				<p className="text-sm text-gray-500">Organization not found.</p>
+				<Link
+					to="/identity/organizations"
+					className="mt-2 inline-flex items-center text-sm text-blue-600 hover:underline"
+				>
+					<ArrowLeft className="mr-1 h-4 w-4" />
+					Back to Organizations
+				</Link>
+			</div>
+		);
+	}
+
+	return (
+		<div className="m-5 space-y-5">
+			<div className="rounded-md bg-white py-5 px-10">
+				<Link
+					to="/identity/organizations"
+					className="inline-flex items-center text-sm text-blue-600 hover:underline"
+				>
+					<ArrowLeft className="mr-1 h-4 w-4" />
+					Back to Organizations
+				</Link>
+				<div className="mt-2 flex items-center gap-3">
+					<h1 className="text-2xl font-semibold text-gray-900">
+						{org.display_name || org.name}
+					</h1>
+					<Badge variant={org.enabled ? 'success' : 'warning'}>
+						{org.enabled ? 'enabled' : 'disabled'}
+					</Badge>
+				</div>
+				<p className="mt-1 text-sm text-gray-500">
+					<span className="font-mono text-xs">{org.name}</span>
+					{org.created_at
+						? ` · created ${dayjs.unix(org.created_at).format('MMM D, YYYY')}`
+						: ''}
+				</p>
+			</div>
+
+			{/* Members */}
+			<Card>
+				<CardHeader>
+					<CardTitle>Members</CardTitle>
+					<CardDescription>
+						Users belonging to this organization with their per-org roles.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<div className="mb-4 flex items-end gap-3">
+						<div className="flex-1">
+							<label className="text-sm font-medium">User ID</label>
+							<Input
+								placeholder="ID of an existing user"
+								value={newMemberUserId}
+								onChange={(e) => setNewMemberUserId(e.currentTarget.value)}
+							/>
+						</div>
+						<div className="flex-1">
+							<label className="text-sm font-medium">Roles</label>
+							<Input
+								placeholder="admin member (space or comma separated)"
+								value={newMemberRoles}
+								onChange={(e) => setNewMemberRoles(e.currentTarget.value)}
+							/>
+						</div>
+						<Button
+							size="sm"
+							onClick={addMemberHandler}
+							isLoading={addingMember}
+							disabled={addingMember || !newMemberUserId.trim()}
+						>
+							<Plus className="mr-2 h-4 w-4" />
+							Add Member
+						</Button>
+					</div>
+					{members.length ? (
+						<>
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>User ID</TableHead>
+										<TableHead>Roles</TableHead>
+										<TableHead>Added</TableHead>
+										<TableHead>Actions</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{members.map((member) => (
+										<TableRow key={member.id}>
+											<TableCell className="max-w-[300px] text-sm">
+												<span className="truncate font-mono text-xs">
+													{member.user_id}
+												</span>
+											</TableCell>
+											<TableCell className="max-w-[300px]">
+												<div className="flex flex-wrap gap-1">
+													{member.roles.length ? (
+														member.roles.map((role) => (
+															<Badge key={role} variant="secondary">
+																{role}
+															</Badge>
+														))
+													) : (
+														<span className="text-sm text-gray-400">—</span>
+													)}
+												</div>
+											</TableCell>
+											<TableCell className="text-sm whitespace-nowrap">
+												{member.created_at
+													? dayjs.unix(member.created_at).format('MMM D, YYYY')
+													: '—'}
+											</TableCell>
+											<TableCell>
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => setMemberToRemove(member)}
+												>
+													Remove
+												</Button>
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
+							{maxMembersPages > 1 && (
+								<div className="mt-4 flex items-center justify-end gap-3 text-sm">
+									<span>
+										Page <strong>{membersPage}</strong> of{' '}
+										<strong>{maxMembersPages}</strong>
+									</span>
+									<div className="flex gap-1">
+										<Button
+											variant="outline"
+											size="icon"
+											onClick={() => setMembersPage(membersPage - 1)}
+											disabled={membersPage <= 1}
+										>
+											<ChevronLeft className="h-4 w-4" />
+										</Button>
+										<Button
+											variant="outline"
+											size="icon"
+											onClick={() => setMembersPage(membersPage + 1)}
+											disabled={membersPage >= maxMembersPages}
+										>
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
+						</>
+					) : (
+						<p className="text-sm text-gray-400">No members yet.</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* SSO: OIDC */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>SSO — OIDC Connection</CardTitle>
+							<CardDescription>
+								Upstream OIDC identity provider brokered for this organization
+								(one per org).
+							</CardDescription>
+						</div>
+						{oidcConnection ? (
+							<div className="flex gap-2">
+								<UpdateOrgOIDCConnectionModal
+									view={UpdateModalViews.Edit}
+									orgId={orgId}
+									selectedConnection={oidcConnection}
+									fetchConnection={fetchOidcConnection}
+								/>
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={() => setDeleteOidcOpen(true)}
+								>
+									Delete
+								</Button>
+							</div>
+						) : (
+							<UpdateOrgOIDCConnectionModal
+								view={UpdateModalViews.ADD}
+								orgId={orgId}
+								fetchConnection={fetchOidcConnection}
+							/>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent>
+					{oidcConnection ? (
+						<dl className="grid grid-cols-1 gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+							<div>
+								<dt className="font-medium text-gray-500">Name</dt>
+								<dd>{oidcConnection.name}</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Active</dt>
+								<dd>
+									<Badge
+										variant={oidcConnection.is_active ? 'success' : 'warning'}
+									>
+										{oidcConnection.is_active.toString()}
+									</Badge>
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Issuer URL</dt>
+								<dd className="font-mono text-xs">
+									{oidcConnection.issuer_url}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Client ID</dt>
+								<dd className="font-mono text-xs">
+									{oidcConnection.sso_client_id}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Scopes</dt>
+								<dd>{oidcConnection.scopes || 'openid profile email'}</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Redirect URI</dt>
+								<dd className="font-mono text-xs">
+									{oidcConnection.redirect_uri || 'Derived from request host'}
+								</dd>
+							</div>
+						</dl>
+					) : (
+						<p className="text-sm text-gray-400">
+							No OIDC connection configured.
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* SSO: SAML */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>SSO — SAML Connection</CardTitle>
+							<CardDescription>
+								Upstream SAML 2.0 identity provider for this organization (one
+								per org). Authorizer acts as the Service Provider.
+							</CardDescription>
+						</div>
+						{samlConnection ? (
+							<div className="flex gap-2">
+								<UpdateOrgSAMLConnectionModal
+									view={UpdateModalViews.Edit}
+									orgId={orgId}
+									selectedConnection={samlConnection}
+									fetchConnection={fetchSamlConnection}
+								/>
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={() => setDeleteSamlOpen(true)}
+								>
+									Delete
+								</Button>
+							</div>
+						) : (
+							<UpdateOrgSAMLConnectionModal
+								view={UpdateModalViews.ADD}
+								orgId={orgId}
+								fetchConnection={fetchSamlConnection}
+							/>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent>
+					{samlConnection ? (
+						<dl className="grid grid-cols-1 gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+							<div>
+								<dt className="font-medium text-gray-500">Name</dt>
+								<dd>{samlConnection.name}</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Active</dt>
+								<dd>
+									<Badge
+										variant={samlConnection.is_active ? 'success' : 'warning'}
+									>
+										{samlConnection.is_active.toString()}
+									</Badge>
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">IdP Entity ID</dt>
+								<dd className="font-mono text-xs">
+									{samlConnection.idp_entity_id}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">IdP SSO URL</dt>
+								<dd className="font-mono text-xs">
+									{samlConnection.idp_sso_url || '—'}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">SP Entity ID</dt>
+								<dd className="font-mono text-xs">
+									{samlConnection.sp_entity_id || 'Derived from request host'}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">ACS URL</dt>
+								<dd className="font-mono text-xs">
+									{samlConnection.acs_url || 'Derived from request host'}
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">IdP Initiated</dt>
+								<dd>
+									{samlConnection.allow_idp_initiated ? 'Allowed' : 'Disabled'}
+								</dd>
+							</div>
+						</dl>
+					) : (
+						<p className="text-sm text-gray-400">
+							No SAML connection configured.
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* SCIM */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>SCIM Provisioning</CardTitle>
+							<CardDescription>
+								Inbound SCIM 2.0 endpoint credential for this organization (one
+								per org). The bearer token is shown only once.
+							</CardDescription>
+						</div>
+						{scimEndpoint ? (
+							<div className="flex gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setRotateScimOpen(true)}
+								>
+									<RefreshCw className="mr-2 h-4 w-4" />
+									Rotate Token
+								</Button>
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={() => setDeleteScimOpen(true)}
+								>
+									Delete
+								</Button>
+							</div>
+						) : (
+							<Button
+								size="sm"
+								onClick={createScimHandler}
+								isLoading={scimLoading}
+							>
+								<Plus className="mr-2 h-4 w-4" />
+								Create SCIM Endpoint
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent>
+					{scimEndpoint ? (
+						<dl className="grid grid-cols-1 gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+							<div>
+								<dt className="font-medium text-gray-500">Endpoint ID</dt>
+								<dd className="font-mono text-xs">{scimEndpoint.id}</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Enabled</dt>
+								<dd>
+									<Badge variant={scimEndpoint.enabled ? 'success' : 'warning'}>
+										{scimEndpoint.enabled.toString()}
+									</Badge>
+								</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Base URL</dt>
+								<dd className="font-mono text-xs">/scim/v2/</dd>
+							</div>
+							<div>
+								<dt className="font-medium text-gray-500">Created</dt>
+								<dd>
+									{scimEndpoint.created_at
+										? dayjs.unix(scimEndpoint.created_at).format('MMM D, YYYY')
+										: '—'}
+								</dd>
+							</div>
+						</dl>
+					) : (
+						<p className="text-sm text-gray-400">
+							No SCIM endpoint configured.
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* Confirm dialogs */}
+			<ConfirmDialog
+				open={!!memberToRemove}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) setMemberToRemove(null);
+				}}
+				title="Remove Member"
+				body={
+					<>
+						User <strong>{memberToRemove?.user_id}</strong> will be removed from
+						this organization.
+					</>
+				}
+				actionLabel="Remove"
+				destructive
+				onConfirm={removeMemberHandler}
+			/>
+			<ConfirmDialog
+				open={deleteOidcOpen}
+				onOpenChange={setDeleteOidcOpen}
+				title="Delete OIDC Connection"
+				body={
+					<>
+						OIDC connection <strong>{oidcConnection?.name}</strong> will be
+						deleted permanently! SSO logins through it will stop working.
+					</>
+				}
+				actionLabel="Delete"
+				destructive
+				onConfirm={deleteOidcHandler}
+			/>
+			<ConfirmDialog
+				open={deleteSamlOpen}
+				onOpenChange={setDeleteSamlOpen}
+				title="Delete SAML Connection"
+				body={
+					<>
+						SAML connection <strong>{samlConnection?.name}</strong> will be
+						deleted permanently! SSO logins through it will stop working.
+					</>
+				}
+				actionLabel="Delete"
+				destructive
+				onConfirm={deleteSamlHandler}
+			/>
+			<ConfirmDialog
+				open={rotateScimOpen}
+				onOpenChange={setRotateScimOpen}
+				title="Rotate SCIM Token"
+				body="The current SCIM token will stop working immediately. The new token is shown only once."
+				actionLabel="Rotate Token"
+				onConfirm={rotateScimHandler}
+			/>
+			<ConfirmDialog
+				open={deleteScimOpen}
+				onOpenChange={setDeleteScimOpen}
+				title="Delete SCIM Endpoint"
+				body="The SCIM endpoint and its token will be deleted permanently! Provisioning from the org's IdP will stop working."
+				actionLabel="Delete"
+				destructive
+				onConfirm={deleteScimHandler}
+			/>
+
+			{/* One-time SCIM token display */}
+			<ClientSecretDialog
+				secret={scimToken}
+				onClose={() => setScimToken(null)}
+				label="SCIM Token"
+			/>
+		</div>
+	);
+};
+
+export default OrganizationDetail;

--- a/web/dashboard/src/pages/OrganizationDetail.tsx
+++ b/web/dashboard/src/pages/OrganizationDetail.tsx
@@ -190,8 +190,13 @@ const OrganizationDetail = () => {
 				},
 			})
 			.toPromise();
-		setMembers(res.data?._org_members?.org_members || []);
+		const list = res.data?._org_members?.org_members || [];
+		setMembers(list);
 		setMembersTotal(res.data?._org_members?.pagination?.total || 0);
+		// removing the last member of a page > 1 leaves it out of range
+		if (list.length === 0 && page > 1) {
+			setMembersPage(1);
+		}
 	};
 
 	// Fetching a missing connection/endpoint errors on the server; treat any

--- a/web/dashboard/src/pages/Organizations.tsx
+++ b/web/dashboard/src/pages/Organizations.tsx
@@ -1,0 +1,309 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import { Link } from 'react-router-dom';
+import {
+	ChevronsLeft,
+	ChevronsRight,
+	ChevronLeft,
+	ChevronRight,
+	ChevronDown,
+	AlertCircle,
+} from 'lucide-react';
+import dayjs from 'dayjs';
+import UpdateOrganizationModal from '../components/UpdateOrganizationModal';
+import DeleteOrganizationModal from '../components/DeleteOrganizationModal';
+import { pageLimitsExtended, UpdateModalViews } from '../constants';
+import { OrganizationsQuery } from '../graphql/queries';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { Select } from '../components/ui/select';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+	DropdownMenu,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+} from '../components/ui/dropdown-menu';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from '../components/ui/table';
+import type { Organization, OrganizationsResponse } from '../types';
+
+interface PaginationProps {
+	limit: number;
+	page: number;
+	offset: number;
+	total: number;
+	maxPages: number;
+}
+
+const Organizations = () => {
+	const client = useClient();
+	const [loading, setLoading] = useState<boolean>(false);
+	const [orgData, setOrgData] = useState<Organization[]>([]);
+	const [paginationProps, setPaginationProps] = useState<PaginationProps>({
+		limit: 10,
+		page: 1,
+		offset: 0,
+		total: 0,
+		maxPages: 1,
+	});
+
+	const getMaxPages = (pagination: PaginationProps) => {
+		const { limit, total } = pagination;
+		if (total > 1) {
+			return total % limit === 0
+				? total / limit
+				: Math.floor(total / limit) + 1;
+		}
+		return 1;
+	};
+
+	const fetchOrgData = async () => {
+		setLoading(true);
+		const res = await client
+			.query<OrganizationsResponse>(OrganizationsQuery, {
+				params: {
+					pagination: {
+						pagination: {
+							limit: paginationProps.limit,
+							page: paginationProps.page,
+						},
+					},
+				},
+			})
+			.toPromise();
+		if (res.data?._organizations) {
+			const { pagination, organizations } = res.data._organizations;
+			const maxPages = getMaxPages(pagination as unknown as PaginationProps);
+			if (organizations?.length) {
+				setOrgData(organizations);
+				setPaginationProps({
+					...paginationProps,
+					...pagination,
+					maxPages,
+				});
+			} else {
+				setOrgData([]);
+				if (paginationProps.page !== 1) {
+					setPaginationProps({
+						...paginationProps,
+						...pagination,
+						maxPages,
+						page: 1,
+					});
+				}
+			}
+		}
+		setLoading(false);
+	};
+
+	const paginationHandler = (value: Record<string, number>) => {
+		setPaginationProps({ ...paginationProps, ...value });
+	};
+
+	useEffect(() => {
+		fetchOrgData();
+	}, [paginationProps.page, paginationProps.limit]);
+
+	return (
+		<div className="m-5 rounded-md bg-white py-5 px-10">
+			<div className="flex items-center justify-between my-4">
+				<div>
+					<h1 className="text-2xl font-semibold text-gray-900">
+						Organizations
+					</h1>
+					<p className="mt-1 text-sm text-gray-500">
+						Manage organizations, their members, SSO connections and SCIM
+						provisioning.
+					</p>
+				</div>
+				<UpdateOrganizationModal
+					view={UpdateModalViews.ADD}
+					fetchOrganizations={fetchOrgData}
+				/>
+			</div>
+			{loading ? (
+				<div className="min-h-[25vh] space-y-3">
+					{[1, 2, 3].map((i) => (
+						<Skeleton key={i} className="h-10 w-full" />
+					))}
+				</div>
+			) : orgData.length ? (
+				<>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Display Name</TableHead>
+								<TableHead>Enabled</TableHead>
+								<TableHead>Created</TableHead>
+								<TableHead>Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{orgData.map((org) => (
+								<TableRow key={org.id}>
+									<TableCell className="max-w-[220px] text-sm">
+										<Link
+											to={`/identity/organizations/${org.id}`}
+											className="font-medium text-blue-600 hover:underline"
+										>
+											{org.name}
+										</Link>
+									</TableCell>
+									<TableCell className="max-w-[220px] text-sm">
+										{org.display_name || '—'}
+									</TableCell>
+									<TableCell>
+										<Badge variant={org.enabled ? 'success' : 'warning'}>
+											{org.enabled.toString()}
+										</Badge>
+									</TableCell>
+									<TableCell className="text-sm whitespace-nowrap">
+										{org.created_at
+											? dayjs.unix(org.created_at).format('MMM D, YYYY')
+											: '—'}
+									</TableCell>
+									<TableCell>
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button variant="ghost" size="sm">
+													<span className="text-sm font-light">Menu</span>
+													<ChevronDown className="ml-2 h-3 w-3" />
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end">
+												<Link
+													to={`/identity/organizations/${org.id}`}
+													className="block w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 rounded-sm"
+												>
+													Manage
+												</Link>
+												<UpdateOrganizationModal
+													view={UpdateModalViews.Edit}
+													selectedOrganization={org}
+													fetchOrganizations={fetchOrgData}
+												/>
+												<DeleteOrganizationModal
+													organizationId={org.id}
+													organizationName={org.name}
+													fetchOrganizations={fetchOrgData}
+												/>
+											</DropdownMenuContent>
+										</DropdownMenu>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+
+					{/* Pagination */}
+					{(paginationProps.maxPages > 1 || paginationProps.total >= 5) && (
+						<div className="mt-4 flex items-center justify-between">
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() => paginationHandler({ page: 1 })}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronsLeft className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page - 1,
+										})
+									}
+									disabled={paginationProps.page <= 1}
+								>
+									<ChevronLeft className="h-4 w-4" />
+								</Button>
+							</div>
+
+							<div className="flex items-center gap-4 text-sm">
+								<span>
+									Page <strong>{paginationProps.page}</strong> of{' '}
+									<strong>{paginationProps.maxPages}</strong>
+								</span>
+								<div className="flex items-center gap-1">
+									<span>Go to:</span>
+									<Input
+										type="number"
+										min={1}
+										max={paginationProps.maxPages}
+										value={paginationProps.page}
+										onChange={(e) =>
+											paginationHandler({
+												page: parseInt(e.target.value) || 1,
+											})
+										}
+										className="h-8 w-16"
+									/>
+								</div>
+								<Select
+									value={paginationProps.limit}
+									onChange={(e) =>
+										paginationHandler({
+											page: 1,
+											limit: parseInt(e.target.value),
+										})
+									}
+									className="h-8 w-28"
+								>
+									{pageLimitsExtended.map((pageSize) => (
+										<option key={pageSize} value={pageSize}>
+											Show {pageSize}
+										</option>
+									))}
+								</Select>
+							</div>
+
+							<div className="flex gap-1">
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.page + 1,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronRight className="h-4 w-4" />
+								</Button>
+								<Button
+									variant="outline"
+									size="icon"
+									onClick={() =>
+										paginationHandler({
+											page: paginationProps.maxPages,
+										})
+									}
+									disabled={paginationProps.page >= paginationProps.maxPages}
+								>
+									<ChevronsRight className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					)}
+				</>
+			) : (
+				<div className="flex min-h-[25vh] flex-col items-center justify-center text-gray-300">
+					<AlertCircle className="h-16 w-16 mb-2" />
+					<p className="text-2xl font-bold">No Data</p>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Organizations;

--- a/web/dashboard/src/routes/index.tsx
+++ b/web/dashboard/src/routes/index.tsx
@@ -14,6 +14,8 @@ const AuthorizationModel = lazy(() => import('../pages/authorization/Model'));
 const AuthorizationTuples = lazy(() => import('../pages/authorization/Tuples'));
 const Clients = lazy(() => import('../pages/Clients'));
 const TrustedIssuers = lazy(() => import('../pages/TrustedIssuers'));
+const Organizations = lazy(() => import('../pages/Organizations'));
+const OrganizationDetail = lazy(() => import('../pages/OrganizationDetail'));
 
 export const AppRoutes = () => {
 	const { isLoggedIn } = useAuthContext();
@@ -47,6 +49,14 @@ export const AppRoutes = () => {
 							<Route
 								path="identity/trusted-issuers"
 								element={<TrustedIssuers />}
+							/>
+							<Route
+								path="identity/organizations"
+								element={<Organizations />}
+							/>
+							<Route
+								path="identity/organizations/:id"
+								element={<OrganizationDetail />}
 							/>
 							<Route path="*" element={<Overview />} />
 						</Route>

--- a/web/dashboard/src/types.ts
+++ b/web/dashboard/src/types.ts
@@ -232,3 +232,78 @@ export interface TrustedIssuersResponse {
 		trusted_issuers: TrustedIssuer[];
 	};
 }
+
+export interface Organization {
+	id: string;
+	// name is a unique, URL-safe slug identifying the organization.
+	name: string;
+	display_name?: string | null;
+	enabled: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface OrganizationsResponse {
+	_organizations: {
+		pagination: PaginationInfo;
+		organizations: Organization[];
+	};
+}
+
+export interface OrgMember {
+	id: string;
+	org_id: string;
+	user_id: string;
+	roles: string[];
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface OrgMembersResponse {
+	_org_members: {
+		pagination: PaginationInfo;
+		org_members: OrgMember[];
+	};
+}
+
+export interface OrgOIDCConnection {
+	id: string;
+	org_id: string;
+	name: string;
+	issuer_url: string;
+	sso_client_id: string;
+	scopes?: string | null;
+	redirect_uri?: string | null;
+	is_active: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface OrgSAMLConnection {
+	id: string;
+	org_id: string;
+	name: string;
+	idp_entity_id: string;
+	idp_sso_url?: string | null;
+	sp_entity_id?: string | null;
+	acs_url?: string | null;
+	attribute_mapping?: string | null;
+	allow_idp_initiated: boolean;
+	is_active: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface ScimEndpoint {
+	id: string;
+	org_id: string;
+	enabled: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface CreateScimEndpointResponse {
+	scim_endpoint: ScimEndpoint;
+	// Returned exactly once at creation/rotation; never retrievable again.
+	token: string;
+}


### PR DESCRIPTION
## What

Second of two dashboard PRs for the MAI admin surface (stacks on #662 — merge that first; this PR's base is `feat/dashboard-clients`).

- **Organizations page** (`/identity/organizations`): paginated list + create/edit/delete.
- **Organization detail** (`/identity/organizations/:id`):
  - **Members**: list with pagination, add, remove
  - **SSO**: per-org OIDC connection and SAML 2.0 connection — create/edit/delete each
  - **SCIM**: endpoint show/create/delete + token rotation; token plaintext surfaced exactly once via the shared one-time-secret dialog
- "Organizations" added to the Identity sidebar group.

All 20 GraphQL ops/inputs verified against `schema.graphqls` (including the nested `pagination.pagination` request shape and `CreateScimEndpointResponse{scim_endpoint, token}`).

## Testing
- `npm ci && npm run build` passes, `npx tsc --noEmit` clean (strict), prettier clean on touched files
- Schema-level verification; no live click-through yet