### PR TITLE
fix(saml): exempt ACS endpoint from CSRF Origin enforcement

### DIFF
--- a/internal/http_handlers/csrf.go
+++ b/internal/http_handlers/csrf.go
@@ -58,6 +58,18 @@ func (h *httpProvider) CSRFMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		// Exempt the SAML ACS endpoint (POST /oauth/saml/:org_slug/acs). The
+		// SAML POST binding delivers the assertion via an auto-submitting form
+		// from the IdP's origin — a legitimate cross-origin POST that Origin
+		// allow-listing would always reject. The handler protects itself with
+		// XML signature validation, InResponseTo binding, and the assertion
+		// replay cache — same rationale as /oauth_callback/ above.
+		if strings.HasPrefix(c.Request.URL.Path, "/oauth/saml/") &&
+			strings.HasSuffix(c.Request.URL.Path, "/acs") {
+			c.Next()
+			return
+		}
+
 		// === Origin / Referer enforcement ===
 		// Browsers always send Origin on cross-origin POST. A missing
 		// Origin header on a state-changing request is suspicious and

--- a/internal/integration_tests/csrf_saml_acs_test.go
+++ b/internal/integration_tests/csrf_saml_acs_test.go
@@ -1,0 +1,58 @@
+package integration_tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCSRFExemptsSAMLACS proves the SAML POST binding survives the CSRF
+// middleware: the IdP delivers the assertion via an auto-submitting form from
+// ITS OWN origin, so the ACS endpoint must accept a cross-origin POST that the
+// Origin allow-list would otherwise reject. The handler defends itself with
+// XML signature validation, InResponseTo binding, and the replay cache.
+func TestCSRFExemptsSAMLACS(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ts.HttpProvider.CSRFMiddleware())
+	reached := false
+	router.POST("/oauth/saml/:org_slug/acs", func(c *gin.Context) {
+		reached = true
+		c.Status(http.StatusBadRequest) // stand-in for SAML validation failure
+	})
+	router.POST("/oauth/saml/:org_slug/login", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	t.Run("cross-origin IdP form POST reaches the ACS handler", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, "/oauth/saml/acme/acs",
+			strings.NewReader("SAMLResponse=dGVzdA%3D%3D&RelayState=abc"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Origin", "https://idp.example.com") // IdP origin, never allow-listed
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.True(t, reached, "ACS handler must be reached, not blocked by CSRF")
+		assert.NotEqual(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("other SAML POST paths are NOT exempt", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, "/oauth/saml/acme/login", nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://attacker.example.com")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code,
+			"the ACS exemption must not leak to other /oauth/saml/ POST routes")
+	})
+}


### PR DESCRIPTION
## What

Found while live-verifying the new `with-org-saml` example against a dockerized Keycloak IdP: the CSRF middleware has no exemption for `POST /oauth/saml/:org_slug/acs`, so the IdP's auto-submitting form POST (SAML POST binding, IdP origin, form-urlencoded) gets `403 csrf_validation_failed` — **the shipped SAML SP feature is unusable for real browser flows** (headless scripts only worked by faking allow-listed `Origin` headers).

## Fix
Exempt `/oauth/saml/*/acs` (prefix + suffix scoped) from Origin enforcement — the same rationale as the existing `/oauth_callback/` exemption: the ACS handler defends itself with XML signature validation, InResponseTo binding, and the assertion replay cache; CSRF Origin checks cannot apply to a flow whose legitimate POST is always cross-origin.

## Testing
- New `TestCSRFExemptsSAMLACS`: cross-origin IdP form POST reaches the ACS handler; other `/oauth/saml/` POST routes (e.g. `/login`) remain CSRF-protected — exemption doesn't leak.
- `go build`, gofmt clean.

Related: the MAI follow-ups memory lists "SAML handler-level tests" as a deferred item — this is the first regression from that gap.