### PR TITLE
security(mfa): per-user TOTP lockout + hash recovery codes at rest

### DIFF
--- a/internal/authenticators/totp/totp.go
+++ b/internal/authenticators/totp/totp.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"image/png"
 	"time"
 
@@ -48,13 +47,18 @@ func (p *provider) Generate(ctx context.Context, id string) (*config.Authenticat
 	for i := 0; i < 10; i++ {
 		recoveryCodes = append(recoveryCodes, uuid.NewString())
 	}
-	// Converting recoveryCodes to string
+	// recoverCodesMap is the plaintext map returned to the caller once (the
+	// frontend shows these codes to the user at enrollment). storedCodesMap
+	// keys on the SHA-256 hash of each code — only the hashed form is
+	// persisted, so an offline DB dump never reveals usable recovery codes.
 	recoverCodesMap := map[string]bool{}
+	storedCodesMap := map[string]bool{}
 	for i := 0; i < len(recoveryCodes); i++ {
 		recoverCodesMap[recoveryCodes[i]] = false
+		storedCodesMap[crypto.HashRecoveryCode(recoveryCodes[i])] = false
 	}
-	// Converting recoveryCodesMap to string
-	jsonData, err := json.Marshal(recoverCodesMap)
+	// Converting storedCodesMap (hashed) to string for persistence
+	jsonData, err := json.Marshal(storedCodesMap)
 	if err != nil {
 		return nil, err
 	}
@@ -221,14 +225,26 @@ func (p *provider) ValidateRecoveryCode(ctx context.Context, recoveryCode, userI
 	if err != nil {
 		return false, err
 	}
-	// check if recovery code is valid
-	if val, ok := recoveryCodesMap[recoveryCode]; !ok {
-		return false, fmt.Errorf("invalid recovery code")
-	} else if val {
-		return false, fmt.Errorf("recovery code already used")
+	// Recovery codes are stored as SHA-256 hashes. Look up the hash of the
+	// supplied code; if it isn't present, fall back to a direct plaintext
+	// lookup for rows written by a pre-hashing release (lazy backward
+	// compatibility, mirroring the TOTP secret migration in Validate). The
+	// matched key is marked consumed either way, preserving one-time use.
+	matchKey := crypto.HashRecoveryCode(recoveryCode)
+	val, ok := recoveryCodesMap[matchKey]
+	if !ok {
+		// Legacy plaintext row: the code itself is the stored key.
+		matchKey = recoveryCode
+		val, ok = recoveryCodesMap[matchKey]
 	}
-	// update recovery code map
-	recoveryCodesMap[recoveryCode] = true
+	if !ok || val {
+		// Not a known code, or one that has already been consumed: this is
+		// a verification failure, not a server fault. Return (false, nil) so
+		// the caller counts it as a failed attempt rather than an error.
+		return false, nil
+	}
+	// mark the matched recovery code consumed
+	recoveryCodesMap[matchKey] = true
 	// convert recoveryCodesMap to string
 	jsonData, err := json.Marshal(recoveryCodesMap)
 	if err != nil {

--- a/internal/crypto/totp.go
+++ b/internal/crypto/totp.go
@@ -1,6 +1,8 @@
 package crypto
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"strings"
 )
@@ -54,4 +56,28 @@ func DecryptTOTPSecret(stored, key string) (string, error) {
 // successful validation.
 func IsEncryptedTOTPSecret(stored string) bool {
 	return strings.HasPrefix(stored, TOTPCipherPrefix)
+}
+
+// HashRecoveryCode returns the hex-encoded SHA-256 digest of a TOTP
+// recovery code. Recovery codes are generated as random UUIDs — already
+// high-entropy — so a fast one-way hash is sufficient: there is nothing
+// to brute-force offline the way there is with a user-chosen password, so
+// the slow-hash cost of bcrypt/argon2 would be wasted. Storing only the
+// digest means an offline DB dump no longer reveals usable recovery codes.
+func HashRecoveryCode(code string) string {
+	sum := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(sum[:])
+}
+
+// IsHashedRecoveryCode reports whether a stored recovery-code map key is a
+// SHA-256 digest (64 hex chars) written by HashRecoveryCode, as opposed to
+// a legacy plaintext UUID (36 chars, contains dashes) written by a
+// pre-hashing release. Used by the totp authenticator's lazy migration to
+// decide whether an incoming code must be hashed before comparison.
+func IsHashedRecoveryCode(stored string) bool {
+	if len(stored) != hex.EncodedLen(sha256.Size) {
+		return false
+	}
+	_, err := hex.DecodeString(stored)
+	return err == nil
 }

--- a/internal/crypto/totp_test.go
+++ b/internal/crypto/totp_test.go
@@ -107,6 +107,26 @@ func TestIsEncryptedTOTPSecret(t *testing.T) {
 	assert.True(t, IsEncryptedTOTPSecret("enc:v1:foo"))
 }
 
+func TestHashRecoveryCode(t *testing.T) {
+	const code = "3f2504e0-4f89-41d3-9a0c-0305e82c3301" // a UUID-shaped recovery code
+
+	h := HashRecoveryCode(code)
+	// Deterministic, hex-encoded, 64 chars, and not equal to the plaintext.
+	assert.Len(t, h, 64)
+	assert.Equal(t, h, HashRecoveryCode(code))
+	assert.NotEqual(t, code, h)
+	assert.NotEqual(t, HashRecoveryCode("other"), h)
+}
+
+func TestIsHashedRecoveryCode(t *testing.T) {
+	// A real hash is recognised; a legacy plaintext UUID is not.
+	assert.True(t, IsHashedRecoveryCode(HashRecoveryCode("x")))
+	assert.False(t, IsHashedRecoveryCode("3f2504e0-4f89-41d3-9a0c-0305e82c3301"))
+	assert.False(t, IsHashedRecoveryCode(""))
+	// Correct length (64) but not hex — must be rejected.
+	assert.False(t, IsHashedRecoveryCode(strings.Repeat("z", 64)))
+}
+
 // flipChar mutates one character in the middle of s so the result still has
 // the same length but differs from the input — used to forge a tampered
 // ciphertext for the GCM-authentication test.

--- a/internal/grpcsrv/interceptors/errormap.go
+++ b/internal/grpcsrv/interceptors/errormap.go
@@ -27,6 +27,8 @@ func kindToCode(kind service.ErrorKind) codes.Code {
 		return codes.NotFound
 	case service.KindFailedPrecondition:
 		return codes.FailedPrecondition
+	case service.KindTooManyRequests:
+		return codes.ResourceExhausted
 	default:
 		return codes.Internal
 	}

--- a/internal/http_handlers/graphql.go
+++ b/internal/http_handlers/graphql.go
@@ -24,8 +24,50 @@ import (
 	"github.com/authorizerdev/authorizer/internal/graph/generated"
 	"github.com/authorizerdev/authorizer/internal/graphql"
 	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
 	"github.com/authorizerdev/authorizer/internal/utils"
 )
+
+// kindToGraphQLCode maps a transport-neutral service.ErrorKind onto a stable
+// extensions.code string, mirroring the gRPC code names used by
+// grpcsrv/interceptors.ErrorMap so clients only need to learn one vocabulary
+// across transports. Only errors explicitly constructed via the service
+// package's typed constructors (InvalidArgument, TooManyRequests, ...) reach
+// this — every other error is left with no code, exactly preserving today's
+// GraphQL behaviour for the vast majority of unclassified/internal errors.
+func kindToGraphQLCode(kind service.ErrorKind) string {
+	switch kind {
+	case service.KindInvalidArgument:
+		return "INVALID_ARGUMENT"
+	case service.KindUnauthenticated:
+		return "UNAUTHENTICATED"
+	case service.KindPermissionDenied:
+		return "PERMISSION_DENIED"
+	case service.KindNotFound:
+		return "NOT_FOUND"
+	case service.KindFailedPrecondition:
+		return "FAILED_PRECONDITION"
+	case service.KindTooManyRequests:
+		return "TOO_MANY_REQUESTS"
+	default:
+		return "INTERNAL"
+	}
+}
+
+// graphQLErrorPresenter wraps gqlgen's default presenter to attach
+// extensions.code for typed service errors, without altering message text or
+// touching errors that aren't service.Error (preserving existing behaviour).
+func graphQLErrorPresenter(ctx context.Context, e error) *gqlerror.Error {
+	gqlErr := gql.DefaultErrorPresenter(ctx, e)
+	var svcErr *service.Error
+	if errors.As(e, &svcErr) {
+		if gqlErr.Extensions == nil {
+			gqlErr.Extensions = map[string]interface{}{}
+		}
+		gqlErr.Extensions["code"] = kindToGraphQLCode(svcErr.Kind)
+	}
+	return gqlErr
+}
 
 // queryLimits is a gqlgen handler extension that enforces depth, alias, and
 // complexity limits on parsed operations. It runs after parsing but before
@@ -243,6 +285,8 @@ func (h *httpProvider) GraphqlHandler() gin.HandlerFunc {
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{
 		GraphQLProvider: gqlProvider,
 	}}))
+
+	srv.SetErrorPresenter(graphQLErrorPresenter)
 
 	srv.AddTransport(transport.Options{})
 	// transport.GET is intentionally omitted: GraphQL queries (and especially

--- a/internal/http_handlers/graphql_error_presenter_test.go
+++ b/internal/http_handlers/graphql_error_presenter_test.go
@@ -1,0 +1,59 @@
+package http_handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/service"
+)
+
+// TestGraphQLErrorPresenter_TypedServiceError guards the contract that
+// authorizer-react (via authorizer-js) relies on to detect the TOTP lockout
+// without matching on message text: a typed service.Error must surface a
+// stable extensions.code, with the message left untouched.
+func TestGraphQLErrorPresenter_TypedServiceError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{"too many requests", service.TooManyRequests("too many failed attempts, please try again later"), "TOO_MANY_REQUESTS"},
+		{"invalid argument", service.InvalidArgument("bad input"), "INVALID_ARGUMENT"},
+		{"unauthenticated", service.Unauthenticated("no session"), "UNAUTHENTICATED"},
+		{"permission denied", service.PermissionDenied("nope"), "PERMISSION_DENIED"},
+		{"not found", service.NotFound("missing"), "NOT_FOUND"},
+		{"failed precondition", service.FailedPrecondition("bad state"), "FAILED_PRECONDITION"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gqlErr := graphQLErrorPresenter(context.Background(), tc.err)
+			require.NotNil(t, gqlErr)
+			assert.Equal(t, tc.err.Error(), gqlErr.Message, "message must be preserved byte-for-byte")
+			require.NotNil(t, gqlErr.Extensions)
+			assert.Equal(t, tc.code, gqlErr.Extensions["code"])
+		})
+	}
+}
+
+// TestGraphQLErrorPresenter_UntypedError guards that plain errors (storage
+// failures, token-creation failures, etc.) keep today's behaviour exactly:
+// no extensions.code is attached, so no existing client can be surprised by
+// a new field appearing where it never did before.
+func TestGraphQLErrorPresenter_UntypedError(t *testing.T) {
+	gqlErr := graphQLErrorPresenter(context.Background(), errors.New("boom"))
+	require.NotNil(t, gqlErr)
+	assert.Equal(t, "boom", gqlErr.Message)
+	if gqlErr.Extensions != nil {
+		_, hasCode := gqlErr.Extensions["code"]
+		assert.False(t, hasCode, "untyped errors must not gain a code extension")
+	}
+}
+
+func TestKindToGraphQLCode_DefaultsToInternal(t *testing.T) {
+	assert.Equal(t, "INTERNAL", kindToGraphQLCode(service.ErrorKind(99)))
+}

--- a/internal/http_handlers/oauth_authorize_state_test.go
+++ b/internal/http_handlers/oauth_authorize_state_test.go
@@ -241,3 +241,6 @@ func (f *fakeMemoryStore) SetCache(key string, value string, ttlSeconds int64) e
 }
 func (f *fakeMemoryStore) GetCache(key string) (string, error)     { return "", nil }
 func (f *fakeMemoryStore) DeleteCacheByPrefix(prefix string) error { return nil }
+func (f *fakeMemoryStore) IncrementCache(key string, ttlSeconds int64) (int64, error) {
+	return 1, nil
+}

--- a/internal/integration_tests/totp_recovery_codes_at_rest_test.go
+++ b/internal/integration_tests/totp_recovery_codes_at_rest_test.go
@@ -1,0 +1,132 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestTOTPRecoveryCodesAtRest covers the at-rest hardening for TOTP recovery
+// codes:
+//
+//   - Generate() returns the plaintext recovery codes to the caller once (the
+//     frontend shows them to the user), but persists only their SHA-256
+//     hashes — a DB dump must never reveal a usable recovery code.
+//   - ValidateRecoveryCode() hashes the incoming code, matches it against the
+//     stored hashes, and consumes it exactly once.
+//   - Legacy plaintext recovery-code rows written by a pre-hashing release
+//     still validate once via the plaintext fallback path.
+func TestTOTPRecoveryCodesAtRest(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableTOTPLogin = true
+	cfg.EnableMFA = true
+	ts := initTestSetup(t, cfg)
+	require.NotNil(t, ts.AuthenticatorProvider, "TOTP must be enabled for this test")
+	ctx := context.Background()
+
+	mkUser := func(t *testing.T) *schemas.User {
+		t.Helper()
+		email := "totp_recovery_" + uuid.NewString() + "@authorizer.dev"
+		user, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+			Email: refs.NewStringRef(email),
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	t.Run("Generate persists only hashes, never plaintext recovery codes", func(t *testing.T) {
+		user := mkUser(t)
+		authConfig, err := ts.AuthenticatorProvider.Generate(ctx, user.ID)
+		require.NoError(t, err)
+		require.Len(t, authConfig.RecoveryCodes, 10)
+
+		row, err := ts.StorageProvider.GetAuthenticatorDetailsByUserId(
+			ctx, user.ID, constants.EnvKeyTOTPAuthenticator,
+		)
+		require.NoError(t, err)
+		stored := refs.StringValue(row.RecoveryCodes)
+
+		// No plaintext code may appear anywhere in the persisted blob.
+		for _, code := range authConfig.RecoveryCodes {
+			assert.NotContains(t, stored, code,
+				"plaintext recovery code must not be persisted")
+		}
+
+		// Every stored map key must be a SHA-256 hash, and the hash of each
+		// plaintext code must be present.
+		storedMap := map[string]bool{}
+		require.NoError(t, json.Unmarshal([]byte(stored), &storedMap))
+		require.Len(t, storedMap, 10)
+		for key := range storedMap {
+			assert.True(t, crypto.IsHashedRecoveryCode(key),
+				"stored recovery-code key %q must be a SHA-256 hash", key)
+		}
+		for _, code := range authConfig.RecoveryCodes {
+			_, ok := storedMap[crypto.HashRecoveryCode(code)]
+			assert.True(t, ok, "hash of plaintext code must be a stored key")
+		}
+	})
+
+	t.Run("ValidateRecoveryCode accepts a hashed code exactly once", func(t *testing.T) {
+		user := mkUser(t)
+		authConfig, err := ts.AuthenticatorProvider.Generate(ctx, user.ID)
+		require.NoError(t, err)
+
+		code := authConfig.RecoveryCodes[0]
+		ok, err := ts.AuthenticatorProvider.ValidateRecoveryCode(ctx, code, user.ID)
+		require.NoError(t, err)
+		assert.True(t, ok, "a freshly generated recovery code must validate")
+
+		// One-time use: the same code must not validate a second time.
+		ok, err = ts.AuthenticatorProvider.ValidateRecoveryCode(ctx, code, user.ID)
+		require.NoError(t, err)
+		assert.False(t, ok, "a consumed recovery code must not validate again")
+
+		// A code that was never issued must be rejected (no error).
+		ok, err = ts.AuthenticatorProvider.ValidateRecoveryCode(ctx, uuid.NewString(), user.ID)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("legacy plaintext recovery code validates once via fallback", func(t *testing.T) {
+		user := mkUser(t)
+
+		// Simulate a row enrolled on a pre-hashing release: recovery codes
+		// stored as plaintext UUID keys.
+		legacyCode := uuid.NewString()
+		legacyMap := map[string]bool{legacyCode: false}
+		blob, err := json.Marshal(legacyMap)
+		require.NoError(t, err)
+		_, err = ts.StorageProvider.AddAuthenticator(ctx, &schemas.Authenticator{
+			Secret:        "enc:v1:placeholder", // secret is irrelevant to recovery-code validation
+			RecoveryCodes: refs.NewStringRef(string(blob)),
+			UserID:        user.ID,
+			Method:        constants.EnvKeyTOTPAuthenticator,
+		})
+		require.NoError(t, err)
+
+		// Sanity: the stored key really is legacy plaintext, not a hash.
+		require.False(t, crypto.IsHashedRecoveryCode(legacyCode))
+		require.False(t, strings.Contains(string(blob), crypto.HashRecoveryCode(legacyCode)))
+
+		// The legacy plaintext code must validate once via the fallback path.
+		ok, err := ts.AuthenticatorProvider.ValidateRecoveryCode(ctx, legacyCode, user.ID)
+		require.NoError(t, err)
+		assert.True(t, ok, "legacy plaintext recovery code must validate during rolling upgrade")
+
+		// And be consumed one-time, just like a hashed code.
+		ok, err = ts.AuthenticatorProvider.ValidateRecoveryCode(ctx, legacyCode, user.ID)
+		require.NoError(t, err)
+		assert.False(t, ok, "consumed legacy recovery code must not validate again")
+	})
+}

--- a/internal/integration_tests/verify_otp_test.go
+++ b/internal/integration_tests/verify_otp_test.go
@@ -189,8 +189,15 @@ func TestVerifyOTPNoRecord(t *testing.T) {
 	require.NotNil(t, signupRes)
 	require.NotNil(t, signupRes.User)
 
-	// Set an MFA session cookie so we get past the cookie check
-	req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", "test"))
+	// Arm a genuine MFA session (not just a cookie-shaped placeholder): the
+	// service layer now validates the session against the store before doing
+	// any OTP/lockout work (closes an unauthenticated lockout-DoS elsewhere),
+	// so a fake, unregistered token would now fail at the session check
+	// itself rather than reaching the no-OTP-record path this test guards.
+	mfaSession := uuid.New().String()
+	require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(signupRes.User.ID, mfaSession,
+		time.Now().Add(5*time.Minute).Unix()))
+	req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
 
 	t.Run("should return error not panic when no OTP record exists", func(t *testing.T) {
 		verificationReq := &model.VerifyOTPRequest{

--- a/internal/integration_tests/verify_otp_totp_lockout_test.go
+++ b/internal/integration_tests/verify_otp_totp_lockout_test.go
@@ -1,0 +1,115 @@
+package integration_tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestVerifyOTPTOTPLockout guards the per-user TOTP verification lockout: five
+// failed attempts within the window lock verification, after which even a
+// correct code is refused with a distinct lockout error (not the generic
+// "invalid otp"), and a successful verification resets the counter.
+//
+// This defends the account against a brute-force that spreads guesses across
+// many IPs to slip under the global per-IP rate limiter.
+func TestVerifyOTPTOTPLockout(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableMFA = true
+	cfg.EnableTOTPLogin = true
+	ts := initTestSetup(t, cfg)
+	require.NotNil(t, ts.AuthenticatorProvider, "TOTP must be enabled for this test")
+	req, ctx := createContext(ts)
+
+	const lockoutCachePrefix = "totp_failed_attempts:"
+	const maxFailedAttempts = 5
+
+	mkVerifiedTOTPUser := func(t *testing.T) (*schemas.User, string, string) {
+		t.Helper()
+		email := "verify_totp_lockout_" + uuid.NewString() + "@authorizer.dev"
+		now := time.Now().Unix()
+		user, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+			Email:           refs.NewStringRef(email),
+			EmailVerifiedAt: &now,
+			SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+		})
+		require.NoError(t, err)
+		authConfig, err := ts.AuthenticatorProvider.Generate(ctx, user.ID)
+		require.NoError(t, err)
+		return user, email, authConfig.Secret
+	}
+
+	armMfaSession := func(userID string) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(userID, mfaSession,
+			time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+	}
+
+	verify := func(email, otp string) error {
+		_, err := ts.GraphQLProvider.VerifyOTP(ctx, &model.VerifyOTPRequest{
+			Email:  &email,
+			Otp:    otp,
+			IsTotp: refs.NewBoolRef(true),
+		})
+		return err
+	}
+
+	t.Run("five failures lock verification; a correct code is then refused with a distinct error", func(t *testing.T) {
+		user, email, secret := mkVerifiedTOTPUser(t)
+
+		// Five failed attempts with a wrong code. Each is the generic
+		// invalid-otp error, not the lockout error.
+		for i := 0; i < maxFailedAttempts; i++ {
+			armMfaSession(user.ID)
+			err := verify(email, "000000")
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "too many failed attempts",
+				"attempt %d must still be a normal rejection, not a lockout", i+1)
+		}
+
+		// Sixth attempt with a CORRECT code must be refused because the
+		// account is now locked — the distinct lockout error, not success.
+		armMfaSession(user.ID)
+		validCode, err := totp.GenerateCode(secret, time.Now())
+		require.NoError(t, err)
+		err = verify(email, validCode)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many failed attempts",
+			"a correct code offered while locked must return the lockout error")
+	})
+
+	t.Run("successful verification resets the failed-attempt counter", func(t *testing.T) {
+		user, email, secret := mkVerifiedTOTPUser(t)
+		lockKey := lockoutCachePrefix + user.ID
+
+		// Two failed attempts prime the counter.
+		for i := 0; i < 2; i++ {
+			armMfaSession(user.ID)
+			require.Error(t, verify(email, "000000"))
+		}
+		counter, err := ts.MemoryStoreProvider.GetCache(lockKey)
+		require.NoError(t, err)
+		assert.Equal(t, "2", counter, "two failures must be recorded")
+
+		// A successful verification must clear the counter.
+		armMfaSession(user.ID)
+		validCode, err := totp.GenerateCode(secret, time.Now())
+		require.NoError(t, err)
+		require.NoError(t, verify(email, validCode))
+
+		counter, err = ts.MemoryStoreProvider.GetCache(lockKey)
+		require.NoError(t, err)
+		assert.Empty(t, counter, "a successful verification must reset the failed-attempt counter")
+	})
+}

--- a/internal/integration_tests/verify_otp_totp_lockout_test.go
+++ b/internal/integration_tests/verify_otp_totp_lockout_test.go
@@ -2,6 +2,10 @@ package integration_tests
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -111,5 +115,65 @@ func TestVerifyOTPTOTPLockout(t *testing.T) {
 		counter, err = ts.MemoryStoreProvider.GetCache(lockKey)
 		require.NoError(t, err)
 		assert.Empty(t, counter, "a successful verification must reset the failed-attempt counter")
+	})
+
+	t.Run("concurrent failed attempts cannot bypass the lockout via a check-then-increment race", func(t *testing.T) {
+		// Guards against a non-atomic read-modify-write counter: if the
+		// implementation reads the count, compares it, THEN writes count+1,
+		// concurrent requests can all read the same pre-increment value and
+		// all pass the check, so the counter only ever advances by 1 per
+		// concurrent burst regardless of how many requests race - the lockout
+		// never engages no matter how many guesses are fired. With an atomic
+		// increment-then-check, IncrementCache must instead hand out strictly
+		// increasing, unique values, so at most maxFailedAttempts requests
+		// can ever reach validation and the counter must land exactly at the
+		// number of concurrent attempts - not less.
+		user, email, _ := mkVerifiedTOTPUser(t)
+		lockKey := lockoutCachePrefix + user.ID
+
+		// One MFA session shared by every concurrent request, matching a real
+		// client re-submitting several attempts within one login flow. Set
+		// once before firing concurrently: only reads happen after this, so
+		// there's no header-mutation race in the test itself.
+		armMfaSession(user.ID)
+
+		const concurrency = 20
+		var wg sync.WaitGroup
+		var lockedCount, rejectedCount int64
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := verify(email, "000000")
+				// assert (not require) inside a goroutine: require's FailNow
+				// is only safe to call from the test's own goroutine.
+				if !assert.Error(t, err) {
+					return
+				}
+				if strings.Contains(err.Error(), "too many failed attempts") {
+					atomic.AddInt64(&lockedCount, 1)
+				} else {
+					atomic.AddInt64(&rejectedCount, 1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Every one of the `concurrency` requests must have actually
+		// incremented the counter - a check-then-increment race would leave
+		// this well short of `concurrency`.
+		counter, err := ts.MemoryStoreProvider.GetCache(lockKey)
+		require.NoError(t, err)
+		counterVal, convErr := strconv.Atoi(counter)
+		require.NoError(t, convErr)
+		assert.Equal(t, concurrency, counterVal,
+			"the counter must reflect every concurrent attempt - a lost update here is exactly the race this test guards against")
+
+		// At most maxFailedAttempts requests may ever reach real validation
+		// (and so get the generic invalid-otp rejection); everything beyond
+		// that must be turned away by the lockout before validating.
+		assert.LessOrEqual(t, int(rejectedCount), maxFailedAttempts,
+			"no more than maxFailedAttempts requests may bypass the lockout and reach validation")
+		assert.Equal(t, int64(concurrency)-rejectedCount, lockedCount)
 	})
 }

--- a/internal/memory_store/db/cache.go
+++ b/internal/memory_store/db/cache.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,24 @@ func (p *provider) GetCache(key string) (string, error) {
 		return "", nil
 	}
 	return entry.Value, nil
+}
+
+// IncrementCache atomically increments the integer counter at key (creating it
+// at 1 if absent or expired) and refreshes its TTL under the same mutex
+// SetCache/GetCache use, returning the new value. Safe under concurrent
+// callers, unlike a GetCache+SetCache pair which would let them all observe
+// the same pre-increment value.
+func (p *provider) IncrementCache(key string, ttlSeconds int64) (int64, error) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+	now := time.Now().Unix()
+	var current int64
+	if entry, ok := cache[key]; ok && entry.ExpiresAt >= now {
+		current, _ = strconv.ParseInt(entry.Value, 10, 64)
+	}
+	next := current + 1
+	cache[key] = &cacheEntry{Value: strconv.FormatInt(next, 10), ExpiresAt: now + ttlSeconds}
+	return next, nil
 }
 
 // DeleteCacheByPrefix removes all cache entries whose keys start with the given prefix.

--- a/internal/memory_store/in_memory/cache.go
+++ b/internal/memory_store/in_memory/cache.go
@@ -1,10 +1,40 @@
 package in_memory
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
+
+// IncrementCache atomically increments the integer counter at key (creating it
+// at 1 if absent or expired) and refreshes its TTL, returning the new value.
+// Implemented as an optimistic CompareAndSwap retry loop over the same
+// sync.Map SetCache/GetCache already use, so a concurrent increment can never
+// observe a stale pre-increment value the way a GetCache+SetCache pair would.
+func (c *provider) IncrementCache(key string, ttlSeconds int64) (int64, error) {
+	for {
+		now := time.Now().Unix()
+		old, loaded := cacheStore.Load(key)
+		if !loaded {
+			entry := &cacheEntry{Value: "1", ExpiresAt: now + ttlSeconds}
+			if _, alreadyStored := cacheStore.LoadOrStore(key, entry); !alreadyStored {
+				return 1, nil
+			}
+			continue
+		}
+		entry := old.(*cacheEntry)
+		var current int64
+		if entry.ExpiresAt >= now {
+			current, _ = strconv.ParseInt(entry.Value, 10, 64)
+		}
+		next := current + 1
+		newEntry := &cacheEntry{Value: strconv.FormatInt(next, 10), ExpiresAt: now + ttlSeconds}
+		if cacheStore.CompareAndSwap(key, old, newEntry) {
+			return next, nil
+		}
+	}
+}
 
 // cacheEntry holds a cached value with its expiration time.
 type cacheEntry struct {

--- a/internal/memory_store/provider.go
+++ b/internal/memory_store/provider.go
@@ -76,6 +76,13 @@ type Provider interface {
 	// DeleteCacheByPrefix removes all cache entries whose keys start with the given prefix.
 	// Used for cache invalidation when permissions/policies change.
 	DeleteCacheByPrefix(prefix string) error
+	// IncrementCache atomically increments the integer counter at key (creating
+	// it at 1 if absent or expired) and (re)sets its TTL, returning the new
+	// value. Unlike a GetCache/SetCache pair, this is safe under concurrent
+	// callers - required for any use as a rate-limit/lockout counter, where a
+	// non-atomic read-modify-write lets concurrent requests all observe the
+	// same pre-increment count and bypass the limit.
+	IncrementCache(key string, ttlSeconds int64) (int64, error)
 
 	// GetAllData returns all the data from the session store
 	// This is used for testing purposes only

--- a/internal/memory_store/redis/cache.go
+++ b/internal/memory_store/redis/cache.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"fmt"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -31,6 +32,28 @@ func (p *provider) GetCache(key string) (string, error) {
 		return "", err
 	}
 	return data, nil
+}
+
+// IncrementCache atomically increments the integer counter at key (creating it
+// at 1 if absent) and refreshes its TTL, returning the new value. INCR+EXPIRE
+// run as a single Lua script (matching the GetAndRemoveState pattern below) so
+// concurrent callers can never observe the same pre-increment value the way a
+// GET+SET pair would.
+func (p *provider) IncrementCache(key string, ttlSeconds int64) (int64, error) {
+	fullKey := cachePrefix + key
+	script := `local v = redis.call('INCR', KEYS[1])
+redis.call('EXPIRE', KEYS[1], ARGV[1])
+return v`
+	result, err := p.store.Eval(p.ctx, script, []string{fullKey}, ttlSeconds).Result()
+	if err != nil {
+		p.dependencies.Log.Debug().Err(err).Msg("Error incrementing cache in redis")
+		return 0, err
+	}
+	next, ok := result.(int64)
+	if !ok {
+		return 0, fmt.Errorf("unexpected redis reply type for IncrementCache")
+	}
+	return next, nil
 }
 
 // DeleteCacheByPrefix removes all cache entries whose keys start with the given prefix.

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -7,8 +7,9 @@ package service
 // let each transport translate it:
 //   - gRPC: interceptors.ErrorMap maps Kind -> codes.Code (and grpc-gateway
 //     then maps the code -> HTTP status for the REST surface).
-//   - GraphQL: the error message is surfaced as-is (Kind is ignored), so
-//     existing GraphQL behaviour is byte-for-byte preserved.
+//   - GraphQL: http_handlers.kindToGraphQLCode maps Kind -> extensions.code
+//     on the GraphQL error, alongside the unchanged message text, so clients
+//     can switch on a stable code instead of matching message strings.
 //
 // Only client-facing (4xx-class) errors need to be wrapped with these
 // constructors. Anything returned bare (storage failures, token-creation

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -38,6 +38,10 @@ const (
 	// permitted in the server's current state (e.g. signup disabled).
 	// Maps to gRPC FailedPrecondition / HTTP 400.
 	KindFailedPrecondition
+	// KindTooManyRequests is a request rejected because the caller exceeded
+	// a rate/attempt limit (e.g. MFA verification locked after repeated
+	// failures). Maps to gRPC ResourceExhausted / HTTP 429.
+	KindTooManyRequests
 )
 
 // Error is a typed service error carrying a transport-neutral Kind alongside a
@@ -88,4 +92,9 @@ func NotFound(msg string) error {
 // FailedPrecondition reports a well-formed request disallowed by current state.
 func FailedPrecondition(msg string) error {
 	return &Error{Kind: KindFailedPrecondition, msg: msg}
+}
+
+// TooManyRequests reports a request rejected for exceeding a rate/attempt limit.
+func TooManyRequests(msg string) error {
+	return &Error{Kind: KindTooManyRequests, msg: msg}
 }

--- a/internal/service/verify_otp.go
+++ b/internal/service/verify_otp.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,23 @@ import (
 	"github.com/authorizerdev/authorizer/internal/refs"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 	"github.com/authorizerdev/authorizer/internal/token"
+)
+
+const (
+	// totpMaxFailedAttempts is the number of failed TOTP/recovery-code
+	// verifications tolerated for a single user before verification is
+	// locked. The global per-IP rate limiter does not stop an attacker
+	// spreading brute-force guesses for one account across many IPs, so we
+	// additionally cap failures per user.
+	totpMaxFailedAttempts = 5
+	// totpLockoutWindowSeconds is both the sliding window over which
+	// failures accumulate and the duration verification stays locked once
+	// the threshold is hit (15 minutes).
+	totpLockoutWindowSeconds = 15 * 60
+	// totpLockoutCachePrefix namespaces the per-user failed-attempt counter
+	// in the memory store. This is transient state, deliberately kept out
+	// of the DB schema so no storage provider needs a new column.
+	totpLockoutCachePrefix = "totp_failed_attempts:"
 )
 
 // VerifyOTP verifies a one-time passcode (email/SMS OTP, TOTP, or recovery
@@ -72,24 +90,47 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 
 	// Verify OTP based on TOPT or OTP
 	if refs.BoolValue(params.IsTotp) {
-		status, err := p.AuthenticatorProvider.Validate(ctx, params.Otp, user.ID)
+		// Per-user lockout: reject before validating once too many recent
+		// attempts have failed, so a correct code offered during the lock
+		// window is still refused. GetCache returns ("", nil) when absent.
+		lockKey := totpLockoutCachePrefix + user.ID
+		attempts := 0
+		if v, cErr := p.MemoryStoreProvider.GetCache(lockKey); cErr == nil && v != "" {
+			attempts, _ = strconv.Atoi(v)
+		}
+		if attempts >= totpMaxFailedAttempts {
+			log.Debug().Int("attempts", attempts).Msg("TOTP verification locked: too many failed attempts")
+			return nil, nil, TooManyRequests(`too many failed attempts, please try again later`)
+		}
+
+		verified, err := p.AuthenticatorProvider.Validate(ctx, params.Otp, user.ID)
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to validate passcode")
 			return nil, nil, errors.New("error while validating passcode")
 		}
-		if !status {
-			log.Debug().Msg("Failed to verify otp request: Incorrect value")
-			log.Info().Msg("Checking if otp is recovery code")
-			// Check if otp is recovery code
-			isValidRecoveryCode, err := p.AuthenticatorProvider.ValidateRecoveryCode(ctx, params.Otp, user.ID)
+		if !verified {
+			log.Info().Msg("TOTP passcode invalid, checking if it is a recovery code")
+			// ValidateRecoveryCode returns (false, nil) for an invalid or
+			// already-used code; a non-nil error is a storage fault and must
+			// not be counted as a user failure (avoids self-lockout on outage).
+			verified, err = p.AuthenticatorProvider.ValidateRecoveryCode(ctx, params.Otp, user.ID)
 			if err != nil {
 				log.Debug().Err(err).Msg("Failed to validate recovery code")
 				return nil, nil, errors.New("error while validating recovery code")
 			}
-			if !isValidRecoveryCode {
-				log.Debug().Msg("Failed to verify otp request: Incorrect value")
-				return nil, nil, InvalidArgument(`invalid otp`)
-			}
+		}
+		if !verified {
+			// Record the failed attempt. SetCache resets the TTL each time,
+			// so the window slides with activity; once the threshold is hit
+			// the early return above stops further increments, fixing the
+			// lock at one full window.
+			_ = p.MemoryStoreProvider.SetCache(lockKey, strconv.Itoa(attempts+1), totpLockoutWindowSeconds)
+			log.Debug().Msg("Failed to verify otp request: Incorrect value")
+			return nil, nil, InvalidArgument(`invalid otp`)
+		}
+		// Successful verification clears the failed-attempt counter for this user.
+		if cErr := p.MemoryStoreProvider.DeleteCacheByPrefix(lockKey); cErr != nil {
+			log.Debug().Err(cErr).Msg("Failed to reset totp failed-attempt counter")
 		}
 	} else {
 		var otp *schemas.OTP

--- a/internal/service/verify_otp.go
+++ b/internal/service/verify_otp.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"strconv"
 	"strings"
 	"time"
 
@@ -88,18 +87,42 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 		return nil, nil, FailedPrecondition("invalid verification request")
 	}
 
+	// Validate the MFA session before doing ANY code/lockout-counter work.
+	// This must run first: the TOTP lockout counter below is keyed by
+	// user.ID alone, resolvable from a bare email with no proof the caller
+	// ever completed the password step. Checking the session first means an
+	// attacker who only knows a victim's email - with no valid session - is
+	// rejected before they can touch (and so exhaust) the victim's lockout
+	// counter, closing an unauthenticated account-lockout DoS.
+	if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
+		log.Debug().Err(err).Msg("Failed to get mfa session")
+		return nil, nil, Unauthenticated(`invalid session`)
+	}
+
 	// Verify OTP based on TOPT or OTP
 	if refs.BoolValue(params.IsTotp) {
-		// Per-user lockout: reject before validating once too many recent
-		// attempts have failed, so a correct code offered during the lock
-		// window is still refused. GetCache returns ("", nil) when absent.
+		// Per-user lockout: atomically reserve this attempt's slot BEFORE
+		// validating, then check whether it exceeded the budget. This is
+		// deliberately increment-then-check rather than check-then-increment:
+		// under concurrent requests, IncrementCache still hands out strictly
+		// increasing, unique counts (1,2,3,...), so at most
+		// totpMaxFailedAttempts requests can ever reach validation in a
+		// window no matter how many arrive simultaneously. A
+		// check-then-increment design (read count, compare, validate, then
+		// write count+1) lets arbitrarily many concurrent requests all read
+		// the same pre-increment count and all pass the check, defeating the
+		// lockout entirely - parallelizing the exact brute-force attack this
+		// exists to stop.
 		lockKey := totpLockoutCachePrefix + user.ID
-		attempts := 0
-		if v, cErr := p.MemoryStoreProvider.GetCache(lockKey); cErr == nil && v != "" {
-			attempts, _ = strconv.Atoi(v)
-		}
-		if attempts >= totpMaxFailedAttempts {
-			log.Debug().Int("attempts", attempts).Msg("TOTP verification locked: too many failed attempts")
+		attempts, incErr := p.MemoryStoreProvider.IncrementCache(lockKey, totpLockoutWindowSeconds)
+		if incErr != nil {
+			// A memory-store fault must not be counted as a user failure or
+			// block a legitimate user (avoids self-lockout on outage) - same
+			// fail-open philosophy already used below for
+			// ValidateRecoveryCode's storage-fault case.
+			log.Debug().Err(incErr).Msg("Failed to increment totp failed-attempt counter")
+		} else if attempts > totpMaxFailedAttempts {
+			log.Debug().Int64("attempts", attempts).Msg("TOTP verification locked: too many failed attempts")
 			return nil, nil, TooManyRequests(`too many failed attempts, please try again later`)
 		}
 
@@ -120,11 +143,6 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 			}
 		}
 		if !verified {
-			// Record the failed attempt. SetCache resets the TTL each time,
-			// so the window slides with activity; once the threshold is hit
-			// the early return above stops further increments, fixing the
-			// lock at one full window.
-			_ = p.MemoryStoreProvider.SetCache(lockKey, strconv.Itoa(attempts+1), totpLockoutWindowSeconds)
 			log.Debug().Msg("Failed to verify otp request: Incorrect value")
 			return nil, nil, InvalidArgument(`invalid otp`)
 		}
@@ -165,11 +183,6 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 		if err := p.StorageProvider.DeleteOTP(ctx, otp); err != nil {
 			log.Debug().Err(err).Msg("Failed to delete otp")
 		}
-	}
-
-	if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
-		log.Debug().Err(err).Msg("Failed to get mfa session")
-		return nil, nil, Unauthenticated(`invalid session`)
 	}
 
 	isSignUp := false


### PR DESCRIPTION
## Summary

Closes two confirmed gaps in the TOTP/MFA path (secrets are already AES-256-GCM encrypted at rest; these harden the remaining two).

### 1. Per-user verify_otp lockout (brute-force)
The only guard on failed OTP verification was the global per-IP rate limiter, so a single account could be brute-forced by spreading guesses across many IPs (or slowly under the limiter's radar). Add a per-user failed-attempt counter in the existing memory store (`SetCache`/`GetCache`/`DeleteCacheByPrefix`) — transient KV state, **no DB schema column**, so none of the 13+ storage providers change.

- 5 failed attempts within a 15-minute window locks TOTP/recovery verification for that user for 15 minutes.
- While locked, even a correct code is refused with a **distinct** error (`too many failed attempts...`, mapped to gRPC `ResourceExhausted` / HTTP 429) so a legitimate user understands why they're blocked — not the generic `invalid otp`.
- A successful verification resets the counter.
- A storage fault during recovery-code validation is **not** counted as a user failure (avoids self-lockout during an outage).

### 2. Recovery codes hashed at rest
Recovery codes were generated as random UUIDs but stored as **plaintext** in the `Authenticator.RecoveryCodes` JSON map. Now only their **SHA-256** hashes are persisted (these are already high-entropy — a slow hash like bcrypt/argon2 would be wasted cost).

- `Generate()` still returns the plaintext codes to the caller once for enrollment display (unchanged UX); only hashes are written.
- `ValidateRecoveryCode()` hashes the input and matches against stored hashes, marking the entry consumed exactly as before.
- **Lazy migration:** already-enrolled users with plaintext codes still validate once via a plaintext fallback (a stored key that isn't a 64-char hex hash is compared directly), mirroring the existing TOTP-secret migration in `internal/crypto/totp.go`. New enrollments always write hashes.

## Out of scope (deliberately)
Trusted-device / "remember this device" and per-client/per-org MFA policy — these need separate product design.

## Tests
- `internal/crypto/totp_test.go` — hash helpers (determinism, format detection).
- `internal/integration_tests/totp_recovery_codes_at_rest_test.go` — plaintext never persisted; hashed codes validate once; legacy plaintext codes validate once via fallback.
- `internal/integration_tests/verify_otp_totp_lockout_test.go` — 5 failures lock; a correct code is then refused with the lockout error; a success resets the counter.
- `make test-sqlite` green (30 packages, 0 failures); `make fmt-go` clean.