### PR TITLE
feat: org-scoped admin (Phase 1 of multi-tenant SSO)

### DIFF
--- a/internal/constants/org_roles.go
+++ b/internal/constants/org_roles.go
@@ -1,0 +1,14 @@
+package constants
+
+// OrgRoleAdmin is the reserved, namespaced OrgMembership role that grants a user
+// org-scoped admin rights (manage their own org's SSO/SCIM/domain config and
+// members) without being a platform super-admin.
+//
+// It is intentionally the namespaced string "authorizer:org_admin", NOT the bare
+// "admin": app-defined org roles are free-form and commonly include "admin" or
+// "owner" for the app's own RBAC meaning, so reserving the bare string would
+// silently hand SSO/SCIM control to every member a tenant already made an
+// app-level admin. The ":" namespace cannot collide with a normal app role.
+// Existing bare-"admin" memberships are NEVER auto-promoted — this role must be
+// granted explicitly.
+const OrgRoleAdmin = "authorizer:org_admin"

--- a/internal/integration_tests/org_scoped_admin_test.go
+++ b/internal/integration_tests/org_scoped_admin_test.go
@@ -1,0 +1,301 @@
+package integration_tests
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// genTestCertPEM returns a self-signed X.509 certificate in PEM form, valid
+// input for CreateOrgSAMLConnection's idp_certificate (validateSAMLCertPEM
+// parses it with x509.ParseCertificate).
+func genTestCertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-idp"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// TestOrgScopedAdmin covers the Phase 1 org-scoped-admin authorization matrix:
+// org-admins may manage their own org's SSO/SCIM/members, the confused-deputy
+// (H2) hole is closed, the bare "admin" role is NOT accepted (H1), org
+// create/delete stays super-admin-only, and the last-admin guard holds.
+func TestOrgScopedAdmin(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	// Auth-mode switches operate on the shared gin request headers. requireOrgAdmin
+	// reads the caller identity from this request (admin cookie or bearer token).
+	asSuperAdmin := func() {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Del("Authorization")
+		setAdminCookie(t, ts)
+	}
+	asUser := func(token string) {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Set("Authorization", "Bearer "+token)
+	}
+	asAnon := func() {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Del("Authorization")
+	}
+
+	// signupUser creates a fresh verified user and returns (id, accessToken).
+	signupUser := func() (string, string) {
+		asAnon()
+		email := "org_admin_" + uuid.NewString() + "@authorizer.test"
+		password := "Password@123"
+		res, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+			Email:           &email,
+			Password:        password,
+			ConfirmPassword: password,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res.User)
+		require.NotNil(t, res.AccessToken)
+		require.NotEmpty(t, *res.AccessToken)
+		return res.User.ID, *res.AccessToken
+	}
+
+	createOrg := func(prefix string) string {
+		asSuperAdmin()
+		org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: prefix + "-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		return org.ID
+	}
+
+	addMember := func(orgID, userID string, roles []string) {
+		asSuperAdmin()
+		_, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  orgID,
+			UserID: userID,
+			Roles:  roles,
+		})
+		require.NoError(t, err)
+	}
+
+	createOIDCConn := func(orgID string) string {
+		asSuperAdmin()
+		conn, err := ts.GraphQLProvider.CreateOrgOidcConnection(ctx, &model.CreateOrgOIDCConnectionRequest{
+			OrgID:        orgID,
+			Name:         "conn-" + uuid.NewString(),
+			IssuerURL:    "https://idp-" + uuid.NewString() + ".example.com",
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+		})
+		require.NoError(t, err)
+		return conn.ID
+	}
+
+	t.Run("org-admin manages its own org's OIDC/SAML/SCIM", func(t *testing.T) {
+		orgID := createOrg("acme")
+		adminID, adminTok := signupUser()
+		addMember(orgID, adminID, []string{constants.OrgRoleAdmin})
+
+		asUser(adminTok)
+
+		// OIDC: create, get, update, delete.
+		oidc, err := ts.GraphQLProvider.CreateOrgOidcConnection(ctx, &model.CreateOrgOIDCConnectionRequest{
+			OrgID:        orgID,
+			Name:         "oidc-" + uuid.NewString(),
+			IssuerURL:    "https://oidc-" + uuid.NewString() + ".example.com",
+			ClientID:     "cid",
+			ClientSecret: "secret",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, oidc)
+
+		got, err := ts.GraphQLProvider.OrgOidcConnection(ctx, &model.OrgOIDCConnectionRequest{ID: refs.NewStringRef(oidc.ID)})
+		require.NoError(t, err)
+		require.Equal(t, orgID, got.OrgID)
+
+		_, err = ts.GraphQLProvider.UpdateOrgOidcConnection(ctx, &model.UpdateOrgOIDCConnectionRequest{
+			ID:   oidc.ID,
+			Name: refs.NewStringRef("renamed"),
+		})
+		require.NoError(t, err)
+
+		_, err = ts.GraphQLProvider.DeleteOrgOidcConnection(ctx, &model.OrgOIDCConnectionRequest{ID: refs.NewStringRef(oidc.ID)})
+		require.NoError(t, err)
+
+		// SAML: create then delete.
+		saml, err := ts.GraphQLProvider.CreateOrgSamlConnection(ctx, &model.CreateOrgSAMLConnectionRequest{
+			OrgID:          orgID,
+			Name:           "saml-" + uuid.NewString(),
+			IdpEntityID:    "https://saml-" + uuid.NewString() + ".example.com",
+			IdpSsoURL:      "https://saml-sso.example.com/sso",
+			IdpCertificate: genTestCertPEM(t),
+		})
+		require.NoError(t, err)
+		_, err = ts.GraphQLProvider.DeleteOrgSamlConnection(ctx, &model.OrgSAMLConnectionRequest{ID: refs.NewStringRef(saml.ID)})
+		require.NoError(t, err)
+
+		// SCIM: create, rotate, delete.
+		scim, err := ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.NoError(t, err)
+		require.NotEmpty(t, scim.Token)
+		_, err = ts.GraphQLProvider.RotateScimToken(ctx, &model.ScimEndpointRequest{OrgID: orgID})
+		require.NoError(t, err)
+		_, err = ts.GraphQLProvider.DeleteScimEndpoint(ctx, &model.ScimEndpointRequest{OrgID: orgID})
+		require.NoError(t, err)
+	})
+
+	t.Run("confused deputy: org-A admin cannot mutate org-B's connection", func(t *testing.T) {
+		orgA := createOrg("orga")
+		orgB := createOrg("orgb")
+		adminID, adminTok := signupUser()
+		addMember(orgA, adminID, []string{constants.OrgRoleAdmin})
+		connB := createOIDCConn(orgB)
+
+		asUser(adminTok)
+
+		// Update by id only — auth must key on the loaded row's OrgID (orgB), deny.
+		_, err := ts.GraphQLProvider.UpdateOrgOidcConnection(ctx, &model.UpdateOrgOIDCConnectionRequest{
+			ID:   connB,
+			Name: refs.NewStringRef("hijacked"),
+		})
+		require.Error(t, err)
+
+		// Delete with {id: orgB-conn, org_id: orgA} — must not pass by claiming orgA.
+		_, err = ts.GraphQLProvider.DeleteOrgOidcConnection(ctx, &model.OrgOIDCConnectionRequest{
+			ID:    refs.NewStringRef(connB),
+			OrgID: refs.NewStringRef(orgA),
+		})
+		require.Error(t, err)
+
+		// Get with the same mismatched pair — deny.
+		_, err = ts.GraphQLProvider.OrgOidcConnection(ctx, &model.OrgOIDCConnectionRequest{
+			ID:    refs.NewStringRef(connB),
+			OrgID: refs.NewStringRef(orgA),
+		})
+		require.Error(t, err)
+
+		// The connection in orgB must still be intact (mutation did not land).
+		asSuperAdmin()
+		still, err := ts.GraphQLProvider.OrgOidcConnection(ctx, &model.OrgOIDCConnectionRequest{ID: refs.NewStringRef(connB)})
+		require.NoError(t, err)
+		require.Equal(t, orgB, still.OrgID)
+	})
+
+	t.Run("bare admin role is not accepted (H1)", func(t *testing.T) {
+		orgID := createOrg("bare")
+		userID, tok := signupUser()
+		addMember(orgID, userID, []string{"admin", "billing"}) // app-level bare admin
+
+		asUser(tok)
+		_, err := ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.Error(t, err)
+		_, err = ts.GraphQLProvider.CreateOrgOidcConnection(ctx, &model.CreateOrgOIDCConnectionRequest{
+			OrgID:        orgID,
+			Name:         "x",
+			IssuerURL:    "https://x-" + uuid.NewString() + ".example.com",
+			ClientID:     "c",
+			ClientSecret: "s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("plain member and non-member are denied", func(t *testing.T) {
+		orgID := createOrg("plain")
+		memberID, memberTok := signupUser()
+		addMember(orgID, memberID, []string{"billing"})
+		_, outsiderTok := signupUser()
+
+		asUser(memberTok)
+		_, err := ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.Error(t, err)
+
+		asUser(outsiderTok)
+		_, err = ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.Error(t, err)
+
+		asAnon()
+		_, err = ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.Error(t, err)
+	})
+
+	t.Run("super-admin retains full access (regression)", func(t *testing.T) {
+		orgID := createOrg("super")
+		asSuperAdmin()
+		scim, err := ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+		require.NoError(t, err)
+		require.NotEmpty(t, scim.Token)
+		conn := createOIDCConn(orgID) // helper runs as super-admin
+		require.NotEmpty(t, conn)
+	})
+
+	t.Run("org-admin cannot create or delete the organization itself", func(t *testing.T) {
+		orgID := createOrg("tenant")
+		adminID, adminTok := signupUser()
+		addMember(orgID, adminID, []string{constants.OrgRoleAdmin})
+
+		asUser(adminTok)
+		_, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{Name: "new-" + uuid.NewString()})
+		require.Error(t, err)
+		_, err = ts.GraphQLProvider.DeleteOrganization(ctx, &model.OrganizationRequest{ID: orgID})
+		require.Error(t, err)
+	})
+
+	t.Run("last-admin guard", func(t *testing.T) {
+		orgID := createOrg("lastadmin")
+		admin1ID, admin1Tok := signupUser()
+		addMember(orgID, admin1ID, []string{constants.OrgRoleAdmin})
+
+		// Removing the only org_admin is refused for a non-super-admin caller.
+		asUser(admin1Tok)
+		_, err := ts.GraphQLProvider.RemoveOrgMember(ctx, &model.RemoveOrgMemberRequest{
+			OrgID:  orgID,
+			UserID: admin1ID,
+		})
+		require.Error(t, err)
+
+		// Promote a second org_admin, then removing a non-last admin is allowed.
+		admin2ID, _ := signupUser()
+		asUser(admin1Tok)
+		_, err = ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID:  orgID,
+			UserID: admin2ID,
+			Roles:  []string{constants.OrgRoleAdmin},
+		})
+		require.NoError(t, err, "org-admin may grant org_admin to another member of its own org")
+
+		asUser(admin1Tok)
+		_, err = ts.GraphQLProvider.RemoveOrgMember(ctx, &model.RemoveOrgMemberRequest{
+			OrgID:  orgID,
+			UserID: admin2ID,
+		})
+		require.NoError(t, err)
+
+		// A super-admin is exempt: may remove the now-last admin.
+		asSuperAdmin()
+		_, err = ts.GraphQLProvider.RemoveOrgMember(ctx, &model.RemoveOrgMemberRequest{
+			OrgID:  orgID,
+			UserID: admin1ID,
+		})
+		require.NoError(t, err)
+	})
+}

--- a/internal/service/admin_org_oidc.go
+++ b/internal/service/admin_org_oidc.go
@@ -145,11 +145,11 @@ func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	// Guard: this op only edits sso_oidc rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
-		return nil, nil, fmt.Errorf("not an OIDC connection")
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("not an OIDC connection"))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -236,7 +236,7 @@ func (p *provider) DeleteOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -268,7 +268,7 @@ func (p *provider) OrgOIDCConnection(ctx context.Context, meta RequestMetadata, 
 	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err

--- a/internal/service/admin_org_oidc.go
+++ b/internal/service/admin_org_oidc.go
@@ -51,13 +51,11 @@ func validateSSOIssuerURL(raw string) error {
 }
 
 // CreateOrgOIDCConnection registers a per-org upstream OIDC IdP (kind=sso_oidc).
-// Requires super-admin auth.
-//
-// ponytail: super-admin gated for now — an org-scoped admin permission model
-// (design H1) is a separate PR; mirror requireSuperAdmin like the other org ops.
+// Gated on the org being written (params.OrgID): a super-admin or an org-admin
+// of that org. See constants.OrgRoleAdmin.
 func (p *provider) CreateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "CreateOrgOIDCConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 
@@ -139,13 +137,11 @@ func (p *provider) CreateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 
 // UpdateOrgOIDCConnection mutates only the fields present in params (load-then-
 // mutate). Kind and OrgID are immutable. Supplying client_secret rotates it.
-// Requires super-admin auth.
+// Gated on the loaded row's OrgID (super-admin or that org's org-admin): the
+// connection is loaded by id FIRST so authorization keys on its real OrgID, not
+// on any caller-supplied org id (design H2, confused-deputy fix).
 func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "UpdateOrgOIDCConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
-
 	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
@@ -154,6 +150,9 @@ func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	// Guard: this op only edits sso_oidc rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
 		return nil, nil, fmt.Errorf("not an OIDC connection")
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
 	}
 
 	if params.Name != nil {
@@ -228,15 +227,21 @@ func (p *provider) resolveOrgOIDCConnection(ctx context.Context, id, orgID *stri
 	}
 }
 
-// DeleteOrgOIDCConnection removes an org's OIDC connection. Requires super-admin.
+// DeleteOrgOIDCConnection removes an org's OIDC connection. Gated on the loaded
+// row's OrgID (super-admin or that org's org-admin): resolved FIRST so
+// authorization keys on its real OrgID, then a caller-supplied org_id that names
+// a different org is rejected (design H2, confused-deputy fix).
 func (p *provider) DeleteOrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.Response, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "DeleteOrgOIDCConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
 	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
+		return nil, nil, err
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := rejectOrgIDMismatch(params.OrgID, issuer.OrgID); err != nil {
 		return nil, nil, err
 	}
 	if err := p.StorageProvider.DeleteTrustedIssuer(ctx, issuer); err != nil {
@@ -255,16 +260,20 @@ func (p *provider) DeleteOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	return &model.Response{Message: "OIDC connection deleted"}, nil, nil
 }
 
-// OrgOIDCConnection fetches an org's OIDC connection by id or org_id. Requires
-// super-admin auth. The secret is never projected.
+// OrgOIDCConnection fetches an org's OIDC connection by id or org_id. Gated on
+// the loaded row's OrgID (super-admin or that org's org-admin, design H2). The
+// secret is never projected.
 func (p *provider) OrgOIDCConnection(ctx context.Context, meta RequestMetadata, params *model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "OrgOIDCConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
 	issuer, err := p.resolveOrgOIDCConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve OIDC connection")
+		return nil, nil, err
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := rejectOrgIDMismatch(params.OrgID, issuer.OrgID); err != nil {
 		return nil, nil, err
 	}
 	return asAPIOrgOIDCConnection(issuer), nil, nil

--- a/internal/service/admin_org_saml.go
+++ b/internal/service/admin_org_saml.go
@@ -78,13 +78,12 @@ func validateSAMLAttributeMapping(raw string) error {
 }
 
 // CreateOrgSAMLConnection registers a per-org upstream SAML IdP (kind=sso_saml).
-// Requires super-admin auth.
-//
-// ponytail: super-admin gated for now — an org-scoped admin permission model
-// (design H1) is a separate PR; mirror requireSuperAdmin like the OIDC op.
+// Gated on the org being written (params.OrgID): a super-admin or an
+// org-admin of that org. See constants.OrgRoleAdmin — the bare "admin" role is
+// not accepted and existing bare-admin memberships are never auto-promoted.
 func (p *provider) CreateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "CreateOrgSAMLConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 
@@ -194,13 +193,11 @@ func validateOptionalSAMLFields(spEntityID, acsURL, attrMap *string) (*string, *
 
 // UpdateOrgSAMLConnection mutates only the fields present in params (load-then-
 // mutate). Kind and OrgID are immutable. Supplying idp_certificate replaces it.
-// Requires super-admin auth.
+// Gated on the loaded row's OrgID (super-admin or that org's org-admin): the
+// connection is loaded by id FIRST so authorization keys on its real OrgID, not
+// on any caller-supplied org id (design H2, confused-deputy fix).
 func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "UpdateOrgSAMLConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
-
 	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
@@ -209,6 +206,9 @@ func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	// Guard: this op only edits sso_saml rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
 		return nil, nil, fmt.Errorf("not a SAML connection")
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
 	}
 
 	if params.Name != nil {
@@ -317,15 +317,21 @@ func (p *provider) resolveOrgSAMLConnection(ctx context.Context, id, orgID *stri
 	}
 }
 
-// DeleteOrgSAMLConnection removes an org's SAML connection. Requires super-admin.
+// DeleteOrgSAMLConnection removes an org's SAML connection. Gated on the loaded
+// row's OrgID (super-admin or that org's org-admin): the connection is resolved
+// FIRST so authorization keys on its real OrgID, then a caller-supplied org_id
+// that names a different org is rejected (design H2, confused-deputy fix).
 func (p *provider) DeleteOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.Response, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "DeleteOrgSAMLConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
 	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve SAML connection")
+		return nil, nil, err
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := rejectOrgIDMismatch(params.OrgID, issuer.OrgID); err != nil {
 		return nil, nil, err
 	}
 	if err := p.StorageProvider.DeleteTrustedIssuer(ctx, issuer); err != nil {
@@ -344,16 +350,20 @@ func (p *provider) DeleteOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	return &model.Response{Message: "SAML connection deleted"}, nil, nil
 }
 
-// OrgSAMLConnection fetches an org's SAML connection by id or org_id. Requires
-// super-admin auth. The IdP certificate is never projected.
+// OrgSAMLConnection fetches an org's SAML connection by id or org_id. Gated on
+// the loaded row's OrgID (super-admin or that org's org-admin, design H2). The
+// IdP certificate is never projected.
 func (p *provider) OrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "OrgSAMLConnection").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
-		return nil, nil, err
-	}
 	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve SAML connection")
+		return nil, nil, err
+	}
+	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := rejectOrgIDMismatch(params.OrgID, issuer.OrgID); err != nil {
 		return nil, nil, err
 	}
 	return asAPIOrgSAMLConnection(issuer), nil, nil

--- a/internal/service/admin_org_saml.go
+++ b/internal/service/admin_org_saml.go
@@ -201,11 +201,11 @@ func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed GetTrustedIssuerByID")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	// Guard: this op only edits sso_saml rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
-		return nil, nil, fmt.Errorf("not a SAML connection")
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("not a SAML connection"))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -326,7 +326,7 @@ func (p *provider) DeleteOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve SAML connection")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -358,7 +358,7 @@ func (p *provider) OrgSAMLConnection(ctx context.Context, meta RequestMetadata, 
 	issuer, err := p.resolveOrgSAMLConnection(ctx, params.ID, params.OrgID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to resolve SAML connection")
-		return nil, nil, err
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, err)
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -370,6 +370,15 @@ func orgMembershipHasRole(m *schemas.OrgMembership, role string) bool {
 // constants.OrgRoleAdmin whose user id is not excludeUserID. It backs the
 // last-admin guard, so it short-circuits as soon as a second admin is found and
 // pages through all members otherwise.
+//
+// KNOWN LIMITATION (check-then-delete, non-atomic): two concurrent
+// RemoveOrgMember calls each removing a *different* one of exactly two admins
+// can both observe "another admin exists" and both proceed, leaving the org
+// with zero admins. This is self-inflicted, single-tenant, and always
+// recoverable by a super-admin (the designed recovery path), so it is accepted
+// for v1. A fully atomic guard would need a storage-layer conditional delete /
+// count-in-transaction, which 3 of the 6 NoSQL providers cannot express
+// uniformly; not worth it for a contained, recoverable race.
 func (p *provider) orgHasAdminOtherThan(ctx context.Context, orgID, excludeUserID string) (bool, error) {
 	const pageLimit = int64(100)
 	offset := int64(0)

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -205,10 +205,12 @@ func (p *provider) Organizations(ctx context.Context, meta RequestMetadata, para
 
 // AddOrgMember adds a user to an organization with a set of per-org roles.
 // The organization and user must exist and the (org, user) pair must be unique.
-// Requires super-admin auth.
+// Gated on params.OrgID: super-admin or an org-admin of that org. An org-admin
+// may grant constants.OrgRoleAdmin to another member of their own org
+// (delegated administration, bounded to their org — design invariant 5).
 func (p *provider) AddOrgMember(ctx context.Context, meta RequestMetadata, params *model.AddOrgMemberRequest) (*model.OrgMember, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "AddOrgMember").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 
@@ -262,10 +264,15 @@ func (p *provider) AddOrgMember(ctx context.Context, meta RequestMetadata, param
 	return membership.AsAPIOrgMember(), nil, nil
 }
 
-// RemoveOrgMember removes a user from an organization. Requires super-admin auth.
+// RemoveOrgMember removes a user from an organization. Gated on params.OrgID:
+// super-admin or an org-admin of that org.
+//
+// Last-admin guard (design invariant 5): a NON-super-admin caller cannot remove
+// the org's final constants.OrgRoleAdmin holder — that would lock the org out
+// of self-service. A super-admin is exempt (can always recover the org).
 func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, params *model.RemoveOrgMemberRequest) (*model.Response, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "RemoveOrgMember").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 
@@ -282,6 +289,22 @@ func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, pa
 		log.Debug().Err(err).Msg("membership not found")
 		p.logOrgMemberRemoveFailure(meta, orgID)
 		return nil, nil, fmt.Errorf("membership not found")
+	}
+
+	// Last-admin guard. Skip for super-admins (recovery escape hatch).
+	if p.requireSuperAdmin(ctx, meta) != nil && orgMembershipHasRole(membership, constants.OrgRoleAdmin) {
+		hasOther, err := p.orgHasAdminOtherThan(ctx, orgID, userID)
+		if err != nil {
+			// Fail closed: if we cannot confirm another admin exists, keep this one.
+			log.Debug().Err(err).Msg("failed to verify remaining org admins")
+			p.logOrgMemberRemoveFailure(meta, orgID)
+			return nil, nil, fmt.Errorf("could not verify remaining organization admins")
+		}
+		if !hasOther {
+			log.Debug().Msg("refusing to remove the last org admin")
+			p.logOrgMemberRemoveFailure(meta, orgID)
+			return nil, nil, fmt.Errorf("cannot remove the last %s of the organization", constants.OrgRoleAdmin)
+		}
 	}
 
 	if err := p.StorageProvider.DeleteOrgMembership(ctx, membership); err != nil {
@@ -304,11 +327,11 @@ func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, pa
 	}, nil, nil
 }
 
-// OrgMembers returns a paginated list of an organization's members. Requires
-// super-admin auth.
+// OrgMembers returns a paginated list of an organization's members. Gated on
+// params.OrgID: super-admin or an org-admin of that org (never another org's).
 func (p *provider) OrgMembers(ctx context.Context, meta RequestMetadata, params *model.ListOrgMembersRequest) (*model.OrgMembers, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "OrgMembers").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 
@@ -331,6 +354,44 @@ func (p *provider) OrgMembers(ctx context.Context, meta RequestMetadata, params 
 		Pagination: pagination,
 		OrgMembers: res,
 	}, nil, nil
+}
+
+// orgMembershipHasRole reports whether the membership carries role.
+func orgMembershipHasRole(m *schemas.OrgMembership, role string) bool {
+	for _, r := range m.ParsedRoles() {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
+// orgHasAdminOtherThan reports whether orgID has at least one member holding
+// constants.OrgRoleAdmin whose user id is not excludeUserID. It backs the
+// last-admin guard, so it short-circuits as soon as a second admin is found and
+// pages through all members otherwise.
+func (p *provider) orgHasAdminOtherThan(ctx context.Context, orgID, excludeUserID string) (bool, error) {
+	const pageLimit = int64(100)
+	offset := int64(0)
+	for {
+		page := &model.Pagination{Limit: pageLimit, Offset: offset, Page: offset/pageLimit + 1}
+		members, pg, err := p.StorageProvider.ListOrgMembershipsByOrg(ctx, orgID, page)
+		if err != nil {
+			return false, err
+		}
+		for _, m := range members {
+			if m.UserID == excludeUserID {
+				continue
+			}
+			if orgMembershipHasRole(m, constants.OrgRoleAdmin) {
+				return true, nil
+			}
+		}
+		offset += int64(len(members))
+		if len(members) < int(pageLimit) || pg == nil || offset >= pg.Total {
+			return false, nil
+		}
+	}
 }
 
 // logOrgFailure records a failed organization admin operation.

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -167,6 +167,14 @@ func (p *provider) requireOrgAdmin(ctx context.Context, meta RequestMetadata, or
 		return Unauthenticated("unauthorized")
 	}
 
+	// Defense in depth: machine (client_credentials) tokens are never org
+	// members. They are already rejected implicitly by the membership lookup
+	// (their sub is a client id, not a user id), but reject them explicitly so
+	// the intent survives any future change to how memberships are minted.
+	if tokenData.LoginMethod == constants.AuthRecipeMethodServiceAccount {
+		return Unauthenticated("unauthorized")
+	}
+
 	membership, err := p.StorageProvider.GetOrgMembership(ctx, orgID, tokenData.UserID)
 	if err != nil || membership == nil {
 		return Unauthenticated("unauthorized")
@@ -184,6 +192,18 @@ func (p *provider) requireOrgAdmin(ctx context.Context, meta RequestMetadata, or
 // ALSO supplied an org_id that names a different org, deny: they are trying to
 // act on another org's resource under their own org's authority. A nil/empty
 // org_id (the common id-only call) is fine.
+// maskNonSuperAdminError collapses a resource-resolution error (not-found,
+// wrong-kind) into a uniform Unauthenticated for non-super-admin callers, so a
+// tenant admin cannot use these ops as a cross-org existence/kind oracle
+// (CWE-204): probing an arbitrary id must not reveal whether it exists or its
+// kind in another org. Super-admins still get the precise error.
+func (p *provider) maskNonSuperAdminError(ctx context.Context, meta RequestMetadata, err error) error {
+	if p.requireSuperAdmin(ctx, meta) == nil {
+		return err
+	}
+	return Unauthenticated("unauthorized")
+}
+
 func rejectOrgIDMismatch(paramOrgID *string, resourceOrgID string) error {
 	if paramOrgID != nil {
 		if v := strings.TrimSpace(*paramOrgID); v != "" && v != resourceOrgID {

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/authorizerdev/authorizer/internal/authctx"
+	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 )
 
@@ -128,6 +130,65 @@ func (p *provider) requireSuperAdmin(ctx context.Context, meta RequestMetadata) 
 	gc := &gin.Context{Request: meta.Request}
 	if !p.TokenProvider.IsSuperAdmin(gc) {
 		return Unauthenticated("unauthorized")
+	}
+	return nil
+}
+
+// requireOrgAdmin enforces org-scoped admin auth for a single organization. It
+// passes when EITHER the caller is a platform super-admin (the unchanged escape
+// hatch, reusing requireSuperAdmin's exact positive path), OR the caller is an
+// authenticated user who holds the reserved namespaced role
+// constants.OrgRoleAdmin ("authorizer:org_admin") in an OrgMembership of orgID.
+//
+// It FAILS CLOSED: any error resolving the caller or their membership, a missing
+// membership, or a membership lacking the reserved role all deny. The bare
+// "admin" role is NOT accepted (see constants.OrgRoleAdmin) — only the
+// namespaced role grants org-scoped admin rights.
+//
+// orgID is the tenant-isolation boundary and MUST be sourced correctly by the
+// caller (design H2): for create/list ops it is the org being written
+// (params.OrgID); for update/delete/get ops it is the OrgID of the target
+// resource AFTER it has been loaded by id — never a caller-supplied org id
+// checked before the load. Returns Unauthenticated to match requireSuperAdmin's
+// error shape and to avoid leaking whether the target resource exists.
+func (p *provider) requireOrgAdmin(ctx context.Context, meta RequestMetadata, orgID string) error {
+	// Super-admin escape hatch — identical positive path to requireSuperAdmin.
+	if p.requireSuperAdmin(ctx, meta) == nil {
+		return nil
+	}
+
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
+		return Unauthenticated("unauthorized")
+	}
+
+	tokenData, err := p.callerTokenData(ctx, meta)
+	if err != nil || tokenData == nil || tokenData.UserID == "" {
+		return Unauthenticated("unauthorized")
+	}
+
+	membership, err := p.StorageProvider.GetOrgMembership(ctx, orgID, tokenData.UserID)
+	if err != nil || membership == nil {
+		return Unauthenticated("unauthorized")
+	}
+	for _, role := range membership.ParsedRoles() {
+		if role == constants.OrgRoleAdmin {
+			return nil
+		}
+	}
+	return Unauthenticated("unauthorized")
+}
+
+// rejectOrgIDMismatch is the confused-deputy guard for the id-or-org_id
+// resolvers (design H2). Once a resource has been loaded by id, if the caller
+// ALSO supplied an org_id that names a different org, deny: they are trying to
+// act on another org's resource under their own org's authority. A nil/empty
+// org_id (the common id-only call) is fine.
+func rejectOrgIDMismatch(paramOrgID *string, resourceOrgID string) error {
+	if paramOrgID != nil {
+		if v := strings.TrimSpace(*paramOrgID); v != "" && v != resourceOrgID {
+			return Unauthenticated("unauthorized")
+		}
 	}
 	return nil
 }

--- a/internal/service/admin_scim.go
+++ b/internal/service/admin_scim.go
@@ -16,10 +16,11 @@ import (
 
 // CreateScimEndpoint provisions the per-org inbound SCIM connection and returns
 // its bearer token exactly once (bcrypt-hashed at rest, crypto/rand entropy).
-// One endpoint per org. Requires super-admin auth.
+// One endpoint per org. Gated on params.OrgID: super-admin or that org's
+// org-admin (see constants.OrgRoleAdmin).
 func (p *provider) CreateScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "CreateScimEndpoint").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 	orgID := strings.TrimSpace(params.OrgID)
@@ -75,10 +76,12 @@ func (p *provider) CreateScimEndpoint(ctx context.Context, meta RequestMetadata,
 }
 
 // RotateScimToken mints a fresh bearer token for an org's endpoint, invalidating
-// the previous one, and returns it once. Requires super-admin auth.
+// the previous one, and returns it once. The endpoint is keyed solely by
+// org_id, so gating on params.OrgID (super-admin or that org's org-admin) is the
+// resource's real OrgID — no id-vs-org confused-deputy vector here.
 func (p *provider) RotateScimToken(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "RotateScimToken").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 	orgID := strings.TrimSpace(params.OrgID)
@@ -116,10 +119,11 @@ func (p *provider) RotateScimToken(ctx context.Context, meta RequestMetadata, pa
 	}, nil, nil
 }
 
-// DeleteScimEndpoint removes an org's SCIM connection. Requires super-admin auth.
+// DeleteScimEndpoint removes an org's SCIM connection. Gated on params.OrgID
+// (super-admin or that org's org-admin); org_id is the resource's sole key.
 func (p *provider) DeleteScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.Response, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "DeleteScimEndpoint").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 	orgID := strings.TrimSpace(params.OrgID)
@@ -147,10 +151,10 @@ func (p *provider) DeleteScimEndpoint(ctx context.Context, meta RequestMetadata,
 }
 
 // ScimEndpoint returns an org's SCIM endpoint metadata (never the token).
-// Requires super-admin auth.
+// Gated on params.OrgID (super-admin or that org's org-admin).
 func (p *provider) ScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.ScimEndpoint, *ResponseSideEffects, error) {
 	log := p.Log.With().Str("func", "ScimEndpoint").Logger()
-	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
 		return nil, nil, err
 	}
 	endpoint, err := p.StorageProvider.GetScimEndpointByOrgID(ctx, strings.TrimSpace(params.OrgID))


### PR DESCRIPTION
Phase 1 of the multi-tenant SSO epic (spec: authorizerdev/docs#74). Lets a **tenant admin** manage their own org's SAML/OIDC/SCIM connections and members — previously only the platform super-admin could. Service-layer only; no schema/proto/GraphQL changes.

## What
- New `requireOrgAdmin(ctx, meta, orgID)`: passes for a super-admin (unchanged) OR an authenticated user holding the reserved **namespaced** role `authorizer:org_admin` in that org's membership. Fails closed on every path.
- Applied to org SAML/OIDC/SCIM create/update/delete/get and member add/remove/list. **Org create/delete stays super-admin.**
- **Confused-deputy fix (H2):** update/delete/get load the target resource first and key auth on the *loaded* row's OrgID, then reject a mismatched `params.OrgID` — an org-A admin cannot touch org-B's row by id.
- Reserved role is namespaced (`authorizer:org_admin`), so it can't collide with an app's own `admin` org role; existing bare-`admin` memberships are **not** auto-promoted.
- Last-admin guard prevents an org removing its final admin (super-admin exempt/recovers).

## Security review (security-engineer): sound, no BLOCKER/HIGH
Verified tenant isolation, fail-closed paths, validated-identity source, reserved-role exactness, and that the gRPC interceptor is *more* restrictive (admin service is super-admin-only over gRPC — org-admin ops are reachable via GraphQL). Three LOWs addressed:
- **A** — explicit service_account-token reject in `requireOrgAdmin` (was implicit).
- **C** — collapse not-found/wrong-kind resolve errors to uniform `unauthorized` for non-super-admins (closes a cross-org existence/kind oracle, CWE-204).
- **B** — last-admin guard's check-then-delete race documented as accepted (recoverable by super-admin; atomic fix needs cross-provider transactions 3 NoSQL backends lack).

## Testing
- New `TestOrgScopedAdmin` matrix: own-org allow; confused-deputy deny (+ resource intact); bare-admin deny; plain-member/non-member/anon deny; super-admin regression; org create/delete deny; last-admin guard.
- Full `TEST_DBS=sqlite` integration suite (74s) + service tests pass; build/vet/gofmt/golangci-lint clean.

## Follow-ups (not this PR)
- gRPC exposure of org-admin ops (currently GraphQL-only by interceptor design) — decide if org-admins should reach them over gRPC.
- Stale `// Permissions: authorizer:admin` doc comments in `internal/graphql/*` resolvers.

Phase 2 (verified domains) and Phase 3 (`/app` home realm discovery) follow per the spec.