### PR TITLE
fix: revoke sessions synchronously on password reset

### DIFF
--- a/internal/integration_tests/reset_password_test.go
+++ b/internal/integration_tests/reset_password_test.go
@@ -192,12 +192,19 @@ func TestResetPassword(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resetRes)
 
-		// Session revocation is fire-and-forget; wait for the store to clear.
-		// This is the discriminating assertion: without the fix the session
-		// is never removed and this times out.
-		require.Eventually(t, func() bool { return !hasUserSession() },
-			2*time.Second, 20*time.Millisecond,
-			"all user sessions must be revoked after password reset")
+		// Revocation is now a synchronous call rather than a fire-and-forget
+		// goroutine, so it must have already happened by the time
+		// ResetPassword returns - asserted immediately, no polling needed.
+		// NOTE: this assertion alone does not reliably distinguish the fix
+		// from the old fire-and-forget version - an in-memory single-map-
+		// delete goroutine typically completes before the surrounding code
+		// (LogEvent, metrics, building the return value) finishes anyway, so
+		// the same assertion can pass by luck against the old code too. The
+		// guarantee that matters here comes from the source (no goroutine =
+		// no race, full stop), not from this test's timing sensitivity -
+		// confirmed by reading internal/service/reset_password.go directly
+		// rather than relying on this check alone.
+		assert.False(t, hasUserSession(), "all user sessions must be revoked before password reset returns")
 
 		// End-to-end: the pre-existing refresh token is now rejected.
 		issuer := "http://" + ts.HttpServer.Listener.Addr().String()

--- a/internal/service/reset_password.go
+++ b/internal/service/reset_password.go
@@ -180,9 +180,16 @@ func (p *provider) ResetPassword(ctx context.Context, meta RequestMetadata, para
 		}
 	}
 	// A password reset must terminate every pre-existing session and refresh
-	// token: the whole point is to lock out anyone who held the old
-	// credential. Fire-and-forget, matching UpdateProfile/DeactivateAccount.
-	go func() { _ = p.MemoryStoreProvider.DeleteAllUserSessions(user.ID) }()
+	// token before the caller is told it succeeded: the whole point is to
+	// lock out anyone who held the old credential. Synchronous (not
+	// fire-and-forget like UpdateProfile/DeactivateAccount) to close the
+	// window where an attacker's pre-existing token could still be used
+	// between the response going out and the goroutine actually running.
+	// Logged rather than silently ignored: a memory-store fault here means
+	// old sessions may still be live even though the reset "succeeded".
+	if err := p.MemoryStoreProvider.DeleteAllUserSessions(user.ID); err != nil {
+		log.Debug().Err(err).Msg("Failed to revoke existing sessions after password reset")
+	}
 	p.AuditProvider.LogEvent(audit.Event{
 		Action:   constants.AuditPasswordResetEvent,
 		Protocol: meta.Protocol, ActorID: user.ID,


### PR DESCRIPTION
## Summary
Follow-up to #669 (already merged before this review pass completed). The independent security review of that PR found the session revocation was fire-and-forget (a goroutine dispatched before the response returned), leaving a small timing window where an attacker holding a pre-existing session/refresh token could still use it.

Made it synchronous — it's a single cheap memory-store call, no reason for it to be async — and logged its error instead of silently discarding it.

## Test plan
- [x] Tightened the existing regression test to assert immediately instead of polling with `require.Eventually`
- [x] Full test suite green (two consecutive runs; one unrelated transient flake in an unrelated area, confirmed pre-existing and non-reproducible on rerun)

## Honest caveat
Verified empirically that the tightened assertion does **not** reliably distinguish sync from fire-and-forget on its own (an in-memory single-map-delete goroutine usually completes before the surrounding code returns anyway — confirmed by reverting the fix and watching the test still pass). The actual guarantee comes from the source having no goroutine at all, not from test timing sensitivity. Documented this directly in the test so it isn't over-trusted later.