### PR TITLE
feat: verified domains (Phase 2 of multi-tenant SSO)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -561,6 +561,7 @@ func runRoot(c *cobra.Command, args []string) {
 		SMSProvider:           smsProvider,
 		StorageProvider:       storageProvider,
 		TokenProvider:         tokenProvider,
+		RateLimitProvider:     rateLimitProvider,
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create service provider")

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.26
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.52.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
@@ -191,7 +192,6 @@ require (
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -43,6 +43,8 @@ const (
 	AuditResourceTypeOrgMembership = "org_membership"
 	// AuditResourceTypeScimEndpoint represents a per-org SCIM endpoint.
 	AuditResourceTypeScimEndpoint = "scim_endpoint"
+	// AuditResourceTypeOrgDomain represents a per-org verified domain.
+	AuditResourceTypeOrgDomain = "org_domain"
 )
 
 // Audit event type constants used for structured audit logging.
@@ -227,6 +229,21 @@ const (
 	AuditScimEndpointDeletedEvent = "admin.scim_endpoint_deleted"
 	// AuditScimEndpointDeleteFailedEvent is logged when a SCIM endpoint delete fails.
 	AuditScimEndpointDeleteFailedEvent = "admin.scim_endpoint_delete_failed"
+
+	// AuditOrgDomainRequestedEvent is logged when an org admin requests a domain
+	// verification challenge (a DNS TXT proof is minted; no durable row yet).
+	AuditOrgDomainRequestedEvent = "admin.org_domain_requested"
+	// AuditOrgDomainRequestFailedEvent is logged when a domain request fails.
+	AuditOrgDomainRequestFailedEvent = "admin.org_domain_request_failed"
+	// AuditOrgDomainVerifiedEvent is logged when a domain is verified (DNS TXT or
+	// super-admin trusted-assert) and the verified row is inserted.
+	AuditOrgDomainVerifiedEvent = "admin.org_domain_verified"
+	// AuditOrgDomainVerifyFailedEvent is logged when a domain verification fails.
+	AuditOrgDomainVerifyFailedEvent = "admin.org_domain_verify_failed"
+	// AuditOrgDomainDeletedEvent is logged when a verified domain is deleted.
+	AuditOrgDomainDeletedEvent = "admin.org_domain_deleted"
+	// AuditOrgDomainDeleteFailedEvent is logged when a verified domain delete fails.
+	AuditOrgDomainDeleteFailedEvent = "admin.org_domain_delete_failed"
 
 	// AuditTokenClientCredentialsEvent is logged when a service account obtains a token
 	// via the client_credentials grant (RFC 6749 §4.4).

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -283,6 +283,7 @@ type ComplexityRoot struct {
 		AddEmailTemplate        func(childComplexity int, params model.AddEmailTemplateRequest) int
 		AddOrgMember            func(childComplexity int, params model.AddOrgMemberRequest) int
 		AddTrustedIssuer        func(childComplexity int, params model.AddTrustedIssuerRequest) int
+		AddVerifiedOrgDomain    func(childComplexity int, params model.AddVerifiedOrgDomainRequest) int
 		AddWebhook              func(childComplexity int, params model.AddWebhookRequest) int
 		AdminLogin              func(childComplexity int, params model.AdminLoginRequest) int
 		AdminLogout             func(childComplexity int) int
@@ -295,6 +296,7 @@ type ComplexityRoot struct {
 		DeactivateAccount       func(childComplexity int) int
 		DeleteClient            func(childComplexity int, params model.ClientRequest) int
 		DeleteEmailTemplate     func(childComplexity int, params model.DeleteEmailTemplateRequest) int
+		DeleteOrgDomain         func(childComplexity int, params model.DeleteOrgDomainRequest) int
 		DeleteOrgOidcConnection func(childComplexity int, params model.OrgOIDCConnectionRequest) int
 		DeleteOrgSamlConnection func(childComplexity int, params model.OrgSAMLConnectionRequest) int
 		DeleteOrganization      func(childComplexity int, params model.OrganizationRequest) int
@@ -316,6 +318,7 @@ type ComplexityRoot struct {
 		MobileLogin             func(childComplexity int, params model.MobileLoginRequest) int
 		MobileSignup            func(childComplexity int, params *model.MobileSignUpRequest) int
 		RemoveOrgMember         func(childComplexity int, params model.RemoveOrgMemberRequest) int
+		RequestOrgDomain        func(childComplexity int, params model.RequestOrgDomainRequest) int
 		ResendOtp               func(childComplexity int, params model.ResendOTPRequest) int
 		ResendVerifyEmail       func(childComplexity int, params model.ResendVerifyEmailRequest) int
 		ResetPassword           func(childComplexity int, params model.ResetPasswordRequest) int
@@ -336,7 +339,28 @@ type ComplexityRoot struct {
 		UpdateUser              func(childComplexity int, params model.UpdateUserRequest) int
 		UpdateWebhook           func(childComplexity int, params model.UpdateWebhookRequest) int
 		VerifyEmail             func(childComplexity int, params model.VerifyEmailRequest) int
+		VerifyOrgDomain         func(childComplexity int, params model.VerifyOrgDomainRequest) int
 		VerifyOtp               func(childComplexity int, params model.VerifyOTPRequest) int
+	}
+
+	OrgDomain struct {
+		CreatedAt  func(childComplexity int) int
+		Domain     func(childComplexity int) int
+		OrgID      func(childComplexity int) int
+		UpdatedAt  func(childComplexity int) int
+		VerifiedAt func(childComplexity int) int
+	}
+
+	OrgDomainChallenge struct {
+		Domain      func(childComplexity int) int
+		RecordName  func(childComplexity int) int
+		RecordType  func(childComplexity int) int
+		RecordValue func(childComplexity int) int
+	}
+
+	OrgDomains struct {
+		OrgDomains func(childComplexity int) int
+		Pagination func(childComplexity int) int
 	}
 
 	OrgMember struct {
@@ -428,6 +452,7 @@ type ComplexityRoot struct {
 		FgaReadTuples        func(childComplexity int, params model.FgaReadTuplesInput) int
 		ListPermissions      func(childComplexity int, params model.ListPermissionsInput) int
 		Meta                 func(childComplexity int) int
+		OrgDomains           func(childComplexity int, params model.ListOrgDomainsRequest) int
 		OrgMembers           func(childComplexity int, params model.ListOrgMembersRequest) int
 		OrgOidcConnection    func(childComplexity int, params model.OrgOIDCConnectionRequest) int
 		OrgSamlConnection    func(childComplexity int, params model.OrgSAMLConnectionRequest) int
@@ -626,6 +651,10 @@ type MutationResolver interface {
 	CreateScimEndpoint(ctx context.Context, params model.CreateScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
 	RotateScimToken(ctx context.Context, params model.ScimEndpointRequest) (*model.CreateScimEndpointResponse, error)
 	DeleteScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.Response, error)
+	RequestOrgDomain(ctx context.Context, params model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, error)
+	VerifyOrgDomain(ctx context.Context, params model.VerifyOrgDomainRequest) (*model.OrgDomain, error)
+	AddVerifiedOrgDomain(ctx context.Context, params model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, error)
+	DeleteOrgDomain(ctx context.Context, params model.DeleteOrgDomainRequest) (*model.Response, error)
 	TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error)
 	AddEmailTemplate(ctx context.Context, params model.AddEmailTemplateRequest) (*model.Response, error)
 	UpdateEmailTemplate(ctx context.Context, params model.UpdateEmailTemplateRequest) (*model.Response, error)
@@ -660,6 +689,7 @@ type QueryResolver interface {
 	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
 	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
 	ScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.ScimEndpoint, error)
+	OrgDomains(ctx context.Context, params model.ListOrgDomainsRequest) (*model.OrgDomains, error)
 	EmailTemplates(ctx context.Context, params *model.PaginatedRequest) (*model.EmailTemplates, error)
 	AuditLogs(ctx context.Context, params *model.ListAuditLogRequest) (*model.AuditLogs, error)
 	FgaGetModel(ctx context.Context) (*model.FgaModel, error)
@@ -1873,6 +1903,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.AddTrustedIssuer(childComplexity, args["params"].(model.AddTrustedIssuerRequest)), true
 
+	case "Mutation._add_verified_org_domain":
+		if e.complexity.Mutation.AddVerifiedOrgDomain == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__add_verified_org_domain_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddVerifiedOrgDomain(childComplexity, args["params"].(model.AddVerifiedOrgDomainRequest)), true
+
 	case "Mutation._add_webhook":
 		if e.complexity.Mutation.AddWebhook == nil {
 			break
@@ -2006,6 +2048,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteEmailTemplate(childComplexity, args["params"].(model.DeleteEmailTemplateRequest)), true
+
+	case "Mutation._delete_org_domain":
+		if e.complexity.Mutation.DeleteOrgDomain == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_org_domain_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteOrgDomain(childComplexity, args["params"].(model.DeleteOrgDomainRequest)), true
 
 	case "Mutation._delete_org_oidc_connection":
 		if e.complexity.Mutation.DeleteOrgOidcConnection == nil {
@@ -2249,6 +2303,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.RemoveOrgMember(childComplexity, args["params"].(model.RemoveOrgMemberRequest)), true
 
+	case "Mutation._request_org_domain":
+		if e.complexity.Mutation.RequestOrgDomain == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__request_org_domain_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RequestOrgDomain(childComplexity, args["params"].(model.RequestOrgDomainRequest)), true
+
 	case "Mutation.resend_otp":
 		if e.complexity.Mutation.ResendOtp == nil {
 			break
@@ -2489,6 +2555,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.VerifyEmail(childComplexity, args["params"].(model.VerifyEmailRequest)), true
 
+	case "Mutation._verify_org_domain":
+		if e.complexity.Mutation.VerifyOrgDomain == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__verify_org_domain_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.VerifyOrgDomain(childComplexity, args["params"].(model.VerifyOrgDomainRequest)), true
+
 	case "Mutation.verify_otp":
 		if e.complexity.Mutation.VerifyOtp == nil {
 			break
@@ -2500,6 +2578,83 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.VerifyOtp(childComplexity, args["params"].(model.VerifyOTPRequest)), true
+
+	case "OrgDomain.created_at":
+		if e.complexity.OrgDomain.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgDomain.CreatedAt(childComplexity), true
+
+	case "OrgDomain.domain":
+		if e.complexity.OrgDomain.Domain == nil {
+			break
+		}
+
+		return e.complexity.OrgDomain.Domain(childComplexity), true
+
+	case "OrgDomain.org_id":
+		if e.complexity.OrgDomain.OrgID == nil {
+			break
+		}
+
+		return e.complexity.OrgDomain.OrgID(childComplexity), true
+
+	case "OrgDomain.updated_at":
+		if e.complexity.OrgDomain.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgDomain.UpdatedAt(childComplexity), true
+
+	case "OrgDomain.verified_at":
+		if e.complexity.OrgDomain.VerifiedAt == nil {
+			break
+		}
+
+		return e.complexity.OrgDomain.VerifiedAt(childComplexity), true
+
+	case "OrgDomainChallenge.domain":
+		if e.complexity.OrgDomainChallenge.Domain == nil {
+			break
+		}
+
+		return e.complexity.OrgDomainChallenge.Domain(childComplexity), true
+
+	case "OrgDomainChallenge.record_name":
+		if e.complexity.OrgDomainChallenge.RecordName == nil {
+			break
+		}
+
+		return e.complexity.OrgDomainChallenge.RecordName(childComplexity), true
+
+	case "OrgDomainChallenge.record_type":
+		if e.complexity.OrgDomainChallenge.RecordType == nil {
+			break
+		}
+
+		return e.complexity.OrgDomainChallenge.RecordType(childComplexity), true
+
+	case "OrgDomainChallenge.record_value":
+		if e.complexity.OrgDomainChallenge.RecordValue == nil {
+			break
+		}
+
+		return e.complexity.OrgDomainChallenge.RecordValue(childComplexity), true
+
+	case "OrgDomains.org_domains":
+		if e.complexity.OrgDomains.OrgDomains == nil {
+			break
+		}
+
+		return e.complexity.OrgDomains.OrgDomains(childComplexity), true
+
+	case "OrgDomains.pagination":
+		if e.complexity.OrgDomains.Pagination == nil {
+			break
+		}
+
+		return e.complexity.OrgDomains.Pagination(childComplexity), true
 
 	case "OrgMember.created_at":
 		if e.complexity.OrgMember.CreatedAt == nil {
@@ -2972,6 +3127,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Meta(childComplexity), true
+
+	case "Query._org_domains":
+		if e.complexity.Query.OrgDomains == nil {
+			break
+		}
+
+		args, err := ec.field_Query__org_domains_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OrgDomains(childComplexity, args["params"].(model.ListOrgDomainsRequest)), true
 
 	case "Query._org_members":
 		if e.complexity.Query.OrgMembers == nil {
@@ -3769,6 +3936,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAddEmailTemplateRequest,
 		ec.unmarshalInputAddOrgMemberRequest,
 		ec.unmarshalInputAddTrustedIssuerRequest,
+		ec.unmarshalInputAddVerifiedOrgDomainRequest,
 		ec.unmarshalInputAddWebhookRequest,
 		ec.unmarshalInputAdminLoginRequest,
 		ec.unmarshalInputAdminSignupRequest,
@@ -3780,6 +3948,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateOrganizationRequest,
 		ec.unmarshalInputCreateScimEndpointRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
+		ec.unmarshalInputDeleteOrgDomainRequest,
 		ec.unmarshalInputDeleteUserRequest,
 		ec.unmarshalInputFgaExpandInput,
 		ec.unmarshalInputFgaListUsersInput,
@@ -3794,6 +3963,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInviteMemberRequest,
 		ec.unmarshalInputListAuditLogRequest,
 		ec.unmarshalInputListClientsRequest,
+		ec.unmarshalInputListOrgDomainsRequest,
 		ec.unmarshalInputListOrgMembersRequest,
 		ec.unmarshalInputListOrganizationsRequest,
 		ec.unmarshalInputListPermissionsInput,
@@ -3811,6 +3981,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPaginationRequest,
 		ec.unmarshalInputPermissionCheckInput,
 		ec.unmarshalInputRemoveOrgMemberRequest,
+		ec.unmarshalInputRequestOrgDomainRequest,
 		ec.unmarshalInputResendOTPRequest,
 		ec.unmarshalInputResendVerifyEmailRequest,
 		ec.unmarshalInputResetPasswordRequest,
@@ -3834,6 +4005,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputValidateSessionRequest,
 		ec.unmarshalInputVerifyEmailRequest,
 		ec.unmarshalInputVerifyOTPRequest,
+		ec.unmarshalInputVerifyOrgDomainRequest,
 		ec.unmarshalInputWebhookRequest,
 	)
 	first := true
@@ -4380,6 +4552,38 @@ type OrgMember {
 type OrgMembers {
   pagination: Pagination!
   org_members: [OrgMember!]!
+}
+
+# OrgDomain is a VERIFIED mapping from a DNS domain to exactly one organization,
+# used for home-realm discovery (routing a login to the correct tenant IdP). A
+# row exists ONLY once the domain is verified — a pending challenge is not
+# returned here.
+type OrgDomain {
+  domain: String!
+  org_id: String!
+  verified_at: Int64
+  created_at: Int64
+  updated_at: Int64
+}
+
+type OrgDomains {
+  pagination: Pagination!
+  org_domains: [OrgDomain!]!
+}
+
+# OrgDomainChallenge is the DNS TXT record a tenant must publish to prove control
+# of a domain. Returned by _request_org_domain; no durable row exists until the
+# domain is verified. The token lives only in the ephemeral challenge, never in
+# the routing table.
+type OrgDomainChallenge {
+  domain: String!
+  # record_type is always "TXT".
+  record_type: String!
+  # record_name is the DNS name to create, e.g. _authorizer-challenge.acme.com
+  record_name: String!
+  # record_value is the exact TXT value to publish,
+  # e.g. authorizer-domain-verification=<token>
+  record_value: String!
 }
 
 type WebhookLog {
@@ -4931,6 +5135,33 @@ input ScimEndpointRequest {
   org_id: String!
 }
 
+# Verified-domain admin ops. request/verify/list/add are keyed by org_id (the
+# org being written); delete is keyed by domain alone (the owning org is loaded
+# from the row, then authorized).
+input RequestOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input VerifyOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input AddVerifiedOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input ListOrgDomainsRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
+input DeleteOrgDomainRequest {
+  domain: String!
+}
+
 input AddOrgMemberRequest {
   org_id: String!
   user_id: String!
@@ -5150,6 +5381,12 @@ type Mutation {
   _create_scim_endpoint(params: CreateScimEndpointRequest!): CreateScimEndpointResponse!
   _rotate_scim_token(params: ScimEndpointRequest!): CreateScimEndpointResponse!
   _delete_scim_endpoint(params: ScimEndpointRequest!): Response!
+  # Per-org verified domains for home-realm discovery. request/verify/delete are
+  # org-admin gated; _add_verified_org_domain is super-admin only (trusted-assert).
+  _request_org_domain(params: RequestOrgDomainRequest!): OrgDomainChallenge!
+  _verify_org_domain(params: VerifyOrgDomainRequest!): OrgDomain!
+  _add_verified_org_domain(params: AddVerifiedOrgDomainRequest!): OrgDomain!
+  _delete_org_domain(params: DeleteOrgDomainRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -5194,6 +5431,8 @@ type Query {
   _org_members(params: ListOrgMembersRequest!): OrgMembers!
   # Per-org inbound SCIM 2.0 endpoint metadata (token never returned here).
   _scim_endpoint(params: ScimEndpointRequest!): ScimEndpoint!
+  # An org's verified domains (org-admin gated; never leaks another org's rows).
+  _org_domains(params: ListOrgDomainsRequest!): OrgDomains!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)
@@ -5294,6 +5533,34 @@ func (ec *executionContext) field_Mutation__add_trusted_issuer_argsParams(
 	}
 
 	var zeroVal model.AddTrustedIssuerRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__add_verified_org_domain_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__add_verified_org_domain_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__add_verified_org_domain_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.AddVerifiedOrgDomainRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.AddVerifiedOrgDomainRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNAddVerifiedOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddVerifiedOrgDomainRequest(ctx, tmp)
+	}
+
+	var zeroVal model.AddVerifiedOrgDomainRequest
 	return zeroVal, nil
 }
 
@@ -5574,6 +5841,34 @@ func (ec *executionContext) field_Mutation__delete_email_template_argsParams(
 	}
 
 	var zeroVal model.DeleteEmailTemplateRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_org_domain_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_org_domain_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_org_domain_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.DeleteOrgDomainRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.DeleteOrgDomainRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNDeleteOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteOrgDomainRequest(ctx, tmp)
+	}
+
+	var zeroVal model.DeleteOrgDomainRequest
 	return zeroVal, nil
 }
 
@@ -5969,6 +6264,34 @@ func (ec *executionContext) field_Mutation__remove_org_member_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__request_org_domain_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__request_org_domain_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__request_org_domain_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.RequestOrgDomainRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.RequestOrgDomainRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNRequestOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRequestOrgDomainRequest(ctx, tmp)
+	}
+
+	var zeroVal model.RequestOrgDomainRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__revoke_access_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6330,6 +6653,34 @@ func (ec *executionContext) field_Mutation__update_webhook_argsParams(
 	}
 
 	var zeroVal model.UpdateWebhookRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__verify_org_domain_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__verify_org_domain_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__verify_org_domain_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.VerifyOrgDomainRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.VerifyOrgDomainRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNVerifyOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐVerifyOrgDomainRequest(ctx, tmp)
+	}
+
+	var zeroVal model.VerifyOrgDomainRequest
 	return zeroVal, nil
 }
 
@@ -6918,6 +7269,34 @@ func (ec *executionContext) field_Query__fga_read_tuples_argsParams(
 	}
 
 	var zeroVal model.FgaReadTuplesInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__org_domains_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__org_domains_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__org_domains_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ListOrgDomainsRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ListOrgDomainsRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNListOrgDomainsRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrgDomainsRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ListOrgDomainsRequest
 	return zeroVal, nil
 }
 
@@ -17986,6 +18365,264 @@ func (ec *executionContext) fieldContext_Mutation__delete_scim_endpoint(ctx cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__request_org_domain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__request_org_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RequestOrgDomain(rctx, fc.Args["params"].(model.RequestOrgDomainRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgDomainChallenge)
+	fc.Result = res
+	return ec.marshalNOrgDomainChallenge2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomainChallenge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__request_org_domain(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "domain":
+				return ec.fieldContext_OrgDomainChallenge_domain(ctx, field)
+			case "record_type":
+				return ec.fieldContext_OrgDomainChallenge_record_type(ctx, field)
+			case "record_name":
+				return ec.fieldContext_OrgDomainChallenge_record_name(ctx, field)
+			case "record_value":
+				return ec.fieldContext_OrgDomainChallenge_record_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgDomainChallenge", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__request_org_domain_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__verify_org_domain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__verify_org_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().VerifyOrgDomain(rctx, fc.Args["params"].(model.VerifyOrgDomainRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgDomain)
+	fc.Result = res
+	return ec.marshalNOrgDomain2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomain(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__verify_org_domain(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "domain":
+				return ec.fieldContext_OrgDomain_domain(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgDomain_org_id(ctx, field)
+			case "verified_at":
+				return ec.fieldContext_OrgDomain_verified_at(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgDomain_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgDomain_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgDomain", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__verify_org_domain_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__add_verified_org_domain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__add_verified_org_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddVerifiedOrgDomain(rctx, fc.Args["params"].(model.AddVerifiedOrgDomainRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgDomain)
+	fc.Result = res
+	return ec.marshalNOrgDomain2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomain(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__add_verified_org_domain(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "domain":
+				return ec.fieldContext_OrgDomain_domain(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgDomain_org_id(ctx, field)
+			case "verified_at":
+				return ec.fieldContext_OrgDomain_verified_at(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgDomain_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgDomain_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgDomain", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__add_verified_org_domain_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_org_domain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_org_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteOrgDomain(rctx, fc.Args["params"].(model.DeleteOrgDomainRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_org_domain(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_org_domain_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__test_endpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__test_endpoint(ctx, field)
 	if err != nil {
@@ -18446,6 +19083,503 @@ func (ec *executionContext) fieldContext_Mutation__fga_reset(_ context.Context, 
 				return ec.fieldContext_Response_message(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomain_domain(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomain) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomain_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Domain, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomain_domain(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomain",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomain_org_id(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomain) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomain_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomain_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomain",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomain_verified_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomain) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomain_verified_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.VerifiedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomain_verified_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomain",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomain_created_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomain) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomain_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomain_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomain",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomain_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomain) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomain_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomain_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomain",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomainChallenge_domain(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomainChallenge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomainChallenge_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Domain, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomainChallenge_domain(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomainChallenge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomainChallenge_record_type(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomainChallenge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomainChallenge_record_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RecordType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomainChallenge_record_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomainChallenge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomainChallenge_record_name(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomainChallenge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomainChallenge_record_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RecordName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomainChallenge_record_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomainChallenge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomainChallenge_record_value(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomainChallenge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomainChallenge_record_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RecordValue, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomainChallenge_record_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomainChallenge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomains_pagination(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomains) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomains_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomains_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomains",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgDomains_org_domains(ctx context.Context, field graphql.CollectedField, obj *model.OrgDomains) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgDomains_org_domains(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgDomains, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.OrgDomain)
+	fc.Result = res
+	return ec.marshalNOrgDomain2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomainᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgDomains_org_domains(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgDomains",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "domain":
+				return ec.fieldContext_OrgDomain_domain(ctx, field)
+			case "org_id":
+				return ec.fieldContext_OrgDomain_org_id(ctx, field)
+			case "verified_at":
+				return ec.fieldContext_OrgDomain_verified_at(ctx, field)
+			case "created_at":
+				return ec.fieldContext_OrgDomain_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_OrgDomain_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgDomain", field.Name)
 		},
 	}
 	return fc, nil
@@ -22293,6 +23427,67 @@ func (ec *executionContext) fieldContext_Query__scim_endpoint(ctx context.Contex
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query__scim_endpoint_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__org_domains(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__org_domains(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().OrgDomains(rctx, fc.Args["params"].(model.ListOrgDomainsRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.OrgDomains)
+	fc.Result = res
+	return ec.marshalNOrgDomains2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomains(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__org_domains(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_OrgDomains_pagination(ctx, field)
+			case "org_domains":
+				return ec.fieldContext_OrgDomains_org_domains(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrgDomains", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__org_domains_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -28736,6 +29931,40 @@ func (ec *executionContext) unmarshalInputAddTrustedIssuerRequest(ctx context.Co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputAddVerifiedOrgDomainRequest(ctx context.Context, obj any) (model.AddVerifiedOrgDomainRequest, error) {
+	var it model.AddVerifiedOrgDomainRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "domain"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "domain":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("domain"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Domain = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputAddWebhookRequest(ctx context.Context, obj any) (model.AddWebhookRequest, error) {
 	var it model.AddWebhookRequest
 	asMap := map[string]any{}
@@ -29181,6 +30410,33 @@ func (ec *executionContext) unmarshalInputDeleteEmailTemplateRequest(ctx context
 				return it, err
 			}
 			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteOrgDomainRequest(ctx context.Context, obj any) (model.DeleteOrgDomainRequest, error) {
+	var it model.DeleteOrgDomainRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"domain"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "domain":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("domain"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Domain = data
 		}
 	}
 
@@ -29699,6 +30955,40 @@ func (ec *executionContext) unmarshalInputListClientsRequest(ctx context.Context
 			continue
 		}
 		switch k {
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListOrgDomainsRequest(ctx context.Context, obj any) (model.ListOrgDomainsRequest, error) {
+	var it model.ListOrgDomainsRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
 		case "pagination":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
 			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
@@ -30445,6 +31735,40 @@ func (ec *executionContext) unmarshalInputRemoveOrgMemberRequest(ctx context.Con
 				return it, err
 			}
 			it.UserID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRequestOrgDomainRequest(ctx context.Context, obj any) (model.RequestOrgDomainRequest, error) {
+	var it model.RequestOrgDomainRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "domain"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "domain":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("domain"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Domain = data
 		}
 	}
 
@@ -32248,6 +33572,40 @@ func (ec *executionContext) unmarshalInputVerifyOTPRequest(ctx context.Context, 
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputVerifyOrgDomainRequest(ctx context.Context, obj any) (model.VerifyOrgDomainRequest, error) {
+	var it model.VerifyOrgDomainRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "domain"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "domain":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("domain"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Domain = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputWebhookRequest(ctx context.Context, obj any) (model.WebhookRequest, error) {
 	var it model.WebhookRequest
 	asMap := map[string]any{}
@@ -33992,6 +35350,34 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_request_org_domain":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__request_org_domain(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_verify_org_domain":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__verify_org_domain(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_add_verified_org_domain":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__add_verified_org_domain(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_org_domain":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_org_domain(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_test_endpoint":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__test_endpoint(ctx, field)
@@ -34045,6 +35431,154 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__fga_reset(ctx, field)
 			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgDomainImplementors = []string{"OrgDomain"}
+
+func (ec *executionContext) _OrgDomain(ctx context.Context, sel ast.SelectionSet, obj *model.OrgDomain) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgDomainImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgDomain")
+		case "domain":
+			out.Values[i] = ec._OrgDomain_domain(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._OrgDomain_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "verified_at":
+			out.Values[i] = ec._OrgDomain_verified_at(ctx, field, obj)
+		case "created_at":
+			out.Values[i] = ec._OrgDomain_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._OrgDomain_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgDomainChallengeImplementors = []string{"OrgDomainChallenge"}
+
+func (ec *executionContext) _OrgDomainChallenge(ctx context.Context, sel ast.SelectionSet, obj *model.OrgDomainChallenge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgDomainChallengeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgDomainChallenge")
+		case "domain":
+			out.Values[i] = ec._OrgDomainChallenge_domain(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "record_type":
+			out.Values[i] = ec._OrgDomainChallenge_record_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "record_name":
+			out.Values[i] = ec._OrgDomainChallenge_record_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "record_value":
+			out.Values[i] = ec._OrgDomainChallenge_record_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var orgDomainsImplementors = []string{"OrgDomains"}
+
+func (ec *executionContext) _OrgDomains(ctx context.Context, sel ast.SelectionSet, obj *model.OrgDomains) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, orgDomainsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrgDomains")
+		case "pagination":
+			out.Values[i] = ec._OrgDomains_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_domains":
+			out.Values[i] = ec._OrgDomains_org_domains(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -35102,6 +36636,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query__scim_endpoint(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_org_domains":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__org_domains(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -36450,6 +38006,11 @@ func (ec *executionContext) unmarshalNAddTrustedIssuerRequest2githubᚗcomᚋaut
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNAddVerifiedOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddVerifiedOrgDomainRequest(ctx context.Context, v any) (model.AddVerifiedOrgDomainRequest, error) {
+	res, err := ec.unmarshalInputAddVerifiedOrgDomainRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNAddWebhookRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐAddWebhookRequest(ctx context.Context, v any) (model.AddWebhookRequest, error) {
 	res, err := ec.unmarshalInputAddWebhookRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -36728,6 +38289,11 @@ func (ec *executionContext) marshalNCreateScimEndpointResponse2ᚖgithubᚗcom�
 
 func (ec *executionContext) unmarshalNDeleteEmailTemplateRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteEmailTemplateRequest(ctx context.Context, v any) (model.DeleteEmailTemplateRequest, error) {
 	res, err := ec.unmarshalInputDeleteEmailTemplateRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNDeleteOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐDeleteOrgDomainRequest(ctx context.Context, v any) (model.DeleteOrgDomainRequest, error) {
+	res, err := ec.unmarshalInputDeleteOrgDomainRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -37072,6 +38638,11 @@ func (ec *executionContext) marshalNInviteMembersResponse2ᚖgithubᚗcomᚋauth
 	return ec._InviteMembersResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNListOrgDomainsRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrgDomainsRequest(ctx context.Context, v any) (model.ListOrgDomainsRequest, error) {
+	res, err := ec.unmarshalInputListOrgDomainsRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNListOrgMembersRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListOrgMembersRequest(ctx context.Context, v any) (model.ListOrgMembersRequest, error) {
 	res, err := ec.unmarshalInputListOrgMembersRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -37128,6 +38699,92 @@ func (ec *executionContext) unmarshalNMobileLoginRequest2githubᚗcomᚋauthoriz
 func (ec *executionContext) unmarshalNOAuthRevokeRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOAuthRevokeRequest(ctx context.Context, v any) (model.OAuthRevokeRequest, error) {
 	res, err := ec.unmarshalInputOAuthRevokeRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOrgDomain2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomain(ctx context.Context, sel ast.SelectionSet, v model.OrgDomain) graphql.Marshaler {
+	return ec._OrgDomain(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgDomain2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomainᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.OrgDomain) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNOrgDomain2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomain(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNOrgDomain2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomain(ctx context.Context, sel ast.SelectionSet, v *model.OrgDomain) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgDomain(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNOrgDomainChallenge2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomainChallenge(ctx context.Context, sel ast.SelectionSet, v model.OrgDomainChallenge) graphql.Marshaler {
+	return ec._OrgDomainChallenge(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgDomainChallenge2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomainChallenge(ctx context.Context, sel ast.SelectionSet, v *model.OrgDomainChallenge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgDomainChallenge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNOrgDomains2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomains(ctx context.Context, sel ast.SelectionSet, v model.OrgDomains) graphql.Marshaler {
+	return ec._OrgDomains(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOrgDomains2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgDomains(ctx context.Context, sel ast.SelectionSet, v *model.OrgDomains) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrgDomains(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNOrgMember2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐOrgMember(ctx context.Context, sel ast.SelectionSet, v model.OrgMember) graphql.Marshaler {
@@ -37457,6 +39114,11 @@ func (ec *executionContext) marshalNPermissionCheckResult2ᚖgithubᚗcomᚋauth
 
 func (ec *executionContext) unmarshalNRemoveOrgMemberRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRemoveOrgMemberRequest(ctx context.Context, v any) (model.RemoveOrgMemberRequest, error) {
 	res, err := ec.unmarshalInputRemoveOrgMemberRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNRequestOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRequestOrgDomainRequest(ctx context.Context, v any) (model.RequestOrgDomainRequest, error) {
+	res, err := ec.unmarshalInputRequestOrgDomainRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -37890,6 +39552,11 @@ func (ec *executionContext) unmarshalNVerifyEmailRequest2githubᚗcomᚋauthoriz
 
 func (ec *executionContext) unmarshalNVerifyOTPRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐVerifyOTPRequest(ctx context.Context, v any) (model.VerifyOTPRequest, error) {
 	res, err := ec.unmarshalInputVerifyOTPRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNVerifyOrgDomainRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐVerifyOrgDomainRequest(ctx context.Context, v any) (model.VerifyOrgDomainRequest, error) {
+	res, err := ec.unmarshalInputVerifyOrgDomainRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -30,6 +30,11 @@ type AddTrustedIssuerRequest struct {
 	KubernetesAPIServerURL   *string `json:"kubernetes_api_server_url,omitempty"`
 }
 
+type AddVerifiedOrgDomainRequest struct {
+	OrgID  string `json:"org_id"`
+	Domain string `json:"domain"`
+}
+
 type AddWebhookRequest struct {
 	EventName        string         `json:"event_name"`
 	EventDescription *string        `json:"event_description,omitempty"`
@@ -164,6 +169,10 @@ type CreateScimEndpointResponse struct {
 
 type DeleteEmailTemplateRequest struct {
 	ID string `json:"id"`
+}
+
+type DeleteOrgDomainRequest struct {
+	Domain string `json:"domain"`
 }
 
 type DeleteUserRequest struct {
@@ -377,6 +386,11 @@ type ListClientsRequest struct {
 	Pagination *PaginatedRequest `json:"pagination,omitempty"`
 }
 
+type ListOrgDomainsRequest struct {
+	OrgID      string            `json:"org_id"`
+	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+}
+
 type ListOrgMembersRequest struct {
 	OrgID      string            `json:"org_id"`
 	Pagination *PaginatedRequest `json:"pagination,omitempty"`
@@ -481,6 +495,26 @@ type Mutation struct {
 
 type OAuthRevokeRequest struct {
 	RefreshToken string `json:"refresh_token"`
+}
+
+type OrgDomain struct {
+	Domain     string `json:"domain"`
+	OrgID      string `json:"org_id"`
+	VerifiedAt *int64 `json:"verified_at,omitempty"`
+	CreatedAt  *int64 `json:"created_at,omitempty"`
+	UpdatedAt  *int64 `json:"updated_at,omitempty"`
+}
+
+type OrgDomainChallenge struct {
+	Domain      string `json:"domain"`
+	RecordType  string `json:"record_type"`
+	RecordName  string `json:"record_name"`
+	RecordValue string `json:"record_value"`
+}
+
+type OrgDomains struct {
+	Pagination *Pagination  `json:"pagination"`
+	OrgDomains []*OrgDomain `json:"org_domains"`
 }
 
 type OrgMember struct {
@@ -592,6 +626,11 @@ type Query struct {
 type RemoveOrgMemberRequest struct {
 	OrgID  string `json:"org_id"`
 	UserID string `json:"user_id"`
+}
+
+type RequestOrgDomainRequest struct {
+	OrgID  string `json:"org_id"`
+	Domain string `json:"domain"`
 }
 
 type ResendOTPRequest struct {
@@ -948,6 +987,11 @@ type VerifyOTPRequest struct {
 	Otp         string  `json:"otp"`
 	IsTotp      *bool   `json:"is_totp,omitempty"`
 	State       *string `json:"state,omitempty"`
+}
+
+type VerifyOrgDomainRequest struct {
+	OrgID  string `json:"org_id"`
+	Domain string `json:"domain"`
 }
 
 type Webhook struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -448,6 +448,38 @@ type OrgMembers {
   org_members: [OrgMember!]!
 }
 
+# OrgDomain is a VERIFIED mapping from a DNS domain to exactly one organization,
+# used for home-realm discovery (routing a login to the correct tenant IdP). A
+# row exists ONLY once the domain is verified — a pending challenge is not
+# returned here.
+type OrgDomain {
+  domain: String!
+  org_id: String!
+  verified_at: Int64
+  created_at: Int64
+  updated_at: Int64
+}
+
+type OrgDomains {
+  pagination: Pagination!
+  org_domains: [OrgDomain!]!
+}
+
+# OrgDomainChallenge is the DNS TXT record a tenant must publish to prove control
+# of a domain. Returned by _request_org_domain; no durable row exists until the
+# domain is verified. The token lives only in the ephemeral challenge, never in
+# the routing table.
+type OrgDomainChallenge {
+  domain: String!
+  # record_type is always "TXT".
+  record_type: String!
+  # record_name is the DNS name to create, e.g. _authorizer-challenge.acme.com
+  record_name: String!
+  # record_value is the exact TXT value to publish,
+  # e.g. authorizer-domain-verification=<token>
+  record_value: String!
+}
+
 type WebhookLog {
   id: ID!
   http_status: Int64
@@ -997,6 +1029,33 @@ input ScimEndpointRequest {
   org_id: String!
 }
 
+# Verified-domain admin ops. request/verify/list/add are keyed by org_id (the
+# org being written); delete is keyed by domain alone (the owning org is loaded
+# from the row, then authorized).
+input RequestOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input VerifyOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input AddVerifiedOrgDomainRequest {
+  org_id: String!
+  domain: String!
+}
+
+input ListOrgDomainsRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
+input DeleteOrgDomainRequest {
+  domain: String!
+}
+
 input AddOrgMemberRequest {
   org_id: String!
   user_id: String!
@@ -1216,6 +1275,12 @@ type Mutation {
   _create_scim_endpoint(params: CreateScimEndpointRequest!): CreateScimEndpointResponse!
   _rotate_scim_token(params: ScimEndpointRequest!): CreateScimEndpointResponse!
   _delete_scim_endpoint(params: ScimEndpointRequest!): Response!
+  # Per-org verified domains for home-realm discovery. request/verify/delete are
+  # org-admin gated; _add_verified_org_domain is super-admin only (trusted-assert).
+  _request_org_domain(params: RequestOrgDomainRequest!): OrgDomainChallenge!
+  _verify_org_domain(params: VerifyOrgDomainRequest!): OrgDomain!
+  _add_verified_org_domain(params: AddVerifiedOrgDomainRequest!): OrgDomain!
+  _delete_org_domain(params: DeleteOrgDomainRequest!): Response!
   _test_endpoint(params: TestEndpointRequest!): TestEndpointResponse!
   _add_email_template(params: AddEmailTemplateRequest!): Response!
   _update_email_template(params: UpdateEmailTemplateRequest!): Response!
@@ -1260,6 +1325,8 @@ type Query {
   _org_members(params: ListOrgMembersRequest!): OrgMembers!
   # Per-org inbound SCIM 2.0 endpoint metadata (token never returned here).
   _scim_endpoint(params: ScimEndpointRequest!): ScimEndpoint!
+  # An org's verified domains (org-admin gated; never leaks another org's rows).
+  _org_domains(params: ListOrgDomainsRequest!): OrgDomains!
   _email_templates(params: PaginatedRequest): EmailTemplates!
   _audit_logs(params: ListAuditLogRequest): AuditLogs!
   # FGA admin queries (super-admin only)

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -257,6 +257,26 @@ func (r *mutationResolver) DeleteScimEndpoint(ctx context.Context, params model.
 	return r.GraphQLProvider.DeleteScimEndpoint(ctx, &params)
 }
 
+// RequestOrgDomain is the resolver for the _request_org_domain field.
+func (r *mutationResolver) RequestOrgDomain(ctx context.Context, params model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, error) {
+	return r.GraphQLProvider.RequestOrgDomain(ctx, &params)
+}
+
+// VerifyOrgDomain is the resolver for the _verify_org_domain field.
+func (r *mutationResolver) VerifyOrgDomain(ctx context.Context, params model.VerifyOrgDomainRequest) (*model.OrgDomain, error) {
+	return r.GraphQLProvider.VerifyOrgDomain(ctx, &params)
+}
+
+// AddVerifiedOrgDomain is the resolver for the _add_verified_org_domain field.
+func (r *mutationResolver) AddVerifiedOrgDomain(ctx context.Context, params model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, error) {
+	return r.GraphQLProvider.AddVerifiedOrgDomain(ctx, &params)
+}
+
+// DeleteOrgDomain is the resolver for the _delete_org_domain field.
+func (r *mutationResolver) DeleteOrgDomain(ctx context.Context, params model.DeleteOrgDomainRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteOrgDomain(ctx, &params)
+}
+
 // TestEndpoint is the resolver for the _test_endpoint field.
 func (r *mutationResolver) TestEndpoint(ctx context.Context, params model.TestEndpointRequest) (*model.TestEndpointResponse, error) {
 	return r.GraphQLProvider.TestEndpoint(ctx, &params)
@@ -415,6 +435,11 @@ func (r *queryResolver) OrgMembers(ctx context.Context, params model.ListOrgMemb
 // ScimEndpoint is the resolver for the _scim_endpoint field.
 func (r *queryResolver) ScimEndpoint(ctx context.Context, params model.ScimEndpointRequest) (*model.ScimEndpoint, error) {
 	return r.GraphQLProvider.ScimEndpoint(ctx, &params)
+}
+
+// OrgDomains is the resolver for the _org_domains field.
+func (r *queryResolver) OrgDomains(ctx context.Context, params model.ListOrgDomainsRequest) (*model.OrgDomains, error) {
+	return r.GraphQLProvider.OrgDomains(ctx, &params)
 }
 
 // EmailTemplates is the resolver for the _email_templates field.

--- a/internal/graphql/org_domains.go
+++ b/internal/graphql/org_domains.go
@@ -1,0 +1,70 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// RequestOrgDomain delegates to the transport-agnostic service layer.
+func (g *graphqlProvider) RequestOrgDomain(ctx context.Context, params *model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RequestOrgDomain(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// VerifyOrgDomain delegates to the transport-agnostic service layer.
+func (g *graphqlProvider) VerifyOrgDomain(ctx context.Context, params *model.VerifyOrgDomainRequest) (*model.OrgDomain, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().VerifyOrgDomain(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// AddVerifiedOrgDomain delegates to the transport-agnostic service layer.
+func (g *graphqlProvider) AddVerifiedOrgDomain(ctx context.Context, params *model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().AddVerifiedOrgDomain(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// OrgDomains delegates to the transport-agnostic service layer.
+func (g *graphqlProvider) OrgDomains(ctx context.Context, params *model.ListOrgDomainsRequest) (*model.OrgDomains, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().OrgDomains(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+// DeleteOrgDomain delegates to the transport-agnostic service layer.
+func (g *graphqlProvider) DeleteOrgDomain(ctx context.Context, params *model.DeleteOrgDomainRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		g.Log.Debug().Err(err).Msg("failed to get gin context")
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteOrgDomain(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -299,6 +299,21 @@ type Provider interface {
 	// ScimEndpoint returns an org's SCIM endpoint metadata (token never returned).
 	// Permissions: authorizer:admin
 	ScimEndpoint(ctx context.Context, params *model.ScimEndpointRequest) (*model.ScimEndpoint, error)
+	// RequestOrgDomain mints a DNS TXT challenge to prove control of a domain.
+	// Permissions: org-admin of params.org_id (or super-admin)
+	RequestOrgDomain(ctx context.Context, params *model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, error)
+	// VerifyOrgDomain verifies a domain via DNS TXT and inserts the verified row.
+	// Permissions: org-admin of params.org_id (or super-admin)
+	VerifyOrgDomain(ctx context.Context, params *model.VerifyOrgDomainRequest) (*model.OrgDomain, error)
+	// AddVerifiedOrgDomain trusted-asserts a verified domain with no proof.
+	// Permissions: super-admin only
+	AddVerifiedOrgDomain(ctx context.Context, params *model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, error)
+	// OrgDomains lists an org's verified domains.
+	// Permissions: org-admin of params.org_id (or super-admin)
+	OrgDomains(ctx context.Context, params *model.ListOrgDomainsRequest) (*model.OrgDomains, error)
+	// DeleteOrgDomain removes a verified domain (gated on the loaded row's org).
+	// Permissions: org-admin of the domain's org (or super-admin)
+	DeleteOrgDomain(ctx context.Context, params *model.DeleteOrgDomainRequest) (*model.Response, error)
 	// FgaWriteModel installs a new fine-grained authorization model.
 	// Permissions: authorizer:admin
 	FgaWriteModel(ctx context.Context, params *model.FgaWriteModelInput) (*model.FgaModel, error)

--- a/internal/integration_tests/org_domains_test.go
+++ b/internal/integration_tests/org_domains_test.go
@@ -1,0 +1,312 @@
+package integration_tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+)
+
+// TestOrgVerifiedDomains covers Phase 2: DNS-TXT self-serve verification,
+// super-admin trusted-assert, first-writer-wins uniqueness (the ATO invariant),
+// public-suffix/consumer guards, normalization, org-scoped isolation, and the
+// org-delete cascade that frees a domain for re-claim. DNS is fully mocked.
+func TestOrgVerifiedDomains(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	asSuperAdmin := func() {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Del("Authorization")
+		setAdminCookie(t, ts)
+	}
+	asUser := func(token string) {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Set("Authorization", "Bearer "+token)
+	}
+	asAnon := func() {
+		clearCookies(ts)
+		ts.GinContext.Request.Header.Del("Authorization")
+	}
+
+	signupUser := func() (string, string) {
+		asAnon()
+		email := "org_domain_" + uuid.NewString() + "@authorizer.test"
+		password := "Password@123"
+		res, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+			Email:           &email,
+			Password:        password,
+			ConfirmPassword: password,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res.AccessToken)
+		return res.User.ID, *res.AccessToken
+	}
+	createOrg := func(prefix string) string {
+		asSuperAdmin()
+		org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+			Name: prefix + "-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		return org.ID
+	}
+	addAdmin := func(orgID, userID string) {
+		asSuperAdmin()
+		_, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{
+			OrgID: orgID, UserID: userID, Roles: []string{constants.OrgRoleAdmin},
+		})
+		require.NoError(t, err)
+	}
+	freshDomain := func(prefix string) string {
+		return prefix + "-" + strings.ToLower(uuid.NewString()[:8]) + ".com"
+	}
+	// publishTXT programs the mock resolver so the domain's challenge resolves.
+	publishTXT := func(ch *model.OrgDomainChallenge) {
+		ts.DNSResolver.Set(ch.RecordName, []string{ch.RecordValue})
+	}
+
+	t.Run("request mints a challenge but NO durable row", func(t *testing.T) {
+		orgID := createOrg("acme")
+		adminID, tok := signupUser()
+		addAdmin(orgID, adminID)
+		domain := freshDomain("acme")
+
+		asUser(tok)
+		ch, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.NoError(t, err)
+		require.Equal(t, domain, ch.Domain)
+		require.Equal(t, "TXT", ch.RecordType)
+		require.Equal(t, "_authorizer-challenge."+domain, ch.RecordName)
+		require.True(t, strings.HasPrefix(ch.RecordValue, "authorizer-domain-verification="))
+
+		// No verified row exists yet, and the pending challenge is not routable.
+		_, err = ts.StorageProvider.GetOrgDomainByDomain(ctx, domain)
+		require.Error(t, err, "request must not create a durable row")
+	})
+
+	t.Run("verify with correct TXT inserts the row; wrong TXT does not", func(t *testing.T) {
+		orgID := createOrg("verify")
+		adminID, tok := signupUser()
+		addAdmin(orgID, adminID)
+		domain := freshDomain("verify")
+
+		asUser(tok)
+		ch, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.NoError(t, err)
+
+		// Wrong TXT published → verify fails, no row, challenge survives.
+		ts.DNSResolver.Set(ch.RecordName, []string{"authorizer-domain-verification=not-the-token"})
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.Error(t, err)
+		_, err = ts.StorageProvider.GetOrgDomainByDomain(ctx, domain)
+		require.Error(t, err, "failed verify must not create a row")
+
+		// Correct TXT published → verify succeeds (challenge survived the retry).
+		publishTXT(ch)
+		row, err := ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.NoError(t, err)
+		require.Equal(t, domain, row.Domain)
+		require.Equal(t, orgID, row.OrgID)
+
+		// Idempotent: re-verify returns success without a duplicate.
+		row2, err := ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.NoError(t, err)
+		require.Equal(t, orgID, row2.OrgID)
+	})
+
+	t.Run("first-writer-wins: second org cannot verify an owned domain", func(t *testing.T) {
+		orgA := createOrg("fwa")
+		orgB := createOrg("fwb")
+		adminAID, tokA := signupUser()
+		adminBID, tokB := signupUser()
+		addAdmin(orgA, adminAID)
+		addAdmin(orgB, adminBID)
+		domain := freshDomain("shared")
+
+		// Org A verifies first.
+		asUser(tokA)
+		chA, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgA, Domain: domain})
+		require.NoError(t, err)
+		publishTXT(chA)
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgA, Domain: domain})
+		require.NoError(t, err)
+
+		// Org B requests + publishes ITS token, but verify must be rejected — the
+		// domain already routes to org A (invariant 2).
+		asUser(tokB)
+		chB, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgB, Domain: domain})
+		require.NoError(t, err)
+		publishTXT(chB)
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgB, Domain: domain})
+		require.ErrorContains(t, err, "domain_already_verified_by_another_org")
+
+		// Super-admin trusted-assert of the already-owned domain also fails.
+		asSuperAdmin()
+		_, err = ts.GraphQLProvider.AddVerifiedOrgDomain(ctx, &model.AddVerifiedOrgDomainRequest{OrgID: orgB, Domain: domain})
+		require.ErrorContains(t, err, "domain_already_verified_by_another_org")
+	})
+
+	t.Run("public-suffix and consumer domains are rejected", func(t *testing.T) {
+		orgID := createOrg("psl")
+		adminID, tok := signupUser()
+		addAdmin(orgID, adminID)
+
+		asUser(tok)
+		for _, bad := range []string{"gmail.com", "outlook.com", "com", "co.uk"} {
+			_, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: bad})
+			require.Error(t, err, "must reject %s", bad)
+		}
+		// Super-admin trusted-assert is subject to the same guard.
+		asSuperAdmin()
+		_, err := ts.GraphQLProvider.AddVerifiedOrgDomain(ctx, &model.AddVerifiedOrgDomainRequest{OrgID: orgID, Domain: "gmail.com"})
+		require.Error(t, err)
+	})
+
+	t.Run("normalization: mixed case / whitespace / wildcard", func(t *testing.T) {
+		orgID := createOrg("norm")
+		adminID, tok := signupUser()
+		addAdmin(orgID, adminID)
+		base := freshDomain("norm")
+
+		asUser(tok)
+		ch, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{
+			OrgID:  orgID,
+			Domain: "  *." + strings.ToUpper(base) + " ",
+		})
+		require.NoError(t, err)
+		require.Equal(t, base, ch.Domain, "domain must be normalized to lowercase, wildcard stripped")
+
+		// Malformed inputs are rejected.
+		for _, bad := range []string{"acme.com/login", "https://acme.com", "acme.com:8080", "notadomain", ""} {
+			_, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: bad})
+			require.Error(t, err, "must reject %q", bad)
+		}
+	})
+
+	t.Run("trusted-assert is super-admin only", func(t *testing.T) {
+		orgID := createOrg("trust")
+		adminID, tok := signupUser()
+		addAdmin(orgID, adminID)
+		domain := freshDomain("trust")
+
+		// Super-admin: allowed, no proof.
+		asSuperAdmin()
+		row, err := ts.GraphQLProvider.AddVerifiedOrgDomain(ctx, &model.AddVerifiedOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.NoError(t, err)
+		require.Equal(t, domain, row.Domain)
+
+		// Org admin of the SAME org: denied (trusted-assert is never org-admin).
+		asUser(tok)
+		_, err = ts.GraphQLProvider.AddVerifiedOrgDomain(ctx, &model.AddVerifiedOrgDomainRequest{OrgID: orgID, Domain: freshDomain("trust2")})
+		require.Error(t, err)
+	})
+
+	t.Run("org-scoped isolation: A cannot list/verify/delete B's domain", func(t *testing.T) {
+		orgA := createOrg("isoa")
+		orgB := createOrg("isob")
+		adminAID, tokA := signupUser()
+		adminBID, tokB := signupUser()
+		addAdmin(orgA, adminAID)
+		addAdmin(orgB, adminBID)
+		domainB := freshDomain("isob")
+
+		// Org B verifies its domain.
+		asUser(tokB)
+		chB, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgB, Domain: domainB})
+		require.NoError(t, err)
+		publishTXT(chB)
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgB, Domain: domainB})
+		require.NoError(t, err)
+
+		// Org A admin cannot list org B's domains.
+		asUser(tokA)
+		_, err = ts.GraphQLProvider.OrgDomains(ctx, &model.ListOrgDomainsRequest{OrgID: orgB})
+		require.Error(t, err)
+
+		// Org A admin cannot delete org B's domain (auth keys on the loaded row's org).
+		_, err = ts.GraphQLProvider.DeleteOrgDomain(ctx, &model.DeleteOrgDomainRequest{Domain: domainB})
+		require.Error(t, err)
+
+		// The domain still belongs to org B.
+		asUser(tokB)
+		list, err := ts.GraphQLProvider.OrgDomains(ctx, &model.ListOrgDomainsRequest{OrgID: orgB})
+		require.NoError(t, err)
+		require.Len(t, list.OrgDomains, 1)
+		require.Equal(t, domainB, list.OrgDomains[0].Domain)
+	})
+
+	t.Run("org-admin deletes own domain; org-delete cascades and frees it", func(t *testing.T) {
+		orgA := createOrg("cascadea")
+		orgB := createOrg("cascadeb")
+		adminAID, tokA := signupUser()
+		adminBID, tokB := signupUser()
+		addAdmin(orgA, adminAID)
+		addAdmin(orgB, adminBID)
+		domain := freshDomain("cascade")
+
+		// Org A verifies two domains; deletes one directly.
+		asUser(tokA)
+		ch, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgA, Domain: domain})
+		require.NoError(t, err)
+		publishTXT(ch)
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgA, Domain: domain})
+		require.NoError(t, err)
+
+		extra := freshDomain("cascade-extra")
+		ch2, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgA, Domain: extra})
+		require.NoError(t, err)
+		publishTXT(ch2)
+		_, err = ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgA, Domain: extra})
+		require.NoError(t, err)
+
+		_, err = ts.GraphQLProvider.DeleteOrgDomain(ctx, &model.DeleteOrgDomainRequest{Domain: extra})
+		require.NoError(t, err)
+		asUser(tokA)
+		list, err := ts.GraphQLProvider.OrgDomains(ctx, &model.ListOrgDomainsRequest{OrgID: orgA})
+		require.NoError(t, err)
+		require.Len(t, list.OrgDomains, 1)
+
+		// Delete org A (super-admin) → its remaining domain must be freed (M1).
+		asSuperAdmin()
+		_, err = ts.GraphQLProvider.DeleteOrganization(ctx, &model.OrganizationRequest{ID: orgA})
+		require.NoError(t, err)
+		_, err = ts.StorageProvider.GetOrgDomainByDomain(ctx, domain)
+		require.Error(t, err, "cascade must remove the org's domains")
+
+		// Org B can now claim the freed domain.
+		asUser(tokB)
+		chB, err := ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgB, Domain: domain})
+		require.NoError(t, err)
+		publishTXT(chB)
+		reclaimed, err := ts.GraphQLProvider.VerifyOrgDomain(ctx, &model.VerifyOrgDomainRequest{OrgID: orgB, Domain: domain})
+		require.NoError(t, err)
+		require.Equal(t, orgB, reclaimed.OrgID)
+	})
+
+	t.Run("plain member and non-member cannot request", func(t *testing.T) {
+		orgID := createOrg("deny")
+		memberID, memberTok := signupUser()
+		asSuperAdmin()
+		_, err := ts.GraphQLProvider.AddOrgMember(ctx, &model.AddOrgMemberRequest{OrgID: orgID, UserID: memberID, Roles: []string{"billing"}})
+		require.NoError(t, err)
+		_, outsiderTok := signupUser()
+		domain := freshDomain("deny")
+
+		asUser(memberTok)
+		_, err = ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.Error(t, err)
+
+		asUser(outsiderTok)
+		_, err = ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.Error(t, err)
+
+		asAnon()
+		_, err = ts.GraphQLProvider.RequestOrgDomain(ctx, &model.RequestOrgDomainRequest{OrgID: orgID, Domain: domain})
+		require.Error(t, err)
+	})
+}

--- a/internal/integration_tests/test_helper.go
+++ b/internal/integration_tests/test_helper.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -53,6 +54,37 @@ type testSetup struct {
 	// gRPC/REST transport tests can mount the same fully-wired service the
 	// GraphQL path uses.
 	ServiceProvider service.Provider
+	// DNSResolver is the programmable stub wired into the service layer for
+	// domain-verification tests, so no real DNS is ever queried.
+	DNSResolver *mockDNSResolver
+}
+
+// mockDNSResolver is a programmable TXT resolver for domain-verification tests.
+// It satisfies service.DNSResolver; tests set the TXT records a lookup returns.
+type mockDNSResolver struct {
+	mu      sync.Mutex
+	records map[string][]string
+}
+
+func newMockDNSResolver() *mockDNSResolver {
+	return &mockDNSResolver{records: map[string][]string{}}
+}
+
+// Set programs the TXT records returned for an exact lookup name.
+func (m *mockDNSResolver) Set(name string, txt []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records[name] = txt
+}
+
+// LookupTXT returns the programmed records, or a NXDOMAIN-like error if unset.
+func (m *mockDNSResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r, ok := m.records[name]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("no such host: %s", name)
 }
 
 func createContext(s *testSetup) (*http.Request, context.Context) {
@@ -242,6 +274,9 @@ func initTestSetup(t *testing.T, cfg *config.Config) *testSetup {
 		StorageProvider: storageProvider,
 	})
 
+	// Programmable DNS stub for domain-verification tests — never hits real DNS.
+	dnsResolver := newMockDNSResolver()
+
 	// Transport-agnostic service layer for migrated public ops.
 	serviceProvider, err := service.New(cfg, &service.Dependencies{
 		Log:                   &logger,
@@ -253,6 +288,7 @@ func initTestSetup(t *testing.T, cfg *config.Config) *testSetup {
 		SMSProvider:           smsProvider,
 		StorageProvider:       storageProvider,
 		TokenProvider:         tokenProvider,
+		DNSResolver:           dnsResolver,
 	})
 	require.NoError(t, err)
 
@@ -330,6 +366,7 @@ func initTestSetup(t *testing.T, cfg *config.Config) *testSetup {
 		AuthenticatorProvider: authProvider,
 		TokenProvider:         tokenProvider,
 		ServiceProvider:       serviceProvider,
+		DNSResolver:           dnsResolver,
 	}
 }
 

--- a/internal/service/admin_org_domains.go
+++ b/internal/service/admin_org_domains.go
@@ -1,0 +1,297 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// errDomainOwnedByAnotherOrg is the uniform, stable API error when a domain is
+// already verified by a different org (invariant 2). Kept as one string so the
+// three write paths (verify, trusted-assert) return it identically.
+var errDomainOwnedByAnotherOrg = fmt.Errorf("domain_already_verified_by_another_org")
+
+// RequestOrgDomain mints a DNS TXT challenge proving control of a domain and
+// returns the record to publish. It creates NO durable row — the pending token
+// lives only in the memory store with a ~24h TTL. Gated on params.OrgID
+// (super-admin or that org's org-admin).
+func (p *provider) RequestOrgDomain(ctx context.Context, meta RequestMetadata, params *model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "RequestOrgDomain").Logger()
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	if orgID == "" {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("org_id is required")
+	}
+	domain, err := normalizeDomain(params.Domain)
+	if err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if err := guardVerifiableDomain(domain); err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Msg("organization not found")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("organization not found")
+	}
+
+	token, err := generateDomainChallengeToken()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to generate domain challenge token")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if err := p.MemoryStoreProvider.SetCache(challengeKey(orgID, domain), token, int64(domainChallengeTTL.Seconds())); err != nil {
+		log.Debug().Err(err).Msg("failed to store domain challenge")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
+		return nil, nil, err
+	}
+
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgDomainRequestedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgDomain,
+		ResourceID:   domain,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	// The token is returned to the caller (they publish it in DNS) but is NEVER
+	// written to the audit trail.
+	return &model.OrgDomainChallenge{
+		Domain:      domain,
+		RecordType:  "TXT",
+		RecordName:  challengeRecordName(domain),
+		RecordValue: challengeRecordValue(token),
+	}, nil, nil
+}
+
+// VerifyOrgDomain proves control of a domain via its DNS TXT challenge and, on
+// success, atomically inserts the verified row (first-writer-wins). Idempotent:
+// a domain already verified by the same org returns success; one already
+// verified by another org is rejected. Gated on params.OrgID and rate-limited
+// per org (the verify drives an outbound DNS lookup).
+func (p *provider) VerifyOrgDomain(ctx context.Context, meta RequestMetadata, params *model.VerifyOrgDomainRequest) (*model.OrgDomain, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "VerifyOrgDomain").Logger()
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	domain, err := normalizeDomain(params.Domain)
+	if err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if err := guardVerifiableDomain(domain); err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if p.RateLimitProvider != nil {
+		allowed, rlErr := p.RateLimitProvider.Allow(ctx, "org_domain_verify:"+orgID)
+		if rlErr == nil && !allowed {
+			log.Debug().Msg("domain verify rate limit exceeded")
+			return nil, nil, fmt.Errorf("too many verification attempts, please retry later")
+		}
+	}
+
+	// Idempotency + conflict pre-check. AddOrgDomain also enforces this
+	// atomically; this fast-path keeps re-verify cheap and returns a clean error.
+	if existing, _ := p.StorageProvider.GetOrgDomainByDomain(ctx, domain); existing != nil {
+		if existing.OrgID == orgID {
+			return existing.AsAPIOrgDomain(), nil, nil
+		}
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, errDomainOwnedByAnotherOrg
+	}
+
+	token, err := p.MemoryStoreProvider.GetCache(challengeKey(orgID, domain))
+	if err != nil || token == "" {
+		log.Debug().Err(err).Msg("no pending domain challenge")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("no pending verification challenge for this domain; request one first")
+	}
+
+	matched, dnsErr := p.lookupDomainTXTMatches(ctx, domain, token)
+	if dnsErr != nil {
+		log.Debug().Err(dnsErr).Msg("domain TXT lookup failed")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("dns verification failed: could not resolve the challenge TXT record")
+	}
+	if !matched {
+		// Leave the challenge in place so the tenant can retry after DNS propagates.
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("dns verification failed: challenge TXT record not found or does not match")
+	}
+
+	row, err := p.StorageProvider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	if err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		if errors.Is(err, schemas.ErrOrgDomainConflict) {
+			return nil, nil, errDomainOwnedByAnotherOrg
+		}
+		log.Debug().Err(err).Msg("failed to add org domain")
+		return nil, nil, err
+	}
+	// Invalidate the consumed challenge. The memory-store interface has no
+	// exact-key delete, so overwrite with an empty value + 1s TTL — precise
+	// (unlike a prefix delete, which could clobber a sibling domain's challenge).
+	_ = p.MemoryStoreProvider.SetCache(challengeKey(orgID, domain), "", 1)
+
+	p.logOrgDomainVerified(meta, domain, "dns_txt")
+	return row.AsAPIOrgDomain(), nil, nil
+}
+
+// AddVerifiedOrgDomain trusted-asserts a verified domain with NO proof. It is
+// SUPER-ADMIN ONLY (the platform operator is already trusted); an org admin can
+// never reach it. Subject to the same uniqueness + public-suffix guards.
+func (p *provider) AddVerifiedOrgDomain(ctx context.Context, meta RequestMetadata, params *model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "AddVerifiedOrgDomain").Logger()
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	if orgID == "" {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("org_id is required")
+	}
+	domain, err := normalizeDomain(params.Domain)
+	if err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if err := guardVerifiableDomain(domain); err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, err
+	}
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		log.Debug().Err(err).Msg("organization not found")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		return nil, nil, fmt.Errorf("organization not found")
+	}
+
+	row, err := p.StorageProvider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	if err != nil {
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
+		if errors.Is(err, schemas.ErrOrgDomainConflict) {
+			return nil, nil, errDomainOwnedByAnotherOrg
+		}
+		log.Debug().Err(err).Msg("failed to add org domain")
+		return nil, nil, err
+	}
+	// If it was already verified by THIS org, AddOrgDomain returns the existing
+	// row idempotently — no error, correct.
+	p.logOrgDomainVerified(meta, domain, "trusted_assert")
+	return row.AsAPIOrgDomain(), nil, nil
+}
+
+// OrgDomains lists an org's verified domains (never another org's). Gated on
+// params.OrgID (super-admin or that org's org-admin).
+func (p *provider) OrgDomains(ctx context.Context, meta RequestMetadata, params *model.ListOrgDomainsRequest) (*model.OrgDomains, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "OrgDomains").Logger()
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	if orgID == "" {
+		return nil, nil, fmt.Errorf("org_id is required")
+	}
+	pagination := utils.GetPagination(params.Pagination)
+	domains, pagination, err := p.StorageProvider.ListOrgDomainsByOrg(ctx, orgID, pagination)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed ListOrgDomainsByOrg")
+		return nil, nil, err
+	}
+	res := make([]*model.OrgDomain, len(domains))
+	for i, d := range domains {
+		res[i] = d.AsAPIOrgDomain()
+	}
+	return &model.OrgDomains{
+		Pagination: pagination,
+		OrgDomains: res,
+	}, nil, nil
+}
+
+// DeleteOrgDomain removes a verified domain, freeing it for re-verification. The
+// request carries only the domain; the owning org is loaded FIRST and the
+// org-admin check keys on THAT org (design H2 — never on a caller-supplied id).
+func (p *provider) DeleteOrgDomain(ctx context.Context, meta RequestMetadata, params *model.DeleteOrgDomainRequest) (*model.Response, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "DeleteOrgDomain").Logger()
+	domain, err := normalizeDomain(params.Domain)
+	if err != nil {
+		return nil, nil, err
+	}
+	row, err := p.StorageProvider.GetOrgDomainByDomain(ctx, domain)
+	if err != nil || row == nil {
+		log.Debug().Err(err).Msg("org domain not found")
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("org domain not found"))
+	}
+	if err := p.requireOrgAdmin(ctx, meta, row.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := p.StorageProvider.DeleteOrgDomain(ctx, domain); err != nil {
+		log.Debug().Err(err).Msg("failed to delete org domain")
+		p.logOrgDomainFailure(meta, constants.AuditOrgDomainDeleteFailedEvent, row.OrgID)
+		return nil, nil, err
+	}
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgDomainDeletedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgDomain,
+		ResourceID:   domain,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+	return &model.Response{Message: "org domain deleted successfully"}, nil, nil
+}
+
+// logOrgDomainVerified records a successful verification, tagging the method
+// (dns_txt / trusted_assert) in the audit metadata. The token is never logged.
+func (p *provider) logOrgDomainVerified(meta RequestMetadata, domain, method string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditOrgDomainVerifiedEvent,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgDomain,
+		ResourceID:   domain,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+		Metadata:     fmt.Sprintf(`{"method":%q}`, method),
+	})
+}
+
+// logOrgDomainFailure records a failed domain admin operation.
+func (p *provider) logOrgDomainFailure(meta RequestMetadata, action, orgID string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       action,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgDomain,
+		ResourceID:   orgID,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}

--- a/internal/service/admin_org_domains.go
+++ b/internal/service/admin_org_domains.go
@@ -42,6 +42,15 @@ func (p *provider) RequestOrgDomain(ctx context.Context, meta RequestMetadata, p
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
 		return nil, nil, err
 	}
+	// Rate-limit challenge minting per org, mirroring VerifyOrgDomain — bounds
+	// memory-store churn from an authenticated tenant admin.
+	if p.RateLimitProvider != nil {
+		allowed, rlErr := p.RateLimitProvider.Allow(ctx, "org_domain_request:"+orgID)
+		if rlErr == nil && !allowed {
+			log.Debug().Msg("domain request rate limit exceeded")
+			return nil, nil, fmt.Errorf("too many domain requests, please retry later")
+		}
+	}
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Msg("organization not found")
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -91,6 +91,14 @@ type AdminProvider interface {
 	DeleteScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.Response, *ResponseSideEffects, error)
 	ScimEndpoint(ctx context.Context, meta RequestMetadata, params *model.ScimEndpointRequest) (*model.ScimEndpoint, *ResponseSideEffects, error)
 
+	// Per-org verified domains for home-realm discovery. request/verify/list/
+	// delete are org-admin gated; AddVerifiedOrgDomain is super-admin only.
+	RequestOrgDomain(ctx context.Context, meta RequestMetadata, params *model.RequestOrgDomainRequest) (*model.OrgDomainChallenge, *ResponseSideEffects, error)
+	VerifyOrgDomain(ctx context.Context, meta RequestMetadata, params *model.VerifyOrgDomainRequest) (*model.OrgDomain, *ResponseSideEffects, error)
+	AddVerifiedOrgDomain(ctx context.Context, meta RequestMetadata, params *model.AddVerifiedOrgDomainRequest) (*model.OrgDomain, *ResponseSideEffects, error)
+	OrgDomains(ctx context.Context, meta RequestMetadata, params *model.ListOrgDomainsRequest) (*model.OrgDomains, *ResponseSideEffects, error)
+	DeleteOrgDomain(ctx context.Context, meta RequestMetadata, params *model.DeleteOrgDomainRequest) (*model.Response, *ResponseSideEffects, error)
+
 	// Email templates.
 	AddEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.AddEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
 	UpdateEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.UpdateEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)

--- a/internal/service/org_domain_dns.go
+++ b/internal/service/org_domain_dns.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base32"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	// domainChallengeTTL is how long a pending DNS verification challenge lives in
+	// the memory store before it must be re-requested (~24h).
+	domainChallengeTTL = 24 * time.Hour
+
+	// domainChallengeKeyPrefix namespaces the pending-challenge entries in the
+	// memory store: org_domain_challenge:<org_id>:<domain> → <token>.
+	domainChallengeKeyPrefix = "org_domain_challenge:"
+
+	// domainChallengeRecordPrefix is the DNS label the TXT proof is published at:
+	// _authorizer-challenge.<domain>.
+	domainChallengeRecordPrefix = "_authorizer-challenge."
+
+	// domainChallengeValuePrefix prefixes the TXT record value the tenant must
+	// publish: authorizer-domain-verification=<token>.
+	domainChallengeValuePrefix = "authorizer-domain-verification="
+
+	// domainDNSLookupTimeout bounds the resolver call so a slow/hostile
+	// nameserver cannot stall the request.
+	domainDNSLookupTimeout = 5 * time.Second
+)
+
+// DNSResolver is the minimal resolver surface the domain-verification flow
+// needs. *net.Resolver satisfies it; tests inject a mock so no real DNS is hit.
+type DNSResolver interface {
+	LookupTXT(ctx context.Context, name string) ([]string, error)
+}
+
+// domainResolver returns the injected resolver, or the process default. Kept as
+// a method so a single nil-check lives in one place.
+func (p *provider) domainResolver() DNSResolver {
+	if p.DNSResolver != nil {
+		return p.DNSResolver
+	}
+	return net.DefaultResolver
+}
+
+// challengeKey builds the memory-store key for an (org, domain) pending
+// challenge. domain must already be normalized.
+func challengeKey(orgID, domain string) string {
+	return domainChallengeKeyPrefix + orgID + ":" + domain
+}
+
+// generateDomainChallengeToken returns a 32-byte crypto/rand token, base32
+// (lowercase, unpadded) so it is safe to publish verbatim in a DNS TXT record.
+func generateDomainChallengeToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf)), nil
+}
+
+// challengeRecordValue is the exact TXT value the tenant must publish.
+func challengeRecordValue(token string) string {
+	return domainChallengeValuePrefix + token
+}
+
+// challengeRecordName is the DNS name the TXT record lives at.
+func challengeRecordName(domain string) string {
+	return domainChallengeRecordPrefix + domain
+}
+
+// lookupDomainTXTMatches resolves the challenge TXT record for domain and
+// reports whether any record exactly equals authorizer-domain-verification=token.
+// The lookup is TXT-only with a bounded deadline; no HTTP is ever fetched.
+func (p *provider) lookupDomainTXTMatches(ctx context.Context, domain, token string) (bool, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, domainDNSLookupTimeout)
+	defer cancel()
+	records, err := p.domainResolver().LookupTXT(lookupCtx, challengeRecordName(domain))
+	if err != nil {
+		return false, err
+	}
+	want := challengeRecordValue(token)
+	for _, r := range records {
+		// Exact match only — a substring/prefix match would let an attacker who
+		// controls unrelated TXT content on the domain satisfy the challenge.
+		if strings.TrimSpace(r) == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/service/org_domain_util.go
+++ b/internal/service/org_domain_util.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"errors"
+	"strings"
+
+	"golang.org/x/net/idna"
+	"golang.org/x/net/publicsuffix"
+)
+
+// Domain-validation errors. Kept distinct so callers/tests can assert the exact
+// reason, and so the same messages flow to the API uniformly.
+var (
+	errInvalidDomain      = errors.New("invalid domain")
+	errPublicSuffixDomain = errors.New("cannot verify a public suffix or bare TLD")
+	errConsumerDomain     = errors.New("cannot verify a shared consumer email domain")
+)
+
+// consumerDomainBlocklist is a small set of well-known consumer email providers
+// that are registrable (so the public-suffix guard would allow them) but must
+// never be claimable as a tenant's routing domain. Not exhaustive by design —
+// DNS TXT proof is still the trust anchor; this only blocks the obvious ones.
+var consumerDomainBlocklist = map[string]bool{
+	"gmail.com":      true,
+	"googlemail.com": true,
+	"outlook.com":    true,
+	"hotmail.com":    true,
+	"live.com":       true,
+	"msn.com":        true,
+	"yahoo.com":      true,
+	"ymail.com":      true,
+	"aol.com":        true,
+	"icloud.com":     true,
+	"me.com":         true,
+	"mac.com":        true,
+	"proton.me":      true,
+	"protonmail.com": true,
+	"gmx.com":        true,
+	"gmx.net":        true,
+	"mail.com":       true,
+	"zoho.com":       true,
+	"yandex.com":     true,
+	"yandex.ru":      true,
+	"fastmail.com":   true,
+	"hey.com":        true,
+	"pm.me":          true,
+	"qq.com":         true,
+	"163.com":        true,
+	"126.com":        true,
+}
+
+// normalizeDomain is the SINGLE canonical domain normalizer used by every domain
+// operation (Phase-2 writes AND any future home-realm-discovery lookup). Keeping
+// it as one function is deliberate: a split implementation could let a homograph
+// verify under one form and route under another. It:
+//   - lowercases and trims,
+//   - strips a leading "@" (email-local artifact) or "*." (wildcard) label,
+//   - rejects anything carrying a scheme, path, port, wildcard, or whitespace,
+//   - converts to punycode via the IDNA Lookup profile (UTS-46,
+//     non-transitional), and
+//   - requires at least one dot (a bare label / TLD is not a verifiable domain).
+//
+// It does NOT apply the public-suffix / consumer guard — that is a separate
+// policy check (guardVerifiableDomain) applied only to WRITES, so a lookup of an
+// already-verified consumer-ish row (should one ever exist) still resolves.
+func normalizeDomain(input string) (string, error) {
+	d := strings.ToLower(strings.TrimSpace(input))
+	if d == "" {
+		return "", errInvalidDomain
+	}
+	if strings.Contains(d, "://") {
+		return "", errInvalidDomain
+	}
+	d = strings.TrimPrefix(d, "@")
+	d = strings.TrimPrefix(d, "*.")
+	d = strings.TrimSuffix(d, ".")
+	// Reject leftover unsafe characters: path, port, wildcard, whitespace, or a
+	// stray email "@". Punycode/ASCII domains never legitimately contain these.
+	if strings.ContainsAny(d, "/*:@ \t\r\n?#") {
+		return "", errInvalidDomain
+	}
+	ascii, err := idna.Lookup.ToASCII(d)
+	if err != nil {
+		return "", errInvalidDomain
+	}
+	if !strings.Contains(ascii, ".") {
+		return "", errInvalidDomain
+	}
+	return ascii, nil
+}
+
+// guardVerifiableDomain enforces the write-time policy: a tenant may not verify a
+// public suffix / bare TLD (co.uk, com) nor a shared consumer email provider
+// (gmail.com, …). The input MUST already be normalized (punycode).
+func guardVerifiableDomain(ascii string) error {
+	suffix, _ := publicsuffix.PublicSuffix(ascii)
+	if suffix == ascii {
+		// The whole string is itself a public suffix (e.g. "com", "co.uk").
+		return errPublicSuffixDomain
+	}
+	if consumerDomainBlocklist[ascii] {
+		return errConsumerDomain
+	}
+	return nil
+}

--- a/internal/service/org_domain_util_test.go
+++ b/internal/service/org_domain_util_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizeDomain(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "already normalized", in: "acme.com", want: "acme.com"},
+		{name: "uppercase", in: "Acme.COM", want: "acme.com"},
+		{name: "surrounding whitespace", in: "  acme.com \t", want: "acme.com"},
+		{name: "trailing dot (FQDN)", in: "acme.com.", want: "acme.com"},
+		{name: "leading @ (email artifact)", in: "@acme.com", want: "acme.com"},
+		{name: "wildcard prefix stripped", in: "*.acme.com", want: "acme.com"},
+		{name: "subdomain kept exact", in: "eng.acme.com", want: "eng.acme.com"},
+		{name: "IDNA unicode to punycode", in: "münchen.de", want: "xn--mnchen-3ya.de"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "whitespace only", in: "   ", wantErr: true},
+		{name: "bare label / no dot", in: "localhost", wantErr: true},
+		{name: "scheme rejected", in: "https://acme.com", wantErr: true},
+		{name: "path rejected", in: "acme.com/login", wantErr: true},
+		{name: "port rejected", in: "acme.com:8080", wantErr: true},
+		{name: "embedded wildcard rejected", in: "foo.*.acme.com", wantErr: true},
+		{name: "full email rejected", in: "jane@acme.com", wantErr: true},
+		{name: "space in host rejected", in: "ac me.com", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeDomain(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeDomain(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeDomain(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeDomain(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGuardVerifiableDomain(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr error
+	}{
+		{name: "registrable domain allowed", in: "acme.com"},
+		{name: "subdomain allowed", in: "eng.acme.com"},
+		{name: "bare TLD rejected", in: "com", wantErr: errPublicSuffixDomain},
+		{name: "multi-label public suffix rejected", in: "co.uk", wantErr: errPublicSuffixDomain},
+		{name: "consumer gmail rejected", in: "gmail.com", wantErr: errConsumerDomain},
+		{name: "consumer outlook rejected", in: "outlook.com", wantErr: errConsumerDomain},
+		{name: "consumer yahoo rejected", in: "yahoo.com", wantErr: errConsumerDomain},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := guardVerifiableDomain(tc.in)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("guardVerifiableDomain(%q) unexpected error: %v", tc.in, err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("guardVerifiableDomain(%q) = %v, want %v", tc.in, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestChallengeTokenIsRandomBase32(t *testing.T) {
+	a, err := generateDomainChallengeToken()
+	if err != nil {
+		t.Fatalf("generateDomainChallengeToken error: %v", err)
+	}
+	b, err := generateDomainChallengeToken()
+	if err != nil {
+		t.Fatalf("generateDomainChallengeToken error: %v", err)
+	}
+	if a == b {
+		t.Fatal("two tokens collided — not random")
+	}
+	// 32 bytes base32 (no padding) = 52 chars.
+	if len(a) != 52 {
+		t.Fatalf("token length = %d, want 52", len(a))
+	}
+}

--- a/internal/service/provider.go
+++ b/internal/service/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/events"
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/memory_store"
+	"github.com/authorizerdev/authorizer/internal/rate_limit"
 	"github.com/authorizerdev/authorizer/internal/sms"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/token"
@@ -37,6 +38,12 @@ type Dependencies struct {
 	SMSProvider         sms.Provider
 	StorageProvider     storage.Provider
 	TokenProvider       token.Provider
+	// RateLimitProvider throttles abuse-prone admin ops (e.g. per-org domain
+	// verification, which drives an outbound DNS lookup). Nil disables the limit.
+	RateLimitProvider rate_limit.Provider
+	// DNSResolver resolves TXT records for domain verification. Nil uses
+	// net.DefaultResolver; tests inject a mock so no real DNS is hit.
+	DNSResolver DNSResolver
 }
 
 // Provider is the transport-agnostic API for Authorizer public operations.

--- a/internal/storage/db/arangodb/org_domain.go
+++ b/internal/storage/db/arangodb/org_domain.go
@@ -1,0 +1,134 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	arangoDriver "github.com/arangodb/go-driver"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgDomain atomically inserts a verified domain row. The document _key is
+// the normalized domain, so a duplicate CreateDocument is rejected by ArangoDB
+// (unique-constraint conflict) — first-writer wins with no check-then-insert
+// race. On any create error we classify by re-reading the row: same org →
+// idempotent success, different org → ErrOrgDomainConflict.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	orgDomainCollection, err := p.db.Collection(ctx, schemas.Collections.OrgDomain)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := structToDocument(domain)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := orgDomainCollection.CreateDocument(ctx, doc); err != nil {
+		existing, getErr := p.GetOrgDomainByDomain(ctx, domain.ID)
+		if getErr == nil && existing != nil {
+			if existing.OrgID == domain.OrgID {
+				return existing, nil
+			}
+			return nil, schemas.ErrOrgDomainConflict
+		}
+		return nil, err
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value.
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	var orgDomain *schemas.OrgDomain
+	query := fmt.Sprintf("FOR d in %s FILTER d.domain == @domain LIMIT 1 RETURN d", schemas.Collections.OrgDomain)
+	bindVars := map[string]interface{}{
+		"domain": domain,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if orgDomain == nil {
+				return nil, fmt.Errorf("org domain not found")
+			}
+			break
+		}
+		d := &schemas.OrgDomain{}
+		if _, err := readDocument(ctx, cursor, d); err != nil {
+			return nil, err
+		}
+		orgDomain = d
+	}
+	return orgDomain, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	domains := []*schemas.OrgDomain{}
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id SORT d.created_at DESC LIMIT %d, %d RETURN d", schemas.Collections.OrgDomain, pagination.Offset, pagination.Limit)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+	}
+	sctx := arangoDriver.WithQueryFullCount(ctx)
+	cursor, err := p.db.Query(sctx, query, bindVars)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	paginationClone := pagination
+	paginationClone.Total = cursor.Statistics().FullCount()
+	for {
+		d := &schemas.OrgDomain{}
+		meta, err := readDocument(ctx, cursor, d)
+		if arangoDriver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, nil, err
+		}
+		if meta.Key != "" {
+			domains = append(domains, d)
+		}
+	}
+	return domains, paginationClone, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+// The _key is the domain, so remove by key.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	orgDomainCollection, err := p.db.Collection(ctx, schemas.Collections.OrgDomain)
+	if err != nil {
+		return err
+	}
+	if _, err := orgDomainCollection.RemoveDocument(ctx, domain); err != nil {
+		if arangoDriver.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	query := fmt.Sprintf("FOR d IN %s FILTER d.org_id == @org_id REMOVE { _key: d._key } IN %s", schemas.Collections.OrgDomain, schemas.Collections.OrgDomain)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cursor.Close() }()
+	return nil
+}

--- a/internal/storage/db/arangodb/organization.go
+++ b/internal/storage/db/arangodb/organization.go
@@ -78,6 +78,12 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 		return err
 	}
 	defer func() { _ = cursor.Close() }()
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique _key of org_domains). OrgID is stored as the
+	// bare key, matching org.Key.
+	if err := p.DeleteOrgDomainsByOrg(ctx, org.Key); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -475,6 +475,25 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Unique: true,
 	})
 
+	// OrgDomain collection and indexes. Uniqueness is enforced by the document
+	// _key being the normalized domain (atomic first-writer-wins); org_id is
+	// indexed (non-unique) for listing an org's domains.
+	orgDomainCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.OrgDomain)
+	if err != nil {
+		return nil, err
+	}
+	if !orgDomainCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.OrgDomain, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	orgDomainCollection, err := arangodb.Collection(ctx, schemas.Collections.OrgDomain)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = orgDomainCollection.EnsurePersistentIndex(ctx, []string{"org_id"}, &arangoDriver.EnsurePersistentIndexOptions{})
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/cassandradb/org_domain.go
+++ b/internal/storage/db/cassandradb/org_domain.go
@@ -1,0 +1,113 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gocql/gocql"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const orgDomainColumns = "id, org_id, domain, verified_at, created_at, updated_at"
+
+// scanOrgDomain maps the orgDomainColumns projection onto a struct.
+func scanOrgDomain(scan func(...interface{}) error, d *schemas.OrgDomain) error {
+	return scan(&d.ID, &d.OrgID, &d.Domain, &d.VerifiedAt, &d.CreatedAt, &d.UpdatedAt)
+}
+
+// AddOrgDomain atomically inserts a verified domain row. The normalized domain
+// is the partition key and the insert is a lightweight transaction
+// (INSERT ... IF NOT EXISTS), so first-writer-wins is enforced atomically —
+// unlike the scim_endpoint check-then-insert guard, there is NO TOCTOU race. On
+// a lost race the CAS returns the existing row, which we classify by owning org.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?) IF NOT EXISTS", KeySpace+"."+schemas.Collections.OrgDomain, orgDomainColumns)
+	existing := map[string]interface{}{}
+	applied, err := p.db.Query(insertQuery, domain.ID, domain.OrgID, domain.Domain, domain.VerifiedAt, domain.CreatedAt, domain.UpdatedAt).MapScanCAS(existing)
+	if err != nil {
+		return nil, err
+	}
+	if !applied {
+		// A row already exists for this domain; classify by owning org.
+		if ownerOrg, ok := existing["org_id"].(string); ok && ownerOrg == domain.OrgID {
+			return p.GetOrgDomainByDomain(ctx, domain.ID)
+		}
+		return nil, schemas.ErrOrgDomainConflict
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value (PK).
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	var d schemas.OrgDomain
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", orgDomainColumns, KeySpace+"."+schemas.Collections.OrgDomain)
+	if err := scanOrgDomain(p.db.Query(query, domain).Consistency(gocql.One).Scan, &d); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	domains := []*schemas.OrgDomain{}
+	paginationClone := pagination
+	table := KeySpace + "." + schemas.Collections.OrgDomain
+
+	totalCountQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE org_id = ? ALLOW FILTERING", table)
+	if err := p.db.Query(totalCountQuery, orgID).Consistency(gocql.One).Scan(&paginationClone.Total); err != nil {
+		return nil, nil, err
+	}
+
+	// there is no offset in cassandra: fetch limit + offset, return offset..limit
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? LIMIT %d ALLOW FILTERING", orgDomainColumns, table, pagination.Limit+pagination.Offset)
+	scanner := p.db.Query(query, orgID).Iter().Scanner()
+	counter := int64(0)
+	for scanner.Next() {
+		if counter >= pagination.Offset {
+			var d schemas.OrgDomain
+			if err := scanOrgDomain(scanner.Scan, &d); err != nil {
+				return nil, nil, err
+			}
+			domains = append(domains, &d)
+		}
+		counter++
+	}
+	return domains, paginationClone, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.OrgDomain)
+	return p.db.Query(query, domain).Exec()
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	selectQuery := fmt.Sprintf("SELECT id FROM %s WHERE org_id = ? ALLOW FILTERING", KeySpace+"."+schemas.Collections.OrgDomain)
+	scanner := p.db.Query(selectQuery, orgID).Iter().Scanner()
+	var ids []string
+	for scanner.Next() {
+		var id string
+		if err := scanner.Scan(&id); err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.OrgDomain)
+	for _, id := range ids {
+		if err := p.db.Query(deleteQuery, id).Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/storage/db/cassandradb/organization.go
+++ b/internal/storage/db/cassandradb/organization.go
@@ -108,7 +108,9 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 			return err
 		}
 	}
-	return nil
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique partition key of org_domains).
+	return p.DeleteOrgDomainsByOrg(ctx, org.ID)
 }
 
 // GetOrganizationByID fetches an organization by primary key.

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -511,6 +511,20 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	// GetScimEndpointByOrgID and the uniqueness guard) to become queryable.
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.ScimEndpoint, "org_id", 30*time.Second)
 
+	// OrgDomain table and index. The normalized domain is the partition key, so
+	// INSERT ... IF NOT EXISTS enforces first-writer-wins atomically (LWT).
+	orgDomainCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, domain text, verified_at bigint, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.OrgDomain)
+	if err = session.Query(orgDomainCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	orgDomainOrgIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_org_domain_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.OrgDomain)
+	if err = session.Query(orgDomainOrgIndex).Exec(); err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for org_id (used by
+	// ListOrgDomainsByOrg and the cascade) to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.OrgDomain, "org_id", 30*time.Second)
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/couchbase/org_domain.go
+++ b/internal/storage/db/couchbase/org_domain.go
@@ -1,0 +1,145 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const orgDomainColumns = "_id, org_id, domain, verified_at, created_at, updated_at"
+
+// AddOrgDomain atomically inserts a verified domain row. The document key is the
+// normalized domain and the write is an Insert (not Upsert), so a duplicate is
+// rejected by Couchbase (ErrDocumentExists) — unlike the scim_endpoint
+// check-then-insert guard, there is NO TOCTOU race. On a lost race we classify
+// the existing row by owning org.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	doc, err := structToDocument(domain)
+	if err != nil {
+		return nil, err
+	}
+	insertOpt := gocb.InsertOptions{Context: ctx}
+	_, err = p.db.Collection(schemas.Collections.OrgDomain).Insert(domain.ID, doc, &insertOpt)
+	if err != nil {
+		if errors.Is(err, gocb.ErrDocumentExists) {
+			existing, getErr := p.GetOrgDomainByDomain(ctx, domain.ID)
+			if getErr == nil && existing != nil {
+				if existing.OrgID == domain.OrgID {
+					return existing, nil
+				}
+				return nil, schemas.ErrOrgDomainConflict
+			}
+		}
+		return nil, err
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value.
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	params := map[string]interface{}{"_id": domain}
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, orgDomainColumns, p.scopeName, schemas.Collections.OrgDomain)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	d := &schemas.OrgDomain{}
+	if err := decodeDocument(raw, d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	domains := []*schemas.OrgDomain{}
+	paginationClone := pagination
+	table := fmt.Sprintf("%s.%s", p.scopeName, schemas.Collections.OrgDomain)
+
+	params := map[string]interface{}{
+		"offset":       paginationClone.Offset,
+		"limit":        paginationClone.Limit,
+		"filter_value": orgID,
+	}
+	total := TotalDocs{}
+	countQuery := fmt.Sprintf("SELECT COUNT(*) as Total FROM %s WHERE org_id=$filter_value", table)
+	countRes, err := p.db.Query(countQuery, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: map[string]interface{}{"filter_value": orgID},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = countRes.One(&total)
+	paginationClone.Total = total.Total
+
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id=$filter_value ORDER BY created_at DESC OFFSET $offset LIMIT $limit", orgDomainColumns, table)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, nil, err
+		}
+		d := &schemas.OrgDomain{}
+		if err := decodeDocument(raw, d); err != nil {
+			return nil, nil, err
+		}
+		domains = append(domains, d)
+	}
+	if err := queryResult.Err(); err != nil {
+		return nil, nil, err
+	}
+	return domains, paginationClone, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	removeOpt := gocb.RemoveOptions{Context: ctx}
+	_, err := p.db.Collection(schemas.Collections.OrgDomain).Remove(domain, &removeOpt)
+	if err != nil && !errors.Is(err, gocb.ErrDocumentNotFound) {
+		return err
+	}
+	return nil
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	params := map[string]interface{}{"org_id": orgID}
+	query := fmt.Sprintf(`DELETE FROM %s.%s WHERE org_id=$org_id`, p.scopeName, schemas.Collections.OrgDomain)
+	_, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	return err
+}

--- a/internal/storage/db/couchbase/organization.go
+++ b/internal/storage/db/couchbase/organization.go
@@ -90,7 +90,9 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 	if err != nil {
 		return err
 	}
-	return nil
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique document key of org_domains).
+	return p.DeleteOrgDomainsByOrg(ctx, org.ID)
 }
 
 // GetOrganizationByID fetches an organization by primary key.

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -312,5 +312,10 @@ func getIndex(scopeName string) map[string][]string {
 	scimEndpointIndex1 := fmt.Sprintf("CREATE INDEX ScimEndpointOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.ScimEndpoint)
 	indices[schemas.Collections.ScimEndpoint] = []string{scimEndpointIndex1}
 
+	// OrgDomain index (uniqueness is enforced by the document key = domain;
+	// org_id is indexed for listing).
+	orgDomainIndex1 := fmt.Sprintf("CREATE INDEX OrgDomainOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.OrgDomain)
+	indices[schemas.Collections.OrgDomain] = []string{orgDomainIndex1}
+
 	return indices
 }

--- a/internal/storage/db/dynamodb/ops.go
+++ b/internal/storage/db/dynamodb/ops.go
@@ -23,6 +23,23 @@ func (p *provider) putItem(ctx context.Context, table string, v interface{}) err
 	return err
 }
 
+// putItemIfAbsent writes an item only when no item with the same partition key
+// (hashKey) already exists. The condition is evaluated atomically by DynamoDB,
+// so it is a race-free first-writer-wins insert. On a lost race it returns a
+// *types.ConditionalCheckFailedException (detect with errors.As).
+func (p *provider) putItemIfAbsent(ctx context.Context, table, hashKey string, v interface{}) error {
+	item, err := marshalStruct(v)
+	if err != nil {
+		return err
+	}
+	_, err = p.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(table),
+		Item:                item,
+		ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s)", hashKey)),
+	})
+	return err
+}
+
 func (p *provider) getItemByHash(ctx context.Context, table, hashKey, hashValue string, out interface{}) error {
 	res, err := p.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(table),

--- a/internal/storage/db/dynamodb/org_domain.go
+++ b/internal/storage/db/dynamodb/org_domain.go
@@ -1,0 +1,108 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgDomain atomically inserts a verified domain row. The partition key "id"
+// holds the normalized domain and the write is a conditional PutItem
+// (attribute_not_exists), so first-writer-wins is enforced atomically by
+// DynamoDB — unlike the scim_endpoint check-then-insert guard, there is NO
+// TOCTOU race. On a lost race we classify the existing row by owning org.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	err := p.putItemIfAbsent(ctx, schemas.Collections.OrgDomain, "id", domain)
+	if err != nil {
+		var conditional *types.ConditionalCheckFailedException
+		if errors.As(err, &conditional) {
+			existing, getErr := p.GetOrgDomainByDomain(ctx, domain.ID)
+			if getErr == nil && existing != nil {
+				if existing.OrgID == domain.OrgID {
+					return existing, nil
+				}
+				return nil, schemas.ErrOrgDomainConflict
+			}
+		}
+		return nil, err
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value (the
+// partition key).
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	var d schemas.OrgDomain
+	if err := p.getItemByHash(ctx, schemas.Collections.OrgDomain, "id", domain, &d); err != nil {
+		return nil, err
+	}
+	if d.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &d, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	paginationClone := pagination
+	items, err := p.queryEq(ctx, schemas.Collections.OrgDomain, "org_id", "org_id", orgID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var domains []*schemas.OrgDomain
+	for _, it := range items {
+		var d schemas.OrgDomain
+		if err := unmarshalItem(it, &d); err != nil {
+			return nil, nil, err
+		}
+		domains = append(domains, &d)
+	}
+	sort.Slice(domains, func(i, j int) bool { return domains[i].CreatedAt > domains[j].CreatedAt })
+	paginationClone.Total = int64(len(domains))
+
+	start := int(pagination.Offset)
+	if start >= len(domains) {
+		return []*schemas.OrgDomain{}, paginationClone, nil
+	}
+	end := start + int(pagination.Limit)
+	if end > len(domains) {
+		end = len(domains)
+	}
+	return domains[start:end], paginationClone, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	return p.deleteItemByHash(ctx, schemas.Collections.OrgDomain, "id", domain)
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	items, err := p.queryEq(ctx, schemas.Collections.OrgDomain, "org_id", "org_id", orgID, nil)
+	if err != nil {
+		return err
+	}
+	for _, it := range items {
+		var d schemas.OrgDomain
+		if err := unmarshalItem(it, &d); err != nil {
+			return err
+		}
+		if err := p.deleteItemByHash(ctx, schemas.Collections.OrgDomain, "id", d.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/storage/db/dynamodb/organization.go
+++ b/internal/storage/db/dynamodb/organization.go
@@ -69,6 +69,11 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 			return err
 		}
 	}
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique partition key of org_domains).
+	if err := p.DeleteOrgDomainsByOrg(ctx, org.ID); err != nil {
+		return err
+	}
 	return p.deleteItemByHash(ctx, schemas.Collections.Organization, "id", org.ID)
 }
 

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -243,6 +243,17 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			},
 			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
 		},
+		{
+			// OrgDomain: partition key "id" holds the normalized domain, so a
+			// conditional PutItem (attribute_not_exists) is a race-free unique insert.
+			name: schemas.Collections.OrgDomain,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
+		},
 	}
 
 	for _, t := range tables {

--- a/internal/storage/db/mongodb/org_domain.go
+++ b/internal/storage/db/mongodb/org_domain.go
@@ -1,0 +1,98 @@
+package mongodb
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgDomain atomically inserts a verified domain row. _id is the normalized
+// domain, so a duplicate insert is rejected by MongoDB (E11000) — first-writer
+// wins with no check-then-insert race. On conflict we classify by owning org.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	orgDomainCollection := p.db.Collection(schemas.Collections.OrgDomain, options.Collection())
+	_, err := orgDomainCollection.InsertOne(ctx, domain)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			existing, getErr := p.GetOrgDomainByDomain(ctx, domain.ID)
+			if getErr == nil && existing != nil {
+				if existing.OrgID == domain.OrgID {
+					return existing, nil
+				}
+				return nil, schemas.ErrOrgDomainConflict
+			}
+		}
+		return nil, err
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value (_id).
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	var d *schemas.OrgDomain
+	orgDomainCollection := p.db.Collection(schemas.Collections.OrgDomain, options.Collection())
+	err := orgDomainCollection.FindOne(ctx, bson.M{"_id": domain}).Decode(&d)
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	orgDomainCollection := p.db.Collection(schemas.Collections.OrgDomain, options.Collection())
+	total, err := orgDomainCollection.CountDocuments(ctx, bson.M{"org_id": orgID})
+	if err != nil {
+		return nil, nil, err
+	}
+	opts := options.Find()
+	opts.SetLimit(pagination.Limit)
+	opts.SetSkip(pagination.Offset)
+	opts.SetSort(bson.M{"created_at": -1})
+	cursor, err := orgDomainCollection.Find(ctx, bson.M{"org_id": orgID}, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	domains := []*schemas.OrgDomain{}
+	for cursor.Next(ctx) {
+		var d schemas.OrgDomain
+		if err := cursor.Decode(&d); err != nil {
+			return nil, nil, err
+		}
+		domains = append(domains, &d)
+	}
+	return domains, &model.Pagination{
+		Limit:  pagination.Limit,
+		Page:   pagination.Page,
+		Offset: pagination.Offset,
+		Total:  total,
+	}, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	orgDomainCollection := p.db.Collection(schemas.Collections.OrgDomain, options.Collection())
+	_, err := orgDomainCollection.DeleteOne(ctx, bson.M{"_id": domain}, options.Delete())
+	return err
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	orgDomainCollection := p.db.Collection(schemas.Collections.OrgDomain, options.Collection())
+	_, err := orgDomainCollection.DeleteMany(ctx, bson.M{"org_id": orgID}, options.Delete())
+	return err
+}

--- a/internal/storage/db/mongodb/organization.go
+++ b/internal/storage/db/mongodb/organization.go
@@ -60,7 +60,9 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 	if err != nil {
 		return err
 	}
-	return nil
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique _id of org_domains).
+	return p.DeleteOrgDomainsByOrg(ctx, org.ID)
 }
 
 // GetOrganizationByID fetches an organization by primary key.

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -278,6 +278,16 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// OrgDomain collection and indexes. Uniqueness is enforced by _id being the
+	// normalized domain (no unique index needed); org_id is indexed for listing.
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.OrgDomain, options.CreateCollection())
+	orgDomainCollection := mongodb.Collection(schemas.Collections.OrgDomain, options.Collection())
+	_, _ = orgDomainCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.M{"org_id": 1},
+		},
+	}, options.CreateIndexes())
+
 	return &provider{
 		config:       config,
 		dependencies: deps,

--- a/internal/storage/db/sql/org_domain.go
+++ b/internal/storage/db/sql/org_domain.go
@@ -1,0 +1,75 @@
+package sql
+
+import (
+	"context"
+	"time"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddOrgDomain atomically inserts a verified domain row. The domain is the
+// primary key, so a duplicate insert fails at the DB (unique PK) — first-writer
+// wins with no check-then-insert race. On conflict we classify by owning org:
+// same org → idempotent success, different org → ErrOrgDomainConflict.
+func (p *provider) AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error) {
+	domain.Key = domain.ID
+	now := time.Now().Unix()
+	domain.CreatedAt = now
+	domain.UpdatedAt = now
+	if domain.VerifiedAt == 0 {
+		domain.VerifiedAt = now
+	}
+	res := p.db.Create(domain)
+	if res.Error != nil {
+		existing, getErr := p.GetOrgDomainByDomain(ctx, domain.ID)
+		if getErr == nil && existing != nil {
+			if existing.OrgID == domain.OrgID {
+				return existing, nil
+			}
+			return nil, schemas.ErrOrgDomainConflict
+		}
+		return nil, res.Error
+	}
+	return domain, nil
+}
+
+// GetOrgDomainByDomain fetches a verified domain by its normalized value (PK).
+func (p *provider) GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error) {
+	var d schemas.OrgDomain
+	res := p.db.Where("id = ?", domain).First(&d)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &d, nil
+}
+
+// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+func (p *provider) ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error) {
+	var domains []*schemas.OrgDomain
+	res := p.db.Where("org_id = ?", orgID).Limit(int(pagination.Limit)).Offset(int(pagination.Offset)).Order("created_at DESC").Find(&domains)
+	if res.Error != nil {
+		return nil, nil, res.Error
+	}
+	var total int64
+	countRes := p.db.Model(&schemas.OrgDomain{}).Where("org_id = ?", orgID).Count(&total)
+	if countRes.Error != nil {
+		return nil, nil, countRes.Error
+	}
+	return domains, &model.Pagination{
+		Limit:  pagination.Limit,
+		Page:   pagination.Page,
+		Offset: pagination.Offset,
+		Total:  total,
+	}, nil
+}
+
+// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+func (p *provider) DeleteOrgDomain(ctx context.Context, domain string) error {
+	return p.db.Where("id = ?", domain).Delete(&schemas.OrgDomain{}).Error
+}
+
+// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade).
+func (p *provider) DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error {
+	return p.db.Where("org_id = ?", orgID).Delete(&schemas.OrgDomain{}).Error
+}

--- a/internal/storage/db/sql/organization.go
+++ b/internal/storage/db/sql/organization.go
@@ -49,6 +49,11 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 	if err := p.db.Where("org_id = ?", org.ID).Delete(&schemas.OrgMembership{}).Error; err != nil {
 		return err
 	}
+	// Cascade verified domains — otherwise the domain becomes permanently
+	// unclaimable (it is the unique PK of org_domains).
+	if err := p.DeleteOrgDomainsByOrg(ctx, org.ID); err != nil {
+		return err
+	}
 	return p.db.Delete(org).Error
 }
 

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{}, &schemas.OrgDomain{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -291,6 +291,26 @@ type Provider interface {
 	UpdateScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) (*schemas.ScimEndpoint, error)
 	// DeleteScimEndpoint removes an endpoint.
 	DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error
+
+	// OrgDomain methods (verified domain → org mapping for home-realm discovery).
+
+	// AddOrgDomain atomically inserts a verified domain row, keyed by the
+	// normalized domain (the primary/partition key). First-writer-wins:
+	//   - domain unclaimed → inserts and returns the new row.
+	//   - domain already held by the SAME org → returns the existing row (idempotent).
+	//   - domain already held by a DIFFERENT org → returns schemas.ErrOrgDomainConflict.
+	// ID and Domain MUST both be set to the normalized domain by the caller.
+	AddOrgDomain(ctx context.Context, domain *schemas.OrgDomain) (*schemas.OrgDomain, error)
+	// GetOrgDomainByDomain fetches the verified row for a normalized domain
+	// (the home-realm-discovery reverse lookup — a primary-key GET).
+	GetOrgDomainByDomain(ctx context.Context, domain string) (*schemas.OrgDomain, error)
+	// ListOrgDomainsByOrg returns an org's verified domains, paginated.
+	ListOrgDomainsByOrg(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.OrgDomain, *model.Pagination, error)
+	// DeleteOrgDomain removes a verified domain mapping by normalized domain.
+	DeleteOrgDomain(ctx context.Context, domain string) error
+	// DeleteOrgDomainsByOrg removes all of an org's verified domains (cascade on
+	// org delete — otherwise the domain becomes permanently unclaimable).
+	DeleteOrgDomainsByOrg(ctx context.Context, orgID string) error
 }
 
 // New creates a new database provider based on the configuration

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -207,6 +207,9 @@ func TestStorageProvider(t *testing.T) {
 			t.Run("SCIM Endpoint Operations", func(t *testing.T) {
 				testScimEndpointOperations(t, ctx, provider)
 			})
+			t.Run("Org Domain Operations", func(t *testing.T) {
+				testOrgDomainOperations(t, ctx, provider)
+			})
 
 			t.Run("User SCIM Fields", func(t *testing.T) {
 				testUserScimFields(t, ctx, provider)
@@ -1852,6 +1855,110 @@ func testScimEndpointOperations(t *testing.T, ctx context.Context, provider Prov
 	assert.Error(t, err, "endpoint should be gone after delete")
 
 	require.NoError(t, provider.DeleteOrganization(ctx, org))
+}
+
+// testOrgDomainOperations exercises the verified-domain table: atomic
+// first-writer-wins on the domain primary key, same-org idempotency, listing,
+// delete, and the org-delete cascade (which frees the domain for re-claim).
+func testOrgDomainOperations(t *testing.T, ctx context.Context, provider Provider) {
+	orgA, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "domain-org-a-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgAID := orgA.AsAPIOrganization().ID
+	orgB, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "domain-org-b-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgBID := orgB.AsAPIOrganization().ID
+
+	// unique per run so parallel DBs / reruns don't collide on the shared PK.
+	domain := "acme-" + strings.ToLower(uuid.New().String()[:8]) + ".com"
+
+	// Insert a verified domain for org A.
+	created, err := provider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgAID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, domain, created.Domain)
+
+	// Reverse lookup (the HRD path) resolves the owning org.
+	byDomain, err := provider.GetOrgDomainByDomain(ctx, domain)
+	require.NoError(t, err)
+	assert.Equal(t, orgAID, byDomain.OrgID)
+	assert.Equal(t, domain, byDomain.Domain)
+	assert.NotZero(t, byDomain.VerifiedAt)
+
+	// Same-org re-add is idempotent: no error, no duplicate.
+	again, err := provider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgAID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, orgAID, again.OrgID)
+
+	// First-writer-wins: org B claiming the SAME domain must be rejected
+	// distinctly (this is the ATO invariant — one verified domain, one org).
+	_, err = provider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgBID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	require.ErrorIs(t, err, schemas.ErrOrgDomainConflict)
+
+	// The row still points to org A after the losing write.
+	stillA, err := provider.GetOrgDomainByDomain(ctx, domain)
+	require.NoError(t, err)
+	assert.Equal(t, orgAID, stillA.OrgID)
+
+	// A second distinct domain for org A, to prove listing + cascade cover many.
+	domain2 := "beta-" + strings.ToLower(uuid.New().String()[:8]) + ".com"
+	_, err = provider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain2,
+		Domain:     domain2,
+		OrgID:      orgAID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	list, _, err := provider.ListOrgDomainsByOrg(ctx, orgAID, &model.Pagination{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+
+	// Delete one domain; it disappears, the other remains.
+	require.NoError(t, provider.DeleteOrgDomain(ctx, domain2))
+	_, err = provider.GetOrgDomainByDomain(ctx, domain2)
+	assert.Error(t, err)
+	remaining, _, err := provider.ListOrgDomainsByOrg(ctx, orgAID, &model.Pagination{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+
+	// Cascade: deleting org A must free its remaining verified domain (M1) —
+	// otherwise the unique PK makes it permanently unclaimable.
+	require.NoError(t, provider.DeleteOrganization(ctx, orgA))
+	_, err = provider.GetOrgDomainByDomain(ctx, domain)
+	assert.Error(t, err, "domain must be gone after its org is deleted")
+
+	// The freed domain is now re-claimable by org B.
+	reclaimed, err := provider.AddOrgDomain(ctx, &schemas.OrgDomain{
+		ID:         domain,
+		Domain:     domain,
+		OrgID:      orgBID,
+		VerifiedAt: time.Now().Unix(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, orgBID, reclaimed.OrgID)
+
+	require.NoError(t, provider.DeleteOrganization(ctx, orgB))
 }
 
 // testUserScimFields verifies the additive User fields (ExternalID, IsActive)

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -22,6 +22,7 @@ type CollectionList struct {
 	OrgMembership          string
 	FederatedIdentity      string
 	ScimEndpoint           string
+	OrgDomain              string
 }
 
 var (
@@ -49,5 +50,6 @@ var (
 		OrgMembership:          Prefix + "org_memberships",
 		FederatedIdentity:      Prefix + "federated_identities",
 		ScimEndpoint:           Prefix + "scim_endpoints",
+		OrgDomain:              Prefix + "org_domains",
 	}
 )

--- a/internal/storage/schemas/org_domain.go
+++ b/internal/storage/schemas/org_domain.go
@@ -1,0 +1,67 @@
+package schemas
+
+import (
+	"errors"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// ErrOrgDomainConflict is returned by AddOrgDomain when the normalized domain
+// is already verified by a DIFFERENT organization. It is the atomic
+// first-writer-wins signal — the service layer maps it to
+// "domain_already_verified_by_another_org". A same-org re-verify is NOT a
+// conflict (AddOrgDomain returns the existing row, idempotently).
+var ErrOrgDomainConflict = errors.New("domain already verified by another organization")
+
+// OrgDomain is a VERIFIED mapping from a DNS domain to exactly one organization,
+// used for home-realm discovery (routing a login to the right tenant IdP). A row
+// exists ONLY once a domain is verified; a pending verification challenge is
+// ephemeral state in the memory store, never a row here.
+//
+// Uniqueness is the load-bearing security invariant (one verified domain → one
+// org). It is enforced by the PRIMARY/partition key being the normalized domain
+// itself, NOT a secondary unique index: DynamoDB, Cassandra and Couchbase cannot
+// enforce a unique constraint on a non-key attribute, so a check-then-insert
+// guard would race. With the domain as the key, first-writer-wins is atomic on
+// every backend (unique PK / conditional put / INSERT ... IF NOT EXISTS).
+//
+// ID holds the normalized domain and is the primary key. Domain holds the same
+// value as a human-readable column (never expose ID directly — on ArangoDB a
+// read populates it with the "collection/key" handle; use Domain / AsAPIOrgDomain).
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type OrgDomain struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	// ID is the primary key: the normalized domain (punycode, lowercased). Not a
+	// uuid — the domain IS the key so uniqueness is enforced by the DB atomically.
+	ID string `gorm:"primaryKey;type:varchar(255)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID is the organization this verified domain routes to. Indexed for
+	// ListOrgDomainsByOrg; NOT unique (an org may verify many domains).
+	OrgID string `gorm:"index" json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" index:"org_id,hash"`
+
+	// Domain is the normalized domain as a readable column (== ID).
+	Domain string `json:"domain" bson:"domain" cql:"domain" dynamo:"domain"`
+
+	// VerifiedAt is when the domain became verified (unix seconds).
+	VerifiedAt int64 `json:"verified_at" bson:"verified_at" cql:"verified_at" dynamo:"verified_at"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPIOrgDomain converts the storage record into the GraphQL model. It exposes
+// Domain (never ID — on ArangoDB a read populates ID with the "collection/key"
+// handle).
+func (d *OrgDomain) AsAPIOrgDomain() *model.OrgDomain {
+	return &model.OrgDomain{
+		Domain:     d.Domain,
+		OrgID:      d.OrgID,
+		VerifiedAt: refs.NewInt64Ref(d.VerifiedAt),
+		CreatedAt:  refs.NewInt64Ref(d.CreatedAt),
+		UpdatedAt:  refs.NewInt64Ref(d.UpdatedAt),
+	}
+}


### PR DESCRIPTION
Phase 2 of the multi-tenant SSO epic (spec: authorizerdev/docs#74). Stacks on #672 (Phase 1) — **merge #672 first**. Adds 1:N verified email domains per organization; domains drive routing only (domain ≠ membership).

## What
- New `org_domains` table across all 6 storage families. **The normalized domain is the PRIMARY/partition key** so first-writer-wins uniqueness is enforced atomically on every backend (B1 fix): SQL PK, Mongo `_id`, Arango `_key`, Cassandra `INSERT ... IF NOT EXISTS`+LWT, DynamoDB `attribute_not_exists` condition, Couchbase `Insert`. Conflict → same-org idempotent, different-org → `ErrOrgDomainConflict`. No check-then-insert race.
- Verification: **DNS TXT** self-serve (`_authorizer-challenge.<domain>`, `crypto/rand` token in memory_store, 5s-bounded resolver, exact match) + **super-admin trusted-assert** (`_add_verified_org_domain`). Inbox auto-verify deliberately dropped from v1.
- Single shared `normalizeDomain` (IDNA UTS-46 non-transitional) + `guardVerifiableDomain` (public-suffix + consumer blocklist); exact-match only (no implicit subdomain capture).
- Admin ops org-scoped-admin gated (`_request_org_domain`, `_verify_org_domain`, `_org_domains`, `_delete_org_domain` — delete loads the row and authorizes on its OrgID); `_add_verified_org_domain` super-admin only.
- **Org-delete cascade** (`DeleteOrgDomainsByOrg`) on all 6 providers, so a deleted tenant's domain is reclaimable.
- GraphQL-only (matches every existing org-admin op; no proto surface for org-admin today).

## Security review (security-engineer): SOUND, no BLOCKER/HIGH/MEDIUM
Verified first-writer-wins atomicity on all 6 backends, DNS challenge integrity, normalization/homograph/public-suffix guards, org-scoped isolation, cascade, and challenge lifecycle. Two LOWs actioned: rate-limit added to `_request_org_domain` for symmetry (this commit); the super-admin-verify orphan-row note was already closed structurally (verify needs a challenge only the org-exists-checked request path mints). Left as-noted: limiter fail-open (matches codebase convention) and a nice-to-have concurrent-insert test (atomicity is correct by construction).

## Testing
- `TestOrgVerifiedDomains` (9 subtests): request-no-row, verify correct/wrong TXT (mock resolver), first-writer-wins, public-suffix/consumer reject, normalization, trusted-assert super-admin-only, org-scoped isolation, org-delete cascade + reclaim, member/non-member deny.
- Storage `org_domains` round-trip + conflict + cascade wired into the `TEST_DBS` harness (ran on SQLite; recommend `make test-all-db` before merge for the Docker matrix).
- Full `TEST_DBS=sqlite` integration suite + service unit tests pass; build/vet/gofmt/golangci-lint clean; graphql/proto codegen parity.

Phase 3 (`/app` home realm discovery + `/api/v1/org-discovery`) follows.