### PR TITLE
chore(app): login UI on authorizer-react 2.2.0-rc.0

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "^2.0.7",
+				"@authorizerdev/authorizer-react": "2.2.0-rc.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-js": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.0.4.tgz",
-			"integrity": "sha512-vkXg1inxC6U2eLra/EQmhTVKzdlpCF4+a93tOfUgSyISYnE8v9np54OAOrs//4aTVOwFTIhahSTvpERKj2NZAQ==",
+			"version": "3.3.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.0.tgz",
+			"integrity": "sha512-P9S25JZpSqYR46YOT1W6BugfQkqHaswFLkUt4drJLPHH3vecRCUC0IczHMT2NkAbZzILoBh3LNOdV1BFd61CLw==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-fetch": "^4.1.0"
@@ -43,12 +43,12 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.0.7.tgz",
-			"integrity": "sha512-+qBrbdE6VyljOge1Ad2AmVIpoheymlLsMxCZHW0hnCeKf0R0wJz3MvoKBiaHAcRF/Bf8Wc6+NBCctAnzXjiwMg==",
+			"version": "2.2.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.0.tgz",
+			"integrity": "sha512-Fyca/MSRzShneUAsk8HNTZLSTzPY/ePW7bwh0CFyEYWobqItlK7Y2YEtc8+capHD7oghvzT1slxLRhMWgi+zcQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@authorizerdev/authorizer-js": "3.0.4",
+				"@authorizerdev/authorizer-js": "3.3.0-rc.0",
 				"@storybook/preset-scss": "^1.0.3",
 				"validator": "^13.11.0"
 			},

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
 	"author": "Lakhan Samani",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@authorizerdev/authorizer-react": "^2.0.7",
+		"@authorizerdev/authorizer-react": "2.2.0-rc.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-is": "^18.3.1",


### PR DESCRIPTION
Phase 2 of the RC e2e prep. Bumps `web/app` (the hosted login page) to `@authorizerdev/authorizer-react@2.2.0-rc.0`, which transitively resolves `@authorizerdev/authorizer-js@3.3.0-rc.0`.

This brings the passkey login and non-dismissible TOTP-lockout UI into the bundled login page. Verified: `npm run build` (vite) succeeds; deps resolve to react 2.2.0-rc.0 / js 3.3.0-rc.0.

After merge, the next server release **2.4.0-rc.0** bundles this app (login-UI e2e). Revert to the stable `^2.x` range when the SDKs cut stable.