### PR TITLE
test: fix make test-all-db TempDir cleanup race

### DIFF
--- a/internal/integration_tests/test_helper.go
+++ b/internal/integration_tests/test_helper.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -216,7 +217,24 @@ func initTestSetup(t *testing.T, cfg *config.Config) *testSetup {
 	}
 
 	if cfg.DatabaseType == constants.DbTypeSqlite || cfg.DatabaseType == constants.DbTypeLibSQL {
-		cfg.DatabaseURL = filepath.Join(t.TempDir(), "authorizer_integration.db")
+		// Not t.TempDir(): its RemoveAll fails the test if the dir is non-empty.
+		// The SQLite DB uses WAL, and the fire-and-forget goroutines from
+		// LogEvent/AddSession (see the storage-close cleanup below) can create a
+		// -wal/-shm sidecar file mid-teardown — a benign race that would
+		// otherwise fail an already-passed test. Manage the dir ourselves and
+		// remove it best-effort. Registered here so it runs AFTER the storage
+		// Close cleanup (t.Cleanup is LIFO; the closer is registered later).
+		dbDir, mkErr := os.MkdirTemp("", "authorizer-it-*")
+		require.NoError(t, mkErr)
+		t.Cleanup(func() {
+			for i := 0; i < 3; i++ {
+				if err := os.RemoveAll(dbDir); err == nil {
+					return
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		})
+		cfg.DatabaseURL = filepath.Join(dbDir, "authorizer_integration.db")
 	}
 
 	// Initialize storage provider first as it's required by other providers


### PR DESCRIPTION
## Problem
`make test-all-db` fails locally (macOS) with:
```
--- FAIL: TestLogout
    testing.go: TempDir RemoveAll cleanup: unlinkat .../TestLogout.../001: directory not empty
```
The test's assertions pass — only the temp-dir cleanup fails, and only under the full suite (TestLogout passes 5/5 in isolation and is green in CI on Linux).

## Root cause
The integration harness puts the SQLite test DB in `t.TempDir()`, and SQLite runs in WAL mode. The fire-and-forget goroutines from `LogEvent`/`AddSession` (started by Login/SignUp/Logout — already documented in the storage-close cleanup comment) can create a `-wal`/`-shm` sidecar file exactly as `t.TempDir()`'s strict `RemoveAll` tears the dir down → "directory not empty" → Go fails the already-passed test. Pre-existing fragility, not from any recent feature merge.

## Fix
Manage the DB's temp dir ourselves instead of `t.TempDir()`, and remove it best-effort (a few retries, ignore the error) so a benign teardown race can't fail the suite. Registered so removal still runs after the storage `Close()` cleanup (t.Cleanup is LIFO). Test-only change.

## Verification
Full module across all 7 DBs (`TEST_DBS=couchbase,postgres,sqlite,mongodb,arangodb,scylladb,dynamodb go test -p 1 ./...`) → exit 0, no failures. Storage provider tests across all NoSQL backends also pass (187s), confirming the new org_domains/webauthn_credentials tables round-trip everywhere.