### PR TITLE
fix: search users by ID + show member email in org lists

### DIFF
--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -370,12 +370,15 @@ type ComplexityRoot struct {
 	}
 
 	OrgMember struct {
-		CreatedAt func(childComplexity int) int
-		ID        func(childComplexity int) int
-		OrgID     func(childComplexity int) int
-		Roles     func(childComplexity int) int
-		UpdatedAt func(childComplexity int) int
-		UserID    func(childComplexity int) int
+		CreatedAt  func(childComplexity int) int
+		Email      func(childComplexity int) int
+		FamilyName func(childComplexity int) int
+		GivenName  func(childComplexity int) int
+		ID         func(childComplexity int) int
+		OrgID      func(childComplexity int) int
+		Roles      func(childComplexity int) int
+		UpdatedAt  func(childComplexity int) int
+		UserID     func(childComplexity int) int
 	}
 
 	OrgMembers struct {
@@ -2772,6 +2775,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.OrgMember.CreatedAt(childComplexity), true
 
+	case "OrgMember.email":
+		if e.complexity.OrgMember.Email == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.Email(childComplexity), true
+
+	case "OrgMember.family_name":
+		if e.complexity.OrgMember.FamilyName == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.FamilyName(childComplexity), true
+
+	case "OrgMember.given_name":
+		if e.complexity.OrgMember.GivenName == nil {
+			break
+		}
+
+		return e.complexity.OrgMember.GivenName(childComplexity), true
+
 	case "OrgMember.id":
 		if e.complexity.OrgMember.ID == nil {
 			break
@@ -4813,6 +4837,11 @@ type OrgMember {
   id: ID!
   org_id: String!
   user_id: String!
+  # Resolved user identity for display. Populated by resolving user_id against
+  # the user store; blank when the referenced user no longer exists.
+  email: String
+  given_name: String
+  family_name: String
   # roles is the set of per-organization roles granted to this member.
   roles: [String!]!
   created_at: Int64
@@ -18931,6 +18960,12 @@ func (ec *executionContext) fieldContext_Mutation__add_org_member(ctx context.Co
 				return ec.fieldContext_OrgMember_org_id(ctx, field)
 			case "user_id":
 				return ec.fieldContext_OrgMember_user_id(ctx, field)
+			case "email":
+				return ec.fieldContext_OrgMember_email(ctx, field)
+			case "given_name":
+				return ec.fieldContext_OrgMember_given_name(ctx, field)
+			case "family_name":
+				return ec.fieldContext_OrgMember_family_name(ctx, field)
 			case "roles":
 				return ec.fieldContext_OrgMember_roles(ctx, field)
 			case "created_at":
@@ -20547,6 +20582,129 @@ func (ec *executionContext) fieldContext_OrgMember_user_id(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _OrgMember_email(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_given_name(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_given_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GivenName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_given_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrgMember_family_name(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgMember_family_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FamilyName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgMember_family_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _OrgMember_roles(ctx context.Context, field graphql.CollectedField, obj *model.OrgMember) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_OrgMember_roles(ctx, field)
 	if err != nil {
@@ -20772,6 +20930,12 @@ func (ec *executionContext) fieldContext_OrgMembers_org_members(_ context.Contex
 				return ec.fieldContext_OrgMember_org_id(ctx, field)
 			case "user_id":
 				return ec.fieldContext_OrgMember_user_id(ctx, field)
+			case "email":
+				return ec.fieldContext_OrgMember_email(ctx, field)
+			case "given_name":
+				return ec.fieldContext_OrgMember_given_name(ctx, field)
+			case "family_name":
+				return ec.fieldContext_OrgMember_family_name(ctx, field)
 			case "roles":
 				return ec.fieldContext_OrgMember_roles(ctx, field)
 			case "created_at":
@@ -37304,6 +37468,12 @@ func (ec *executionContext) _OrgMember(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "email":
+			out.Values[i] = ec._OrgMember_email(ctx, field, obj)
+		case "given_name":
+			out.Values[i] = ec._OrgMember_given_name(ctx, field, obj)
+		case "family_name":
+			out.Values[i] = ec._OrgMember_family_name(ctx, field, obj)
 		case "roles":
 			out.Values[i] = ec._OrgMember_roles(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -524,12 +524,15 @@ type OrgDomains struct {
 }
 
 type OrgMember struct {
-	ID        string   `json:"id"`
-	OrgID     string   `json:"org_id"`
-	UserID    string   `json:"user_id"`
-	Roles     []string `json:"roles"`
-	CreatedAt *int64   `json:"created_at,omitempty"`
-	UpdatedAt *int64   `json:"updated_at,omitempty"`
+	ID         string   `json:"id"`
+	OrgID      string   `json:"org_id"`
+	UserID     string   `json:"user_id"`
+	Email      *string  `json:"email,omitempty"`
+	GivenName  *string  `json:"given_name,omitempty"`
+	FamilyName *string  `json:"family_name,omitempty"`
+	Roles      []string `json:"roles"`
+	CreatedAt  *int64   `json:"created_at,omitempty"`
+	UpdatedAt  *int64   `json:"updated_at,omitempty"`
 }
 
 type OrgMembers struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -491,6 +491,11 @@ type OrgMember {
   id: ID!
   org_id: String!
   user_id: String!
+  # Resolved user identity for display. Populated by resolving user_id against
+  # the user store; blank when the referenced user no longer exists.
+  email: String
+  given_name: String
+  family_name: String
   # roles is the set of per-organization roles granted to this member.
   roles: [String!]!
   created_at: Int64

--- a/internal/integration_tests/organization_test.go
+++ b/internal/integration_tests/organization_test.go
@@ -122,6 +122,9 @@ func TestOrganizationAdmin(t *testing.T) {
 		require.NotNil(t, members)
 		require.Len(t, members.OrgMembers, 1)
 		assert.Equal(t, userID, members.OrgMembers[0].UserID)
+		// The member's user identity is resolved for display.
+		require.NotNil(t, members.OrgMembers[0].Email)
+		assert.Equal(t, "org-member-"+userID+"@authorizer.test", *members.OrgMembers[0].Email)
 
 		removed, err := ts.GraphQLProvider.RemoveOrgMember(ctx, &model.RemoveOrgMemberRequest{
 			OrgID:  org.ID,

--- a/internal/integration_tests/users_test.go
+++ b/internal/integration_tests/users_test.go
@@ -94,6 +94,21 @@ func TestUsers(t *testing.T) {
 		require.Len(t, users.Users, 1)
 		assert.Equal(t, email, *users.Users[0].Email)
 
+		// Search also matches the user id: a prefix of the id returns the user.
+		userID := users.Users[0].ID
+		idQuery := userID[:13]
+		byID, err := ts.GraphQLProvider.Users(ctx, &model.ListUsersRequest{Query: &idQuery})
+		require.NoError(t, err)
+		require.NotNil(t, byID)
+		foundByID := false
+		for _, u := range byID.Users {
+			if u.ID == userID {
+				foundByID = true
+				break
+			}
+		}
+		assert.True(t, foundByID, "search by id prefix must return the user")
+
 		// A query matching nothing returns an empty list.
 		noMatch := "no-such-user-" + uuid.New().String()
 		empty, err := ts.GraphQLProvider.Users(ctx, &model.ListUsersRequest{Query: &noMatch})

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -348,7 +348,18 @@ func (p *provider) OrgMembers(ctx context.Context, meta RequestMetadata, params 
 	}
 	res := make([]*model.OrgMember, len(memberships))
 	for i, m := range memberships {
-		res[i] = m.AsAPIOrgMember()
+		member := m.AsAPIOrgMember()
+		// Resolve the member's user identity for display. One lookup per member
+		// per page; acceptable since the list is paginated. A dangling user
+		// reference must not break the listing, so leave the identity blank.
+		if user, uErr := p.StorageProvider.GetUserByID(ctx, m.UserID); uErr == nil {
+			member.Email = user.Email
+			member.GivenName = user.GivenName
+			member.FamilyName = user.FamilyName
+		} else {
+			log.Debug().Err(uErr).Str("user_id", m.UserID).Msg("failed GetUserByID; leaving member identity blank")
+		}
+		res[i] = member
 	}
 	return &model.OrgMembers{
 		Pagination: pagination,

--- a/internal/storage/db/arangodb/user.go
+++ b/internal/storage/db/arangodb/user.go
@@ -106,7 +106,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination, 
 	filter := ""
 	if q := strings.TrimSpace(query); q != "" {
 		// LIKE(..., true) is case-insensitive; %term% matches substrings.
-		filter = "FILTER LIKE(d.email, @q, true) OR LIKE(d.given_name, @q, true) OR LIKE(d.family_name, @q, true) OR LIKE(d.nickname, @q, true) "
+		filter = "FILTER LIKE(d._id, @q, true) OR LIKE(d.email, @q, true) OR LIKE(d.given_name, @q, true) OR LIKE(d.family_name, @q, true) OR LIKE(d.nickname, @q, true) "
 		bindVars["q"] = "%" + q + "%"
 	}
 	aql := fmt.Sprintf("FOR d in %s %sSORT d.created_at DESC LIMIT @offset, @limit RETURN d", schemas.Collections.User, filter)

--- a/internal/storage/db/couchbase/user.go
+++ b/internal/storage/db/couchbase/user.go
@@ -118,7 +118,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination, 
 	whereClause := ""
 	params := []interface{}{}
 	if q := strings.TrimSpace(query); q != "" {
-		whereClause = " WHERE LOWER(email) LIKE $1 OR LOWER(given_name) LIKE $1 OR LOWER(family_name) LIKE $1 OR LOWER(nickname) LIKE $1"
+		whereClause = " WHERE LOWER(_id) LIKE $1 OR LOWER(email) LIKE $1 OR LOWER(given_name) LIKE $1 OR LOWER(family_name) LIKE $1 OR LOWER(nickname) LIKE $1"
 		params = append(params, "%"+strings.ToLower(q)+"%")
 	}
 

--- a/internal/storage/db/mongodb/user.go
+++ b/internal/storage/db/mongodb/user.go
@@ -90,6 +90,7 @@ func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination, 
 		// QuoteMeta so user input is treated as a literal substring, not a regex.
 		rx := bson.M{"$regex": regexp.QuoteMeta(q), "$options": "i"}
 		filter = bson.M{"$or": []bson.M{
+			{"_id": rx},
 			{"email": rx},
 			{"given_name": rx},
 			{"family_name": rx},

--- a/internal/storage/db/sql/user.go
+++ b/internal/storage/db/sql/user.go
@@ -90,16 +90,16 @@ func (p *provider) DeleteUser(ctx context.Context, user *schemas.User) error {
 
 // ListUsers to get list of users from database. When query is non-empty it is
 // applied as a case-insensitive substring filter (indexed columns use plain
-// LIKE; email/given_name/family_name/nickname are matched with LOWER(...) LIKE).
+// LIKE; id/email/given_name/family_name/nickname are matched with LOWER(...) LIKE).
 func (p *provider) ListUsers(ctx context.Context, pagination *model.Pagination, query string) ([]*schemas.User, *model.Pagination, error) {
 	var users []*schemas.User
 	listQuery := p.db.Model(&schemas.User{})
 	countQuery := p.db.Model(&schemas.User{})
 	if q := strings.TrimSpace(query); q != "" {
 		pattern := "%" + strings.ToLower(q) + "%"
-		const where = "LOWER(email) LIKE ? OR LOWER(given_name) LIKE ? OR LOWER(family_name) LIKE ? OR LOWER(nickname) LIKE ?"
-		listQuery = listQuery.Where(where, pattern, pattern, pattern, pattern)
-		countQuery = countQuery.Where(where, pattern, pattern, pattern, pattern)
+		const where = "LOWER(id) LIKE ? OR LOWER(email) LIKE ? OR LOWER(given_name) LIKE ? OR LOWER(family_name) LIKE ? OR LOWER(nickname) LIKE ?"
+		listQuery = listQuery.Where(where, pattern, pattern, pattern, pattern, pattern)
+		countQuery = countQuery.Where(where, pattern, pattern, pattern, pattern, pattern)
 	}
 
 	result := listQuery.Limit(int(pagination.Limit)).Offset(int(pagination.Offset)).Order("created_at DESC").Find(&users)

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -392,6 +392,28 @@ func testUserSearchOperations(t *testing.T, ctx context.Context, provider Provid
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), nonePagination.Total)
 	assert.Len(t, none, 0)
+
+	// Search also matches on the user id: a prefix of a user's id returns that
+	// user even when no other field contains the query. A uuid prefix is unique
+	// enough to identify exactly one user.
+	idUser := &schemas.User{
+		ID:            uuid.New().String(),
+		Email:         refs.NewStringRef("erin_" + uuid.New().String() + "@test.com"),
+		Password:      refs.NewStringRef("hashedPassword"),
+		SignupMethods: "basic_auth",
+	}
+	_, err = provider.AddUser(ctx, idUser)
+	require.NoError(t, err)
+	byID, _, err := provider.ListUsers(ctx, &model.Pagination{Limit: 50, Offset: 0}, idUser.ID[:13])
+	require.NoError(t, err)
+	foundByID := false
+	for _, u := range byID {
+		if u.ID == idUser.ID {
+			foundByID = true
+			break
+		}
+	}
+	assert.True(t, foundByID, "search by id prefix must return the user")
 }
 
 func testUserOperations(t *testing.T, ctx context.Context, provider Provider, dbType string) {

--- a/internal/storage/schemas/user.go
+++ b/internal/storage/schemas/user.go
@@ -87,12 +87,15 @@ func (user *User) AsAPIUser() *model.User {
 }
 
 // MatchesSearch reports whether the user matches a case-insensitive substring
-// query across email, given_name, family_name and nickname. An empty query
+// query across id, email, given_name, family_name and nickname. An empty query
 // matches everything. Used by storage backends without a native substring
 // index (DynamoDB, Cassandra/ScyllaDB) to filter in application code.
 func (user *User) MatchesSearch(query string) bool {
 	q := strings.ToLower(strings.TrimSpace(query))
 	if q == "" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(user.ID), q) {
 		return true
 	}
 	for _, f := range []*string{user.Email, user.GivenName, user.FamilyName, user.Nickname} {

--- a/web/dashboard/src/graphql/queries/index.ts
+++ b/web/dashboard/src/graphql/queries/index.ts
@@ -301,6 +301,9 @@ export const OrgMembersQuery = `
         id
         org_id
         user_id
+        email
+        given_name
+        family_name
         roles
         created_at
       }

--- a/web/dashboard/src/pages/OrganizationDetail.tsx
+++ b/web/dashboard/src/pages/OrganizationDetail.tsx
@@ -477,7 +477,7 @@ const OrganizationDetail = () => {
 							<Table>
 								<TableHeader>
 									<TableRow>
-										<TableHead>User ID</TableHead>
+										<TableHead>User</TableHead>
 										<TableHead>Roles</TableHead>
 										<TableHead>Added</TableHead>
 										<TableHead>Actions</TableHead>
@@ -487,9 +487,14 @@ const OrganizationDetail = () => {
 									{members.map((member) => (
 										<TableRow key={member.id}>
 											<TableCell className="max-w-[300px] text-sm">
-												<span className="truncate font-mono text-xs">
-													{member.user_id}
+												<span className="block truncate">
+													{member.email || member.user_id}
 												</span>
+												{member.email && (
+													<span className="block truncate font-mono text-xs text-gray-500">
+														{member.user_id}
+													</span>
+												)}
 											</TableCell>
 											<TableCell className="max-w-[300px]">
 												<div className="flex flex-wrap gap-1">

--- a/web/dashboard/src/pages/Users.tsx
+++ b/web/dashboard/src/pages/Users.tsx
@@ -253,7 +253,7 @@ export default function Users() {
 				<div className="relative flex-1 max-w-sm">
 					<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
 					<Input
-						placeholder="Search by email or name..."
+						placeholder="Search by email, name, or ID..."
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						className="pl-9"

--- a/web/dashboard/src/types.ts
+++ b/web/dashboard/src/types.ts
@@ -255,6 +255,9 @@ export interface OrgMember {
 	id: string;
 	org_id: string;
 	user_id: string;
+	email?: string | null;
+	given_name?: string | null;
+	family_name?: string | null;
 	roles: string[];
 	created_at?: number | null;
 	updated_at?: number | null;


### PR DESCRIPTION
Two follow-up fixes to #678 (both reported broken from the dashboard).

## 1. Search users by ID
`_users` search matched email/name/nickname but not the user id, so admins couldn't find a user by ID. Added the **id** to the search on every backend (SQL/Mongo/Arango/Couchbase LIKE-or-regex with bound params/QuoteMeta; DynamoDB/Cassandra scan via `MatchesSearch`). Dashboard placeholder → "Search by email, name, or ID...". Search tests extended (id-prefix returns the user) across TEST_DBS.

## 2. Show member email in org member lists
The `OrgMember` type had only `user_id`, so the org detail member list showed opaque IDs. Added `email`/`given_name`/`family_name` (nullable) to `OrgMember`, resolved from the user in the `_org_members` service (one lookup per member per page; dangling user → blank, never errors). Dashboard member cell shows email (falls back to user_id). GraphQL-only; gen committed.

## Testing
go build/vet/golangci-lint (0 issues), graphql codegen parity, SQLite integration + storage search tests green (id-search + member-email assertions added), dashboard tsc/build/prettier clean. Non-SQLite via CI make test-all-db (id-search mirrors the already-cross-DB-validated email search).