### PR TITLE
fix(docker): install git in node-builder for github: react dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,10 @@ RUN apk add --no-cache -X "${ALPINE_EDGE_MAIN}" "busybox>=1.37.0-r31"
 WORKDIR /authorizer
 COPY web/app/package*.json web/app/
 COPY web/dashboard/package*.json web/dashboard/
-RUN apk add --no-cache nodejs npm
+# git is required by `npm ci`: web/app depends on @authorizerdev/authorizer-react
+# via a github: URL, which npm resolves by cloning. Drop once the app pins a
+# published authorizer-react version.
+RUN apk add --no-cache nodejs npm git
 # Cache npm package tarballs across builds (faster re-installs in CI)
 RUN --mount=type=cache,target=/root/.npm \
     npm config set cache /root/.npm && \


### PR DESCRIPTION
Docker release build failed at `npm ci` (web/app) with `spawn git ENOENT`: web/app depends on `@authorizerdev/authorizer-react` via a `github:...#main` URL, which npm resolves by cloning — but the node-builder stage had no git. Adds git to that stage.

Unblocks the 2.4.0-rc.1 image build. Drop once the app pins a published authorizer-react version.