### PR TITLE
chore(app): regenerate package-lock.json for authorizer-react git dep

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "2.2.0-rc.0",
+				"@authorizerdev/authorizer-react": "github:authorizerdev/authorizer-react#main",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-js": {
-			"version": "3.3.0-rc.0",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.0.tgz",
-			"integrity": "sha512-P9S25JZpSqYR46YOT1W6BugfQkqHaswFLkUt4drJLPHH3vecRCUC0IczHMT2NkAbZzILoBh3LNOdV1BFd61CLw==",
+			"version": "3.3.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.1.tgz",
+			"integrity": "sha512-L6S2BzHIP7cPa4nD3FT2RxRiQM5w6jauCNtEX+5t+8sUr4DrrcZON2MhYhVSuBT8+8/Y9TcKO2ZamZwuDX0pVg==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-fetch": "^4.1.0"
@@ -44,11 +44,10 @@
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
 			"version": "2.2.0-rc.0",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.0.tgz",
-			"integrity": "sha512-Fyca/MSRzShneUAsk8HNTZLSTzPY/ePW7bwh0CFyEYWobqItlK7Y2YEtc8+capHD7oghvzT1slxLRhMWgi+zcQ==",
+			"resolved": "git+ssh://git@github.com/authorizerdev/authorizer-react.git#c56d0585bf9e137283b89ab59f8541bc056e115f",
 			"license": "MIT",
 			"dependencies": {
-				"@authorizerdev/authorizer-js": "3.3.0-rc.0",
+				"@authorizerdev/authorizer-js": "^3.3.0-rc.1",
 				"@storybook/preset-scss": "^1.0.3",
 				"validator": "^13.11.0"
 			},


### PR DESCRIPTION
## Summary
- package.json pinned authorizer-react to a github: dep in #686; the lockfile was never regenerated to match and drifted (still showed the old npm 2.2.0-rc.0 resolution).
- Regenerates web/app/package-lock.json to match package.json; picks up authorizer-js 3.3.0-rc.1 as a side effect.

## Test plan
- [x] `npm ci --dry-run` in web/app resolves cleanly against the new lockfile
- [ ] local docker build (make build-local-image) to confirm the full multi-stage build still succeeds