### PR TITLE
fix(app): pin authorizer-react to the published npm release, not main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,7 @@ RUN apk add --no-cache -X "${ALPINE_EDGE_MAIN}" "busybox>=1.37.0-r31"
 WORKDIR /authorizer
 COPY web/app/package*.json web/app/
 COPY web/dashboard/package*.json web/dashboard/
-# git is required by `npm ci`: web/app depends on @authorizerdev/authorizer-react
-# via a github: URL, which npm resolves by cloning. Drop once the app pins a
-# published authorizer-react version.
-RUN apk add --no-cache nodejs npm git
+RUN apk add --no-cache nodejs npm
 # Cache npm package tarballs across builds (faster re-installs in CI)
 RUN --mount=type=cache,target=/root/.npm \
     npm config set cache /root/.npm && \

--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "github:authorizerdev/authorizer-react#main",
+				"@authorizerdev/authorizer-react": "2.2.0-rc.1",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-js": {
-			"version": "3.3.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.1.tgz",
-			"integrity": "sha512-L6S2BzHIP7cPa4nD3FT2RxRiQM5w6jauCNtEX+5t+8sUr4DrrcZON2MhYhVSuBT8+8/Y9TcKO2ZamZwuDX0pVg==",
+			"version": "3.3.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.2.tgz",
+			"integrity": "sha512-mukoMoDzjcyEWzsjMA50UwVEhsEbC2G1HnY6NMTnZ3x4puDI98PHpkd3R292jlYLjpE6aj4iO+2pMq0cUrVKlA==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-fetch": "^4.1.0"
@@ -43,11 +43,12 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
-			"version": "2.2.0-rc.0",
-			"resolved": "git+ssh://git@github.com/authorizerdev/authorizer-react.git#c56d0585bf9e137283b89ab59f8541bc056e115f",
+			"version": "2.2.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.1.tgz",
+			"integrity": "sha512-Z+6Kd19nQCEmGbZbv61fVQgk4DWBYdHCgKkt0Rz6K7WA2bpl42Vx+/7gyj/An7xnD3oBP0WqPjUvxENvC8inkA==",
 			"license": "MIT",
 			"dependencies": {
-				"@authorizerdev/authorizer-js": "^3.3.0-rc.1",
+				"@authorizerdev/authorizer-js": "^3.3.0-rc.2",
 				"@storybook/preset-scss": "^1.0.3",
 				"validator": "^13.11.0"
 			},

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
 	"author": "Lakhan Samani",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@authorizerdev/authorizer-react": "github:authorizerdev/authorizer-react#main",
+		"@authorizerdev/authorizer-react": "2.2.0-rc.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-is": "^18.3.1",


### PR DESCRIPTION
## Summary
- web/app pinned @authorizerdev/authorizer-react to a floating github:#main ref instead of a released npm version.
- That floating ref is what was breaking the 2.4.0-rc.2 docker build: npm ci --prefer-offline resolving the git dependency's own nested prepare step could pull a stale/incompatible authorizer-js, non-deterministically (reproduced across multiple clean-cache rebuilds).
- authorizer-react 2.2.0-rc.1 (published today) already contains everything main had (confirmed against the commit main was pinned at). Pin to it and drop the git-in-Dockerfile workaround that the floating ref required.

## Test plan
- [x] npm ci in web/app resolves cleanly against the regenerated lockfile
- [x] local docker build (make build-local-image) succeeds end-to-end