### PR TITLE
feat(saml): add SAML 2.0 Identity Provider role

### DIFF
--- a/gen/go/authorizer/v1/admin.pb.go
+++ b/gen/go/authorizer/v1/admin.pb.go
@@ -5612,6 +5612,1277 @@ func (x *TrustedIssuersResponse) GetPagination() *Pagination {
 	return nil
 }
 
+// SamlServiceProvider mirrors model.SAMLServiceProvider field-for-field. It is a
+// downstream SAML 2.0 SP that Authorizer (acting as the IdP) issues signed
+// assertions to. Optional pointer fields collapse to zero values on the wire.
+type SamlServiceProvider struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id    string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	OrgId string `protobuf:"bytes,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	Name  string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// entity_id: the SP entity ID (the AuthnRequest Issuer and assertion Audience).
+	EntityId string `protobuf:"bytes,4,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`
+	// acs_url: the SP Assertion Consumer Service URL — the only place assertions
+	// are POSTed.
+	AcsUrl string `protobuf:"bytes,5,opt,name=acs_url,json=acsUrl,proto3" json:"acs_url,omitempty"`
+	// sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+	SpCertPem string `protobuf:"bytes,6,opt,name=sp_cert_pem,json=spCertPem,proto3" json:"sp_cert_pem,omitempty"`
+	// name_id_format: SAML NameID format for the Subject (default emailAddress).
+	NameIdFormat string `protobuf:"bytes,7,opt,name=name_id_format,json=nameIdFormat,proto3" json:"name_id_format,omitempty"`
+	// mapped_attributes: JSON mapping profile fields to emitted SAML attribute names.
+	MappedAttributes string `protobuf:"bytes,8,opt,name=mapped_attributes,json=mappedAttributes,proto3" json:"mapped_attributes,omitempty"`
+	// allow_idp_initiated: whether unsolicited IdP-initiated SSO is permitted.
+	AllowIdpInitiated bool  `protobuf:"varint,9,opt,name=allow_idp_initiated,json=allowIdpInitiated,proto3" json:"allow_idp_initiated,omitempty"`
+	IsActive          bool  `protobuf:"varint,10,opt,name=is_active,json=isActive,proto3" json:"is_active,omitempty"`
+	CreatedAt         int64 `protobuf:"varint,11,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt         int64 `protobuf:"varint,12,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+}
+
+func (x *SamlServiceProvider) Reset() {
+	*x = SamlServiceProvider{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[95]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SamlServiceProvider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SamlServiceProvider) ProtoMessage() {}
+
+func (x *SamlServiceProvider) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[95]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SamlServiceProvider.ProtoReflect.Descriptor instead.
+func (*SamlServiceProvider) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{95}
+}
+
+func (x *SamlServiceProvider) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetAcsUrl() string {
+	if x != nil {
+		return x.AcsUrl
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetSpCertPem() string {
+	if x != nil {
+		return x.SpCertPem
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetNameIdFormat() string {
+	if x != nil {
+		return x.NameIdFormat
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetMappedAttributes() string {
+	if x != nil {
+		return x.MappedAttributes
+	}
+	return ""
+}
+
+func (x *SamlServiceProvider) GetAllowIdpInitiated() bool {
+	if x != nil {
+		return x.AllowIdpInitiated
+	}
+	return false
+}
+
+func (x *SamlServiceProvider) GetIsActive() bool {
+	if x != nil {
+		return x.IsActive
+	}
+	return false
+}
+
+func (x *SamlServiceProvider) GetCreatedAt() int64 {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return 0
+}
+
+func (x *SamlServiceProvider) GetUpdatedAt() int64 {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return 0
+}
+
+// SamlIdpKey mirrors model.SAMLIDPKey. The private key is NEVER projected — only
+// the certificate and rotation status.
+type SamlIdpKey struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id    string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	OrgId string `protobuf:"bytes,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	// cert_pem: the self-signed X.509 signing certificate (PEM), pinned by SPs.
+	CertPem   string `protobuf:"bytes,3,opt,name=cert_pem,json=certPem,proto3" json:"cert_pem,omitempty"`
+	Algorithm string `protobuf:"bytes,4,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	// status: "current" (signs new assertions), "active" (published in metadata,
+	// not signing), or "retired" (neither).
+	Status    string `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	CreatedAt int64  `protobuf:"varint,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt int64  `protobuf:"varint,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+}
+
+func (x *SamlIdpKey) Reset() {
+	*x = SamlIdpKey{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[96]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SamlIdpKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SamlIdpKey) ProtoMessage() {}
+
+func (x *SamlIdpKey) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[96]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SamlIdpKey.ProtoReflect.Descriptor instead.
+func (*SamlIdpKey) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{96}
+}
+
+func (x *SamlIdpKey) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SamlIdpKey) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *SamlIdpKey) GetCertPem() string {
+	if x != nil {
+		return x.CertPem
+	}
+	return ""
+}
+
+func (x *SamlIdpKey) GetAlgorithm() string {
+	if x != nil {
+		return x.Algorithm
+	}
+	return ""
+}
+
+func (x *SamlIdpKey) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *SamlIdpKey) GetCreatedAt() int64 {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return 0
+}
+
+func (x *SamlIdpKey) GetUpdatedAt() int64 {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return 0
+}
+
+// SamlSpMetadataParseResult mirrors model.SAMLSPMetadataParseResult. It does NOT
+// create a record — it returns fields to prefill a create call.
+type SamlSpMetadataParseResult struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EntityId    string `protobuf:"bytes,1,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`
+	AcsUrl      string `protobuf:"bytes,2,opt,name=acs_url,json=acsUrl,proto3" json:"acs_url,omitempty"`
+	Certificate string `protobuf:"bytes,3,opt,name=certificate,proto3" json:"certificate,omitempty"`
+}
+
+func (x *SamlSpMetadataParseResult) Reset() {
+	*x = SamlSpMetadataParseResult{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[97]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SamlSpMetadataParseResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SamlSpMetadataParseResult) ProtoMessage() {}
+
+func (x *SamlSpMetadataParseResult) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[97]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SamlSpMetadataParseResult.ProtoReflect.Descriptor instead.
+func (*SamlSpMetadataParseResult) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{97}
+}
+
+func (x *SamlSpMetadataParseResult) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+func (x *SamlSpMetadataParseResult) GetAcsUrl() string {
+	if x != nil {
+		return x.AcsUrl
+	}
+	return ""
+}
+
+func (x *SamlSpMetadataParseResult) GetCertificate() string {
+	if x != nil {
+		return x.Certificate
+	}
+	return ""
+}
+
+// CreateSamlServiceProviderRequest mirrors model.CreateSAMLServiceProviderRequest.
+// sp_cert_pem, name_id_format, mapped_attributes, and allow_idp_initiated are
+// optional.
+type CreateSamlServiceProviderRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrgId     string  `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	Name      string  `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	EntityId  string  `protobuf:"bytes,3,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`
+	AcsUrl    string  `protobuf:"bytes,4,opt,name=acs_url,json=acsUrl,proto3" json:"acs_url,omitempty"`
+	SpCertPem *string `protobuf:"bytes,5,opt,name=sp_cert_pem,json=spCertPem,proto3,oneof" json:"sp_cert_pem,omitempty"`
+	// name_id_format: default urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress.
+	NameIdFormat *string `protobuf:"bytes,6,opt,name=name_id_format,json=nameIdFormat,proto3,oneof" json:"name_id_format,omitempty"`
+	// mapped_attributes: JSON, e.g. {"email":"email","given_name":"firstName"}.
+	MappedAttributes *string `protobuf:"bytes,7,opt,name=mapped_attributes,json=mappedAttributes,proto3,oneof" json:"mapped_attributes,omitempty"`
+	// allow_idp_initiated: default false (SP-initiated only).
+	AllowIdpInitiated *bool `protobuf:"varint,8,opt,name=allow_idp_initiated,json=allowIdpInitiated,proto3,oneof" json:"allow_idp_initiated,omitempty"`
+}
+
+func (x *CreateSamlServiceProviderRequest) Reset() {
+	*x = CreateSamlServiceProviderRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[98]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSamlServiceProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSamlServiceProviderRequest) ProtoMessage() {}
+
+func (x *CreateSamlServiceProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[98]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSamlServiceProviderRequest.ProtoReflect.Descriptor instead.
+func (*CreateSamlServiceProviderRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{98}
+}
+
+func (x *CreateSamlServiceProviderRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetAcsUrl() string {
+	if x != nil {
+		return x.AcsUrl
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetSpCertPem() string {
+	if x != nil && x.SpCertPem != nil {
+		return *x.SpCertPem
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetNameIdFormat() string {
+	if x != nil && x.NameIdFormat != nil {
+		return *x.NameIdFormat
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetMappedAttributes() string {
+	if x != nil && x.MappedAttributes != nil {
+		return *x.MappedAttributes
+	}
+	return ""
+}
+
+func (x *CreateSamlServiceProviderRequest) GetAllowIdpInitiated() bool {
+	if x != nil && x.AllowIdpInitiated != nil {
+		return *x.AllowIdpInitiated
+	}
+	return false
+}
+
+type CreateSamlServiceProviderResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlServiceProvider *SamlServiceProvider `protobuf:"bytes,1,opt,name=saml_service_provider,json=samlServiceProvider,proto3" json:"saml_service_provider,omitempty"`
+}
+
+func (x *CreateSamlServiceProviderResponse) Reset() {
+	*x = CreateSamlServiceProviderResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[99]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSamlServiceProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSamlServiceProviderResponse) ProtoMessage() {}
+
+func (x *CreateSamlServiceProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[99]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSamlServiceProviderResponse.ProtoReflect.Descriptor instead.
+func (*CreateSamlServiceProviderResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{99}
+}
+
+func (x *CreateSamlServiceProviderResponse) GetSamlServiceProvider() *SamlServiceProvider {
+	if x != nil {
+		return x.SamlServiceProvider
+	}
+	return nil
+}
+
+// UpdateSamlServiceProviderRequest mirrors model.UpdateSAMLServiceProviderRequest.
+// Nullable GraphQL inputs use proto3 `optional` so an unset field is
+// distinguishable from an empty value.
+type UpdateSamlServiceProviderRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id                string  `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name              *string `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
+	EntityId          *string `protobuf:"bytes,3,opt,name=entity_id,json=entityId,proto3,oneof" json:"entity_id,omitempty"`
+	AcsUrl            *string `protobuf:"bytes,4,opt,name=acs_url,json=acsUrl,proto3,oneof" json:"acs_url,omitempty"`
+	SpCertPem         *string `protobuf:"bytes,5,opt,name=sp_cert_pem,json=spCertPem,proto3,oneof" json:"sp_cert_pem,omitempty"`
+	NameIdFormat      *string `protobuf:"bytes,6,opt,name=name_id_format,json=nameIdFormat,proto3,oneof" json:"name_id_format,omitempty"`
+	MappedAttributes  *string `protobuf:"bytes,7,opt,name=mapped_attributes,json=mappedAttributes,proto3,oneof" json:"mapped_attributes,omitempty"`
+	AllowIdpInitiated *bool   `protobuf:"varint,8,opt,name=allow_idp_initiated,json=allowIdpInitiated,proto3,oneof" json:"allow_idp_initiated,omitempty"`
+	IsActive          *bool   `protobuf:"varint,9,opt,name=is_active,json=isActive,proto3,oneof" json:"is_active,omitempty"`
+}
+
+func (x *UpdateSamlServiceProviderRequest) Reset() {
+	*x = UpdateSamlServiceProviderRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[100]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSamlServiceProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSamlServiceProviderRequest) ProtoMessage() {}
+
+func (x *UpdateSamlServiceProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[100]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSamlServiceProviderRequest.ProtoReflect.Descriptor instead.
+func (*UpdateSamlServiceProviderRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{100}
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetName() string {
+	if x != nil && x.Name != nil {
+		return *x.Name
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetEntityId() string {
+	if x != nil && x.EntityId != nil {
+		return *x.EntityId
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetAcsUrl() string {
+	if x != nil && x.AcsUrl != nil {
+		return *x.AcsUrl
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetSpCertPem() string {
+	if x != nil && x.SpCertPem != nil {
+		return *x.SpCertPem
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetNameIdFormat() string {
+	if x != nil && x.NameIdFormat != nil {
+		return *x.NameIdFormat
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetMappedAttributes() string {
+	if x != nil && x.MappedAttributes != nil {
+		return *x.MappedAttributes
+	}
+	return ""
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetAllowIdpInitiated() bool {
+	if x != nil && x.AllowIdpInitiated != nil {
+		return *x.AllowIdpInitiated
+	}
+	return false
+}
+
+func (x *UpdateSamlServiceProviderRequest) GetIsActive() bool {
+	if x != nil && x.IsActive != nil {
+		return *x.IsActive
+	}
+	return false
+}
+
+type UpdateSamlServiceProviderResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlServiceProvider *SamlServiceProvider `protobuf:"bytes,1,opt,name=saml_service_provider,json=samlServiceProvider,proto3" json:"saml_service_provider,omitempty"`
+}
+
+func (x *UpdateSamlServiceProviderResponse) Reset() {
+	*x = UpdateSamlServiceProviderResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[101]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSamlServiceProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSamlServiceProviderResponse) ProtoMessage() {}
+
+func (x *UpdateSamlServiceProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[101]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSamlServiceProviderResponse.ProtoReflect.Descriptor instead.
+func (*UpdateSamlServiceProviderResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{101}
+}
+
+func (x *UpdateSamlServiceProviderResponse) GetSamlServiceProvider() *SamlServiceProvider {
+	if x != nil {
+		return x.SamlServiceProvider
+	}
+	return nil
+}
+
+// DeleteSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a
+// single SP id). Kept distinct from GetSamlServiceProviderRequest per buf's
+// one-message-per-RPC rule.
+type DeleteSamlServiceProviderRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+}
+
+func (x *DeleteSamlServiceProviderRequest) Reset() {
+	*x = DeleteSamlServiceProviderRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[102]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSamlServiceProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSamlServiceProviderRequest) ProtoMessage() {}
+
+func (x *DeleteSamlServiceProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[102]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSamlServiceProviderRequest.ProtoReflect.Descriptor instead.
+func (*DeleteSamlServiceProviderRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{102}
+}
+
+func (x *DeleteSamlServiceProviderRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type DeleteSamlServiceProviderResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *DeleteSamlServiceProviderResponse) Reset() {
+	*x = DeleteSamlServiceProviderResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[103]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSamlServiceProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSamlServiceProviderResponse) ProtoMessage() {}
+
+func (x *DeleteSamlServiceProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[103]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSamlServiceProviderResponse.ProtoReflect.Descriptor instead.
+func (*DeleteSamlServiceProviderResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{103}
+}
+
+func (x *DeleteSamlServiceProviderResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// GetSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a
+// single SP id). Kept distinct from DeleteSamlServiceProviderRequest per buf's
+// one-message-per-RPC rule.
+type GetSamlServiceProviderRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+}
+
+func (x *GetSamlServiceProviderRequest) Reset() {
+	*x = GetSamlServiceProviderRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[104]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSamlServiceProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSamlServiceProviderRequest) ProtoMessage() {}
+
+func (x *GetSamlServiceProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[104]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSamlServiceProviderRequest.ProtoReflect.Descriptor instead.
+func (*GetSamlServiceProviderRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{104}
+}
+
+func (x *GetSamlServiceProviderRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetSamlServiceProviderResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlServiceProvider *SamlServiceProvider `protobuf:"bytes,1,opt,name=saml_service_provider,json=samlServiceProvider,proto3" json:"saml_service_provider,omitempty"`
+}
+
+func (x *GetSamlServiceProviderResponse) Reset() {
+	*x = GetSamlServiceProviderResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[105]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSamlServiceProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSamlServiceProviderResponse) ProtoMessage() {}
+
+func (x *GetSamlServiceProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[105]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSamlServiceProviderResponse.ProtoReflect.Descriptor instead.
+func (*GetSamlServiceProviderResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{105}
+}
+
+func (x *GetSamlServiceProviderResponse) GetSamlServiceProvider() *SamlServiceProvider {
+	if x != nil {
+		return x.SamlServiceProvider
+	}
+	return nil
+}
+
+// ListSamlServiceProvidersRequest mirrors model.ListSAMLServiceProvidersRequest.
+type ListSamlServiceProvidersRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrgId      string             `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	Pagination *PaginationRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (x *ListSamlServiceProvidersRequest) Reset() {
+	*x = ListSamlServiceProvidersRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[106]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSamlServiceProvidersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSamlServiceProvidersRequest) ProtoMessage() {}
+
+func (x *ListSamlServiceProvidersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[106]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSamlServiceProvidersRequest.ProtoReflect.Descriptor instead.
+func (*ListSamlServiceProvidersRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{106}
+}
+
+func (x *ListSamlServiceProvidersRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *ListSamlServiceProvidersRequest) GetPagination() *PaginationRequest {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+type ListSamlServiceProvidersResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlServiceProviders []*SamlServiceProvider `protobuf:"bytes,1,rep,name=saml_service_providers,json=samlServiceProviders,proto3" json:"saml_service_providers,omitempty"`
+	Pagination           *Pagination            `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (x *ListSamlServiceProvidersResponse) Reset() {
+	*x = ListSamlServiceProvidersResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[107]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSamlServiceProvidersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSamlServiceProvidersResponse) ProtoMessage() {}
+
+func (x *ListSamlServiceProvidersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[107]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSamlServiceProvidersResponse.ProtoReflect.Descriptor instead.
+func (*ListSamlServiceProvidersResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{107}
+}
+
+func (x *ListSamlServiceProvidersResponse) GetSamlServiceProviders() []*SamlServiceProvider {
+	if x != nil {
+		return x.SamlServiceProviders
+	}
+	return nil
+}
+
+func (x *ListSamlServiceProvidersResponse) GetPagination() *Pagination {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+// RotateSamlIdpCertRequest mirrors model.RotateSAMLIDPCertRequest.
+type RotateSamlIdpCertRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrgId string `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+}
+
+func (x *RotateSamlIdpCertRequest) Reset() {
+	*x = RotateSamlIdpCertRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[108]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RotateSamlIdpCertRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RotateSamlIdpCertRequest) ProtoMessage() {}
+
+func (x *RotateSamlIdpCertRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[108]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RotateSamlIdpCertRequest.ProtoReflect.Descriptor instead.
+func (*RotateSamlIdpCertRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{108}
+}
+
+func (x *RotateSamlIdpCertRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+type RotateSamlIdpCertResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlIdpKey *SamlIdpKey `protobuf:"bytes,1,opt,name=saml_idp_key,json=samlIdpKey,proto3" json:"saml_idp_key,omitempty"`
+}
+
+func (x *RotateSamlIdpCertResponse) Reset() {
+	*x = RotateSamlIdpCertResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[109]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RotateSamlIdpCertResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RotateSamlIdpCertResponse) ProtoMessage() {}
+
+func (x *RotateSamlIdpCertResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[109]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RotateSamlIdpCertResponse.ProtoReflect.Descriptor instead.
+func (*RotateSamlIdpCertResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{109}
+}
+
+func (x *RotateSamlIdpCertResponse) GetSamlIdpKey() *SamlIdpKey {
+	if x != nil {
+		return x.SamlIdpKey
+	}
+	return nil
+}
+
+// RetireSamlIdpKeyRequest mirrors model.RetireSAMLIDPKeyRequest (a single key id).
+type RetireSamlIdpKeyRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+}
+
+func (x *RetireSamlIdpKeyRequest) Reset() {
+	*x = RetireSamlIdpKeyRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[110]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetireSamlIdpKeyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetireSamlIdpKeyRequest) ProtoMessage() {}
+
+func (x *RetireSamlIdpKeyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[110]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetireSamlIdpKeyRequest.ProtoReflect.Descriptor instead.
+func (*RetireSamlIdpKeyRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{110}
+}
+
+func (x *RetireSamlIdpKeyRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type RetireSamlIdpKeyResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *RetireSamlIdpKeyResponse) Reset() {
+	*x = RetireSamlIdpKeyResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[111]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetireSamlIdpKeyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetireSamlIdpKeyResponse) ProtoMessage() {}
+
+func (x *RetireSamlIdpKeyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[111]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetireSamlIdpKeyResponse.ProtoReflect.Descriptor instead.
+func (*RetireSamlIdpKeyResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{111}
+}
+
+func (x *RetireSamlIdpKeyResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// ListSamlIdpKeysRequest mirrors model.ListSAMLIDPKeysRequest.
+type ListSamlIdpKeysRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrgId string `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+}
+
+func (x *ListSamlIdpKeysRequest) Reset() {
+	*x = ListSamlIdpKeysRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[112]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSamlIdpKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSamlIdpKeysRequest) ProtoMessage() {}
+
+func (x *ListSamlIdpKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[112]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSamlIdpKeysRequest.ProtoReflect.Descriptor instead.
+func (*ListSamlIdpKeysRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{112}
+}
+
+func (x *ListSamlIdpKeysRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+type ListSamlIdpKeysResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	SamlIdpKeys []*SamlIdpKey `protobuf:"bytes,1,rep,name=saml_idp_keys,json=samlIdpKeys,proto3" json:"saml_idp_keys,omitempty"`
+}
+
+func (x *ListSamlIdpKeysResponse) Reset() {
+	*x = ListSamlIdpKeysResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[113]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSamlIdpKeysResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSamlIdpKeysResponse) ProtoMessage() {}
+
+func (x *ListSamlIdpKeysResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[113]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSamlIdpKeysResponse.ProtoReflect.Descriptor instead.
+func (*ListSamlIdpKeysResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{113}
+}
+
+func (x *ListSamlIdpKeysResponse) GetSamlIdpKeys() []*SamlIdpKey {
+	if x != nil {
+		return x.SamlIdpKeys
+	}
+	return nil
+}
+
+// ImportSamlSpMetadataRequest mirrors model.ImportSAMLSPMetadataRequest. The
+// metadata is pasted XML — NOT a URL; no remote fetch is performed.
+type ImportSamlSpMetadataRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	MetadataXml string `protobuf:"bytes,1,opt,name=metadata_xml,json=metadataXml,proto3" json:"metadata_xml,omitempty"`
+}
+
+func (x *ImportSamlSpMetadataRequest) Reset() {
+	*x = ImportSamlSpMetadataRequest{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[114]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ImportSamlSpMetadataRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ImportSamlSpMetadataRequest) ProtoMessage() {}
+
+func (x *ImportSamlSpMetadataRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[114]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ImportSamlSpMetadataRequest.ProtoReflect.Descriptor instead.
+func (*ImportSamlSpMetadataRequest) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{114}
+}
+
+func (x *ImportSamlSpMetadataRequest) GetMetadataXml() string {
+	if x != nil {
+		return x.MetadataXml
+	}
+	return ""
+}
+
+type ImportSamlSpMetadataResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Result *SamlSpMetadataParseResult `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+}
+
+func (x *ImportSamlSpMetadataResponse) Reset() {
+	*x = ImportSamlSpMetadataResponse{}
+	mi := &file_authorizer_v1_admin_proto_msgTypes[115]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ImportSamlSpMetadataResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ImportSamlSpMetadataResponse) ProtoMessage() {}
+
+func (x *ImportSamlSpMetadataResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_authorizer_v1_admin_proto_msgTypes[115]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ImportSamlSpMetadataResponse.ProtoReflect.Descriptor instead.
+func (*ImportSamlSpMetadataResponse) Descriptor() ([]byte, []int) {
+	return file_authorizer_v1_admin_proto_rawDescGZIP(), []int{115}
+}
+
+func (x *ImportSamlSpMetadataResponse) GetResult() *SamlSpMetadataParseResult {
+	if x != nil {
+		return x.Result
+	}
+	return nil
+}
+
 var File_authorizer_v1_admin_proto protoreflect.FileDescriptor
 
 var file_authorizer_v1_admin_proto_rawDesc = []byte{
@@ -6401,7 +7672,200 @@ var file_authorizer_v1_admin_proto_rawDesc = []byte{
 	0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x61,
 	0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x67,
 	0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74,
-	0x69, 0x6f, 0x6e, 0x32, 0xa8, 0x2a, 0x0a, 0x16, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x69, 0x6f, 0x6e, 0x22, 0x84, 0x03, 0x0a, 0x13, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0x0e, 0x0a, 0x02, 0x69,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x15, 0x0a, 0x06, 0x6f,
+	0x72, 0x67, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x6f, 0x72, 0x67,
+	0x49, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79,
+	0x5f, 0x69, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x6e, 0x74, 0x69, 0x74,
+	0x79, 0x49, 0x64, 0x12, 0x17, 0x0a, 0x07, 0x61, 0x63, 0x73, 0x5f, 0x75, 0x72, 0x6c, 0x18, 0x05,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x61, 0x63, 0x73, 0x55, 0x72, 0x6c, 0x12, 0x1e, 0x0a, 0x0b,
+	0x73, 0x70, 0x5f, 0x63, 0x65, 0x72, 0x74, 0x5f, 0x70, 0x65, 0x6d, 0x18, 0x06, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x09, 0x73, 0x70, 0x43, 0x65, 0x72, 0x74, 0x50, 0x65, 0x6d, 0x12, 0x24, 0x0a, 0x0e,
+	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x69, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x07,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x6e, 0x61, 0x6d, 0x65, 0x49, 0x64, 0x46, 0x6f, 0x72, 0x6d,
+	0x61, 0x74, 0x12, 0x2b, 0x0a, 0x11, 0x6d, 0x61, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x74,
+	0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x6d,
+	0x61, 0x70, 0x70, 0x65, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x12,
+	0x2e, 0x0a, 0x13, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x69, 0x6e, 0x69,
+	0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x18, 0x09, 0x20, 0x01, 0x28, 0x08, 0x52, 0x11, 0x61, 0x6c,
+	0x6c, 0x6f, 0x77, 0x49, 0x64, 0x70, 0x49, 0x6e, 0x69, 0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x12,
+	0x1b, 0x0a, 0x09, 0x69, 0x73, 0x5f, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65, 0x18, 0x0a, 0x20, 0x01,
+	0x28, 0x08, 0x52, 0x08, 0x69, 0x73, 0x41, 0x63, 0x74, 0x69, 0x76, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+	0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x09, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x12, 0x1d, 0x0a, 0x0a, 0x75,
+	0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x03, 0x52,
+	0x09, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x22, 0xc2, 0x01, 0x0a, 0x0a, 0x53,
+	0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x15, 0x0a, 0x06, 0x6f, 0x72, 0x67,
+	0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64,
+	0x12, 0x19, 0x0a, 0x08, 0x63, 0x65, 0x72, 0x74, 0x5f, 0x70, 0x65, 0x6d, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x07, 0x63, 0x65, 0x72, 0x74, 0x50, 0x65, 0x6d, 0x12, 0x1c, 0x0a, 0x09, 0x61,
+	0x6c, 0x67, 0x6f, 0x72, 0x69, 0x74, 0x68, 0x6d, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09,
+	0x61, 0x6c, 0x67, 0x6f, 0x72, 0x69, 0x74, 0x68, 0x6d, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x74, 0x61,
+	0x74, 0x75, 0x73, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75,
+	0x73, 0x12, 0x1d, 0x0a, 0x0a, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18,
+	0x06, 0x20, 0x01, 0x28, 0x03, 0x52, 0x09, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74,
+	0x12, 0x1d, 0x0a, 0x0a, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x07,
+	0x20, 0x01, 0x28, 0x03, 0x52, 0x09, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x22,
+	0x73, 0x0a, 0x19, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
+	0x61, 0x50, 0x61, 0x72, 0x73, 0x65, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x1b, 0x0a, 0x09,
+	0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x08, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x49, 0x64, 0x12, 0x17, 0x0a, 0x07, 0x61, 0x63, 0x73,
+	0x5f, 0x75, 0x72, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x61, 0x63, 0x73, 0x55,
+	0x72, 0x6c, 0x12, 0x20, 0x0a, 0x0b, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
+	0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69,
+	0x63, 0x61, 0x74, 0x65, 0x22, 0xaf, 0x03, 0x0a, 0x20, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x53,
+	0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1e, 0x0a, 0x06, 0x6f, 0x72, 0x67,
+	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02,
+	0x10, 0x01, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64, 0x12, 0x1b, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
+	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01,
+	0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x24, 0x0a, 0x09, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79,
+	0x5f, 0x69, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02,
+	0x10, 0x01, 0x52, 0x08, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x49, 0x64, 0x12, 0x20, 0x0a, 0x07,
+	0x61, 0x63, 0x73, 0x5f, 0x75, 0x72, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba,
+	0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x06, 0x61, 0x63, 0x73, 0x55, 0x72, 0x6c, 0x12, 0x23,
+	0x0a, 0x0b, 0x73, 0x70, 0x5f, 0x63, 0x65, 0x72, 0x74, 0x5f, 0x70, 0x65, 0x6d, 0x18, 0x05, 0x20,
+	0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x09, 0x73, 0x70, 0x43, 0x65, 0x72, 0x74, 0x50, 0x65, 0x6d,
+	0x88, 0x01, 0x01, 0x12, 0x29, 0x0a, 0x0e, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x69, 0x64, 0x5f, 0x66,
+	0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x0c, 0x6e,
+	0x61, 0x6d, 0x65, 0x49, 0x64, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x88, 0x01, 0x01, 0x12, 0x30,
+	0x0a, 0x11, 0x6d, 0x61, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75,
+	0x74, 0x65, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x48, 0x02, 0x52, 0x10, 0x6d, 0x61, 0x70,
+	0x70, 0x65, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x88, 0x01, 0x01,
+	0x12, 0x33, 0x0a, 0x13, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x69, 0x6e,
+	0x69, 0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x18, 0x08, 0x20, 0x01, 0x28, 0x08, 0x48, 0x03, 0x52,
+	0x11, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x49, 0x64, 0x70, 0x49, 0x6e, 0x69, 0x74, 0x69, 0x61, 0x74,
+	0x65, 0x64, 0x88, 0x01, 0x01, 0x42, 0x0e, 0x0a, 0x0c, 0x5f, 0x73, 0x70, 0x5f, 0x63, 0x65, 0x72,
+	0x74, 0x5f, 0x70, 0x65, 0x6d, 0x42, 0x11, 0x0a, 0x0f, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x69,
+	0x64, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x14, 0x0a, 0x12, 0x5f, 0x6d, 0x61, 0x70,
+	0x70, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x42, 0x16,
+	0x0a, 0x14, 0x5f, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x69, 0x6e, 0x69,
+	0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x22, 0x7b, 0x0a, 0x21, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65,
+	0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x56, 0x0a, 0x15, 0x73,
+	0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76,
+	0x69, 0x64, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x61, 0x75, 0x74,
+	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x61, 0x6d, 0x6c, 0x53,
+	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x13,
+	0x73, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x22, 0xef, 0x03, 0x0a, 0x20, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x61,
+	0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65,
+	0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x17, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x02, 0x69,
+	0x64, 0x12, 0x17, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48,
+	0x00, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x88, 0x01, 0x01, 0x12, 0x20, 0x0a, 0x09, 0x65, 0x6e,
+	0x74, 0x69, 0x74, 0x79, 0x5f, 0x69, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52,
+	0x08, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x49, 0x64, 0x88, 0x01, 0x01, 0x12, 0x1c, 0x0a, 0x07,
+	0x61, 0x63, 0x73, 0x5f, 0x75, 0x72, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x48, 0x02, 0x52,
+	0x06, 0x61, 0x63, 0x73, 0x55, 0x72, 0x6c, 0x88, 0x01, 0x01, 0x12, 0x23, 0x0a, 0x0b, 0x73, 0x70,
+	0x5f, 0x63, 0x65, 0x72, 0x74, 0x5f, 0x70, 0x65, 0x6d, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x48,
+	0x03, 0x52, 0x09, 0x73, 0x70, 0x43, 0x65, 0x72, 0x74, 0x50, 0x65, 0x6d, 0x88, 0x01, 0x01, 0x12,
+	0x29, 0x0a, 0x0e, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x69, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61,
+	0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x48, 0x04, 0x52, 0x0c, 0x6e, 0x61, 0x6d, 0x65, 0x49,
+	0x64, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x88, 0x01, 0x01, 0x12, 0x30, 0x0a, 0x11, 0x6d, 0x61,
+	0x70, 0x70, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x18,
+	0x07, 0x20, 0x01, 0x28, 0x09, 0x48, 0x05, 0x52, 0x10, 0x6d, 0x61, 0x70, 0x70, 0x65, 0x64, 0x41,
+	0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x88, 0x01, 0x01, 0x12, 0x33, 0x0a, 0x13,
+	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x61,
+	0x74, 0x65, 0x64, 0x18, 0x08, 0x20, 0x01, 0x28, 0x08, 0x48, 0x06, 0x52, 0x11, 0x61, 0x6c, 0x6c,
+	0x6f, 0x77, 0x49, 0x64, 0x70, 0x49, 0x6e, 0x69, 0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x88, 0x01,
+	0x01, 0x12, 0x20, 0x0a, 0x09, 0x69, 0x73, 0x5f, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65, 0x18, 0x09,
+	0x20, 0x01, 0x28, 0x08, 0x48, 0x07, 0x52, 0x08, 0x69, 0x73, 0x41, 0x63, 0x74, 0x69, 0x76, 0x65,
+	0x88, 0x01, 0x01, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x42, 0x0c, 0x0a, 0x0a,
+	0x5f, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x5f, 0x69, 0x64, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x61,
+	0x63, 0x73, 0x5f, 0x75, 0x72, 0x6c, 0x42, 0x0e, 0x0a, 0x0c, 0x5f, 0x73, 0x70, 0x5f, 0x63, 0x65,
+	0x72, 0x74, 0x5f, 0x70, 0x65, 0x6d, 0x42, 0x11, 0x0a, 0x0f, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x5f,
+	0x69, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x14, 0x0a, 0x12, 0x5f, 0x6d, 0x61,
+	0x70, 0x70, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65, 0x73, 0x42,
+	0x16, 0x0a, 0x14, 0x5f, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x69, 0x6e,
+	0x69, 0x74, 0x69, 0x61, 0x74, 0x65, 0x64, 0x42, 0x0c, 0x0a, 0x0a, 0x5f, 0x69, 0x73, 0x5f, 0x61,
+	0x63, 0x74, 0x69, 0x76, 0x65, 0x22, 0x7b, 0x0a, 0x21, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53,
+	0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x56, 0x0a, 0x15, 0x73, 0x61,
+	0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x61, 0x75, 0x74, 0x68,
+	0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x13, 0x73,
+	0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x22, 0x3b, 0x0a, 0x20, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c,
+	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x17, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x02, 0x69, 0x64, 0x22,
+	0x3d, 0x0a, 0x21, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70,
+	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x22, 0x38,
+	0x0a, 0x1d, 0x47, 0x65, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
+	0x17, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04,
+	0x72, 0x02, 0x10, 0x01, 0x52, 0x02, 0x69, 0x64, 0x22, 0x78, 0x0a, 0x1e, 0x47, 0x65, 0x74, 0x53,
+	0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x56, 0x0a, 0x15, 0x73, 0x61,
+	0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x61, 0x75, 0x74, 0x68,
+	0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x13, 0x73,
+	0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x22, 0x83, 0x01, 0x0a, 0x1f, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53,
+	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1e, 0x0a, 0x06, 0x6f, 0x72, 0x67, 0x5f, 0x69, 0x64,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52,
+	0x05, 0x6f, 0x72, 0x67, 0x49, 0x64, 0x12, 0x40, 0x0a, 0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x61, 0x75, 0x74,
+	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x67, 0x69, 0x6e,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x52, 0x0a, 0x70, 0x61,
+	0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb7, 0x01, 0x0a, 0x20, 0x4c, 0x69, 0x73,
+	0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76,
+	0x69, 0x64, 0x65, 0x72, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x58, 0x0a,
+	0x16, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72,
+	0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x22, 0x2e,
+	0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x61,
+	0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65,
+	0x72, 0x52, 0x14, 0x73, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72,
+	0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x12, 0x39, 0x0a, 0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x61, 0x75,
+	0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x67, 0x69,
+	0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x18, 0x52, 0x6f, 0x74, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c,
+	0x49, 0x64, 0x70, 0x43, 0x65, 0x72, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1e,
+	0x0a, 0x06, 0x6f, 0x72, 0x67, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07,
+	0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64, 0x22, 0x58,
+	0x0a, 0x19, 0x52, 0x6f, 0x74, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x43,
+	0x65, 0x72, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x0c, 0x73,
+	0x61, 0x6d, 0x6c, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x19, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76,
+	0x31, 0x2e, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x52, 0x0a, 0x73, 0x61,
+	0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x22, 0x32, 0x0a, 0x17, 0x52, 0x65, 0x74, 0x69,
+	0x72, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x17, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42,
+	0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x02, 0x69, 0x64, 0x22, 0x34, 0x0a, 0x18,
+	0x52, 0x65, 0x74, 0x69, 0x72, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73,
+	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61,
+	0x67, 0x65, 0x22, 0x38, 0x0a, 0x16, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64,
+	0x70, 0x4b, 0x65, 0x79, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1e, 0x0a, 0x06,
+	0x6f, 0x72, 0x67, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48,
+	0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64, 0x22, 0x58, 0x0a, 0x17,
+	0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x73, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3d, 0x0a, 0x0d, 0x73, 0x61, 0x6d, 0x6c, 0x5f,
+	0x69, 0x64, 0x70, 0x5f, 0x6b, 0x65, 0x79, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x19,
+	0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53,
+	0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x52, 0x0b, 0x73, 0x61, 0x6d, 0x6c, 0x49,
+	0x64, 0x70, 0x4b, 0x65, 0x79, 0x73, 0x22, 0x49, 0x0a, 0x1b, 0x49, 0x6d, 0x70, 0x6f, 0x72, 0x74,
+	0x53, 0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x2a, 0x0a, 0x0c, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
+	0x61, 0x5f, 0x78, 0x6d, 0x6c, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x07, 0xba, 0x48, 0x04,
+	0x72, 0x02, 0x10, 0x01, 0x52, 0x0b, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x58, 0x6d,
+	0x6c, 0x22, 0x60, 0x0a, 0x1c, 0x49, 0x6d, 0x70, 0x6f, 0x72, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53,
+	0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x12, 0x40, 0x0a, 0x06, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x28, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76,
+	0x31, 0x2e, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61,
+	0x50, 0x61, 0x72, 0x73, 0x65, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x52, 0x06, 0x72, 0x65, 0x73,
+	0x75, 0x6c, 0x74, 0x32, 0xde, 0x35, 0x0a, 0x16, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
 	0x65, 0x72, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x71,
 	0x0a, 0x0a, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x4c, 0x6f, 0x67, 0x69, 0x6e, 0x12, 0x20, 0x2e, 0x61,
 	0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x64, 0x6d,
@@ -6739,20 +8203,111 @@ var file_authorizer_v1_admin_proto_rawDesc = []byte{
 	0x31, 0x2e, 0x54, 0x72, 0x75, 0x73, 0x74, 0x65, 0x64, 0x49, 0x73, 0x73, 0x75, 0x65, 0x72, 0x73,
 	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x24, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x1e,
 	0x3a, 0x01, 0x2a, 0x22, 0x19, 0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x74,
-	0x72, 0x75, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x69, 0x73, 0x73, 0x75, 0x65, 0x72, 0x73, 0x42, 0xbb,
-	0x01, 0x0a, 0x11, 0x63, 0x6f, 0x6d, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65,
-	0x72, 0x2e, 0x76, 0x31, 0x42, 0x0a, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
-	0x50, 0x01, 0x5a, 0x45, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61,
-	0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x64, 0x65, 0x76, 0x2f, 0x61, 0x75, 0x74,
-	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2f, 0x67, 0x65, 0x6e, 0x2f, 0x67, 0x6f, 0x2f, 0x61,
-	0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2f, 0x76, 0x31, 0x3b, 0x61, 0x75, 0x74,
-	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x76, 0x31, 0xa2, 0x02, 0x03, 0x41, 0x58, 0x58, 0xaa,
-	0x02, 0x0d, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x56, 0x31, 0xca,
-	0x02, 0x0d, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x5c, 0x56, 0x31, 0xe2,
-	0x02, 0x19, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x5c, 0x56, 0x31, 0x5c,
-	0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x0e, 0x41, 0x75,
-	0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x33,
+	0x72, 0x75, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x69, 0x73, 0x73, 0x75, 0x65, 0x72, 0x73, 0x12, 0xb1,
+	0x01, 0x0a, 0x19, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0x2f, 0x2e, 0x61,
+	0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x72, 0x65,
+	0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72,
+	0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x30, 0x2e,
+	0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x72,
+	0x65, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50,
+	0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x31, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x2b, 0x3a, 0x01, 0x2a, 0x22, 0x26, 0x2f, 0x76, 0x31, 0x2f,
+	0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x5f, 0x73, 0x61, 0x6d,
+	0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64,
+	0x65, 0x72, 0x12, 0xb1, 0x01, 0x0a, 0x19, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d,
+	0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72,
+	0x12, 0x2f, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31,
+	0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69,
+	0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x30, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76,
+	0x31, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x22, 0x31, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x2b, 0x3a, 0x01, 0x2a, 0x22, 0x26,
+	0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65,
+	0x5f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72,
+	0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0xb1, 0x01, 0x0a, 0x19, 0x44, 0x65, 0x6c, 0x65, 0x74,
+	0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76,
+	0x69, 0x64, 0x65, 0x72, 0x12, 0x2f, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65,
+	0x72, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x53,
+	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x30, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c,
+	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x31, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x2b, 0x3a,
+	0x01, 0x2a, 0x22, 0x26, 0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x64, 0x65,
+	0x6c, 0x65, 0x74, 0x65, 0x5f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63,
+	0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0xa1, 0x01, 0x0a, 0x16, 0x47,
+	0x65, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f,
+	0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0x2c, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x1a, 0x2d, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72,
+	0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69,
+	0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x22, 0x2a, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x24, 0x3a, 0x01, 0x2a, 0x22, 0x1f, 0x2f,
+	0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0xa8,
+	0x01, 0x0a, 0x18, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69,
+	0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x12, 0x2e, 0x2e, 0x61, 0x75,
+	0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74,
+	0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2f, 0x2e, 0x61, 0x75,
+	0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74,
+	0x53, 0x61, 0x6d, 0x6c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69,
+	0x64, 0x65, 0x72, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x2b, 0x82, 0xd3,
+	0xe4, 0x93, 0x02, 0x25, 0x3a, 0x01, 0x2a, 0x22, 0x20, 0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d,
+	0x69, 0x6e, 0x2f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f,
+	0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x12, 0x91, 0x01, 0x0a, 0x11, 0x52, 0x6f,
+	0x74, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x43, 0x65, 0x72, 0x74, 0x12,
+	0x27, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e,
+	0x52, 0x6f, 0x74, 0x61, 0x74, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x43, 0x65, 0x72,
+	0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x28, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f,
+	0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x6f, 0x74, 0x61, 0x74, 0x65, 0x53,
+	0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x43, 0x65, 0x72, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x22, 0x29, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x23, 0x3a, 0x01, 0x2a, 0x22, 0x1e, 0x2f,
+	0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x72, 0x6f, 0x74, 0x61, 0x74, 0x65, 0x5f,
+	0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x63, 0x65, 0x72, 0x74, 0x12, 0x8d, 0x01,
+	0x0a, 0x10, 0x52, 0x65, 0x74, 0x69, 0x72, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b,
+	0x65, 0x79, 0x12, 0x26, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e,
+	0x76, 0x31, 0x2e, 0x52, 0x65, 0x74, 0x69, 0x72, 0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70,
+	0x4b, 0x65, 0x79, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x27, 0x2e, 0x61, 0x75, 0x74,
+	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x74, 0x69, 0x72,
+	0x65, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x22, 0x28, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x22, 0x3a, 0x01, 0x2a, 0x22, 0x1d,
+	0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x72, 0x65, 0x74, 0x69, 0x72, 0x65,
+	0x5f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x69, 0x64, 0x70, 0x5f, 0x6b, 0x65, 0x79, 0x12, 0x84, 0x01,
+	0x0a, 0x0f, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79,
+	0x73, 0x12, 0x25, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76,
+	0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79,
+	0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x26, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x6f,
+	0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x61, 0x6d,
+	0x6c, 0x49, 0x64, 0x70, 0x4b, 0x65, 0x79, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x22, 0x22, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x1c, 0x3a, 0x01, 0x2a, 0x22, 0x17, 0x2f, 0x76, 0x31,
+	0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x69, 0x64, 0x70, 0x5f,
+	0x6b, 0x65, 0x79, 0x73, 0x12, 0x9d, 0x01, 0x0a, 0x14, 0x49, 0x6d, 0x70, 0x6f, 0x72, 0x74, 0x53,
+	0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x2a, 0x2e,
+	0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x49, 0x6d,
+	0x70, 0x6f, 0x72, 0x74, 0x53, 0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61,
+	0x74, 0x61, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b, 0x2e, 0x61, 0x75, 0x74, 0x68,
+	0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x49, 0x6d, 0x70, 0x6f, 0x72, 0x74,
+	0x53, 0x61, 0x6d, 0x6c, 0x53, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x2c, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x26, 0x3a, 0x01,
+	0x2a, 0x22, 0x21, 0x2f, 0x76, 0x31, 0x2f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2f, 0x69, 0x6d, 0x70,
+	0x6f, 0x72, 0x74, 0x5f, 0x73, 0x61, 0x6d, 0x6c, 0x5f, 0x73, 0x70, 0x5f, 0x6d, 0x65, 0x74, 0x61,
+	0x64, 0x61, 0x74, 0x61, 0x42, 0xbb, 0x01, 0x0a, 0x11, 0x63, 0x6f, 0x6d, 0x2e, 0x61, 0x75, 0x74,
+	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x42, 0x0a, 0x41, 0x64, 0x6d, 0x69,
+	0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x45, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x64,
+	0x65, 0x76, 0x2f, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2f, 0x67, 0x65,
+	0x6e, 0x2f, 0x67, 0x6f, 0x2f, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x2f,
+	0x76, 0x31, 0x3b, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x76, 0x31, 0xa2,
+	0x02, 0x03, 0x41, 0x58, 0x58, 0xaa, 0x02, 0x0d, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x65, 0x72, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0d, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x65, 0x72, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x19, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a,
+	0x65, 0x72, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
+	0x61, 0xea, 0x02, 0x0e, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x72, 0x3a, 0x3a,
+	0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -6767,246 +8322,294 @@ func file_authorizer_v1_admin_proto_rawDescGZIP() []byte {
 	return file_authorizer_v1_admin_proto_rawDescData
 }
 
-var file_authorizer_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
+var file_authorizer_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 116)
 var file_authorizer_v1_admin_proto_goTypes = []any{
-	(*AdminLoginRequest)(nil),            // 0: authorizer.v1.AdminLoginRequest
-	(*AdminLoginResponse)(nil),           // 1: authorizer.v1.AdminLoginResponse
-	(*AdminLogoutRequest)(nil),           // 2: authorizer.v1.AdminLogoutRequest
-	(*AdminLogoutResponse)(nil),          // 3: authorizer.v1.AdminLogoutResponse
-	(*AdminSessionRequest)(nil),          // 4: authorizer.v1.AdminSessionRequest
-	(*AdminSessionResponse)(nil),         // 5: authorizer.v1.AdminSessionResponse
-	(*AdminMetaRequest)(nil),             // 6: authorizer.v1.AdminMetaRequest
-	(*AdminMetaResponse)(nil),            // 7: authorizer.v1.AdminMetaResponse
-	(*AdminMeta)(nil),                    // 8: authorizer.v1.AdminMeta
-	(*UsersRequest)(nil),                 // 9: authorizer.v1.UsersRequest
-	(*UsersResponse)(nil),                // 10: authorizer.v1.UsersResponse
-	(*UserRequest)(nil),                  // 11: authorizer.v1.UserRequest
-	(*UserResponse)(nil),                 // 12: authorizer.v1.UserResponse
-	(*UpdateUserRequest)(nil),            // 13: authorizer.v1.UpdateUserRequest
-	(*UpdateUserResponse)(nil),           // 14: authorizer.v1.UpdateUserResponse
-	(*DeleteUserRequest)(nil),            // 15: authorizer.v1.DeleteUserRequest
-	(*DeleteUserResponse)(nil),           // 16: authorizer.v1.DeleteUserResponse
-	(*VerificationRequestsRequest)(nil),  // 17: authorizer.v1.VerificationRequestsRequest
-	(*VerificationRequestsResponse)(nil), // 18: authorizer.v1.VerificationRequestsResponse
-	(*VerificationRequest)(nil),          // 19: authorizer.v1.VerificationRequest
-	(*RevokeAccessRequest)(nil),          // 20: authorizer.v1.RevokeAccessRequest
-	(*RevokeAccessResponse)(nil),         // 21: authorizer.v1.RevokeAccessResponse
-	(*EnableAccessRequest)(nil),          // 22: authorizer.v1.EnableAccessRequest
-	(*EnableAccessResponse)(nil),         // 23: authorizer.v1.EnableAccessResponse
-	(*InviteMembersRequest)(nil),         // 24: authorizer.v1.InviteMembersRequest
-	(*InviteMembersResponse)(nil),        // 25: authorizer.v1.InviteMembersResponse
-	(*Webhook)(nil),                      // 26: authorizer.v1.Webhook
-	(*WebhookLog)(nil),                   // 27: authorizer.v1.WebhookLog
-	(*AddWebhookRequest)(nil),            // 28: authorizer.v1.AddWebhookRequest
-	(*AddWebhookResponse)(nil),           // 29: authorizer.v1.AddWebhookResponse
-	(*UpdateWebhookRequest)(nil),         // 30: authorizer.v1.UpdateWebhookRequest
-	(*UpdateWebhookResponse)(nil),        // 31: authorizer.v1.UpdateWebhookResponse
-	(*DeleteWebhookRequest)(nil),         // 32: authorizer.v1.DeleteWebhookRequest
-	(*DeleteWebhookResponse)(nil),        // 33: authorizer.v1.DeleteWebhookResponse
-	(*GetWebhookRequest)(nil),            // 34: authorizer.v1.GetWebhookRequest
-	(*GetWebhookResponse)(nil),           // 35: authorizer.v1.GetWebhookResponse
-	(*WebhooksRequest)(nil),              // 36: authorizer.v1.WebhooksRequest
-	(*WebhooksResponse)(nil),             // 37: authorizer.v1.WebhooksResponse
-	(*WebhookLogsRequest)(nil),           // 38: authorizer.v1.WebhookLogsRequest
-	(*WebhookLogsResponse)(nil),          // 39: authorizer.v1.WebhookLogsResponse
-	(*TestEndpointRequest)(nil),          // 40: authorizer.v1.TestEndpointRequest
-	(*TestEndpointResponse)(nil),         // 41: authorizer.v1.TestEndpointResponse
-	(*EmailTemplate)(nil),                // 42: authorizer.v1.EmailTemplate
-	(*AddEmailTemplateRequest)(nil),      // 43: authorizer.v1.AddEmailTemplateRequest
-	(*AddEmailTemplateResponse)(nil),     // 44: authorizer.v1.AddEmailTemplateResponse
-	(*UpdateEmailTemplateRequest)(nil),   // 45: authorizer.v1.UpdateEmailTemplateRequest
-	(*UpdateEmailTemplateResponse)(nil),  // 46: authorizer.v1.UpdateEmailTemplateResponse
-	(*DeleteEmailTemplateRequest)(nil),   // 47: authorizer.v1.DeleteEmailTemplateRequest
-	(*DeleteEmailTemplateResponse)(nil),  // 48: authorizer.v1.DeleteEmailTemplateResponse
-	(*EmailTemplatesRequest)(nil),        // 49: authorizer.v1.EmailTemplatesRequest
-	(*EmailTemplatesResponse)(nil),       // 50: authorizer.v1.EmailTemplatesResponse
-	(*AuditLog)(nil),                     // 51: authorizer.v1.AuditLog
-	(*AuditLogsRequest)(nil),             // 52: authorizer.v1.AuditLogsRequest
-	(*AuditLogsResponse)(nil),            // 53: authorizer.v1.AuditLogsResponse
-	(*FgaModel)(nil),                     // 54: authorizer.v1.FgaModel
-	(*FgaTuple)(nil),                     // 55: authorizer.v1.FgaTuple
-	(*FgaGetModelRequest)(nil),           // 56: authorizer.v1.FgaGetModelRequest
-	(*FgaGetModelResponse)(nil),          // 57: authorizer.v1.FgaGetModelResponse
-	(*FgaWriteModelRequest)(nil),         // 58: authorizer.v1.FgaWriteModelRequest
-	(*FgaWriteModelResponse)(nil),        // 59: authorizer.v1.FgaWriteModelResponse
-	(*FgaWriteTuplesRequest)(nil),        // 60: authorizer.v1.FgaWriteTuplesRequest
-	(*FgaWriteTuplesResponse)(nil),       // 61: authorizer.v1.FgaWriteTuplesResponse
-	(*FgaDeleteTuplesRequest)(nil),       // 62: authorizer.v1.FgaDeleteTuplesRequest
-	(*FgaDeleteTuplesResponse)(nil),      // 63: authorizer.v1.FgaDeleteTuplesResponse
-	(*FgaReadTuplesRequest)(nil),         // 64: authorizer.v1.FgaReadTuplesRequest
-	(*FgaReadTuplesResponse)(nil),        // 65: authorizer.v1.FgaReadTuplesResponse
-	(*FgaListUsersRequest)(nil),          // 66: authorizer.v1.FgaListUsersRequest
-	(*FgaListUsersResponse)(nil),         // 67: authorizer.v1.FgaListUsersResponse
-	(*FgaExpandRequest)(nil),             // 68: authorizer.v1.FgaExpandRequest
-	(*FgaExpandResponse)(nil),            // 69: authorizer.v1.FgaExpandResponse
-	(*FgaResetRequest)(nil),              // 70: authorizer.v1.FgaResetRequest
-	(*FgaResetResponse)(nil),             // 71: authorizer.v1.FgaResetResponse
-	(*Client)(nil),                       // 72: authorizer.v1.Client
-	(*CreateClientRequest)(nil),          // 73: authorizer.v1.CreateClientRequest
-	(*CreateClientResponse)(nil),         // 74: authorizer.v1.CreateClientResponse
-	(*UpdateClientRequest)(nil),          // 75: authorizer.v1.UpdateClientRequest
-	(*UpdateClientResponse)(nil),         // 76: authorizer.v1.UpdateClientResponse
-	(*DeleteClientRequest)(nil),          // 77: authorizer.v1.DeleteClientRequest
-	(*DeleteClientResponse)(nil),         // 78: authorizer.v1.DeleteClientResponse
-	(*RotateClientSecretRequest)(nil),    // 79: authorizer.v1.RotateClientSecretRequest
-	(*GetClientRequest)(nil),             // 80: authorizer.v1.GetClientRequest
-	(*GetClientResponse)(nil),            // 81: authorizer.v1.GetClientResponse
-	(*ClientsRequest)(nil),               // 82: authorizer.v1.ClientsRequest
-	(*ClientsResponse)(nil),              // 83: authorizer.v1.ClientsResponse
-	(*TrustedIssuer)(nil),                // 84: authorizer.v1.TrustedIssuer
-	(*AddTrustedIssuerRequest)(nil),      // 85: authorizer.v1.AddTrustedIssuerRequest
-	(*AddTrustedIssuerResponse)(nil),     // 86: authorizer.v1.AddTrustedIssuerResponse
-	(*UpdateTrustedIssuerRequest)(nil),   // 87: authorizer.v1.UpdateTrustedIssuerRequest
-	(*UpdateTrustedIssuerResponse)(nil),  // 88: authorizer.v1.UpdateTrustedIssuerResponse
-	(*DeleteTrustedIssuerRequest)(nil),   // 89: authorizer.v1.DeleteTrustedIssuerRequest
-	(*DeleteTrustedIssuerResponse)(nil),  // 90: authorizer.v1.DeleteTrustedIssuerResponse
-	(*GetTrustedIssuerRequest)(nil),      // 91: authorizer.v1.GetTrustedIssuerRequest
-	(*GetTrustedIssuerResponse)(nil),     // 92: authorizer.v1.GetTrustedIssuerResponse
-	(*TrustedIssuersRequest)(nil),        // 93: authorizer.v1.TrustedIssuersRequest
-	(*TrustedIssuersResponse)(nil),       // 94: authorizer.v1.TrustedIssuersResponse
-	(*PaginationRequest)(nil),            // 95: authorizer.v1.PaginationRequest
-	(*User)(nil),                         // 96: authorizer.v1.User
-	(*Pagination)(nil),                   // 97: authorizer.v1.Pagination
-	(*AppData)(nil),                      // 98: authorizer.v1.AppData
-	(*FgaTupleInput)(nil),                // 99: authorizer.v1.FgaTupleInput
+	(*AdminLoginRequest)(nil),                 // 0: authorizer.v1.AdminLoginRequest
+	(*AdminLoginResponse)(nil),                // 1: authorizer.v1.AdminLoginResponse
+	(*AdminLogoutRequest)(nil),                // 2: authorizer.v1.AdminLogoutRequest
+	(*AdminLogoutResponse)(nil),               // 3: authorizer.v1.AdminLogoutResponse
+	(*AdminSessionRequest)(nil),               // 4: authorizer.v1.AdminSessionRequest
+	(*AdminSessionResponse)(nil),              // 5: authorizer.v1.AdminSessionResponse
+	(*AdminMetaRequest)(nil),                  // 6: authorizer.v1.AdminMetaRequest
+	(*AdminMetaResponse)(nil),                 // 7: authorizer.v1.AdminMetaResponse
+	(*AdminMeta)(nil),                         // 8: authorizer.v1.AdminMeta
+	(*UsersRequest)(nil),                      // 9: authorizer.v1.UsersRequest
+	(*UsersResponse)(nil),                     // 10: authorizer.v1.UsersResponse
+	(*UserRequest)(nil),                       // 11: authorizer.v1.UserRequest
+	(*UserResponse)(nil),                      // 12: authorizer.v1.UserResponse
+	(*UpdateUserRequest)(nil),                 // 13: authorizer.v1.UpdateUserRequest
+	(*UpdateUserResponse)(nil),                // 14: authorizer.v1.UpdateUserResponse
+	(*DeleteUserRequest)(nil),                 // 15: authorizer.v1.DeleteUserRequest
+	(*DeleteUserResponse)(nil),                // 16: authorizer.v1.DeleteUserResponse
+	(*VerificationRequestsRequest)(nil),       // 17: authorizer.v1.VerificationRequestsRequest
+	(*VerificationRequestsResponse)(nil),      // 18: authorizer.v1.VerificationRequestsResponse
+	(*VerificationRequest)(nil),               // 19: authorizer.v1.VerificationRequest
+	(*RevokeAccessRequest)(nil),               // 20: authorizer.v1.RevokeAccessRequest
+	(*RevokeAccessResponse)(nil),              // 21: authorizer.v1.RevokeAccessResponse
+	(*EnableAccessRequest)(nil),               // 22: authorizer.v1.EnableAccessRequest
+	(*EnableAccessResponse)(nil),              // 23: authorizer.v1.EnableAccessResponse
+	(*InviteMembersRequest)(nil),              // 24: authorizer.v1.InviteMembersRequest
+	(*InviteMembersResponse)(nil),             // 25: authorizer.v1.InviteMembersResponse
+	(*Webhook)(nil),                           // 26: authorizer.v1.Webhook
+	(*WebhookLog)(nil),                        // 27: authorizer.v1.WebhookLog
+	(*AddWebhookRequest)(nil),                 // 28: authorizer.v1.AddWebhookRequest
+	(*AddWebhookResponse)(nil),                // 29: authorizer.v1.AddWebhookResponse
+	(*UpdateWebhookRequest)(nil),              // 30: authorizer.v1.UpdateWebhookRequest
+	(*UpdateWebhookResponse)(nil),             // 31: authorizer.v1.UpdateWebhookResponse
+	(*DeleteWebhookRequest)(nil),              // 32: authorizer.v1.DeleteWebhookRequest
+	(*DeleteWebhookResponse)(nil),             // 33: authorizer.v1.DeleteWebhookResponse
+	(*GetWebhookRequest)(nil),                 // 34: authorizer.v1.GetWebhookRequest
+	(*GetWebhookResponse)(nil),                // 35: authorizer.v1.GetWebhookResponse
+	(*WebhooksRequest)(nil),                   // 36: authorizer.v1.WebhooksRequest
+	(*WebhooksResponse)(nil),                  // 37: authorizer.v1.WebhooksResponse
+	(*WebhookLogsRequest)(nil),                // 38: authorizer.v1.WebhookLogsRequest
+	(*WebhookLogsResponse)(nil),               // 39: authorizer.v1.WebhookLogsResponse
+	(*TestEndpointRequest)(nil),               // 40: authorizer.v1.TestEndpointRequest
+	(*TestEndpointResponse)(nil),              // 41: authorizer.v1.TestEndpointResponse
+	(*EmailTemplate)(nil),                     // 42: authorizer.v1.EmailTemplate
+	(*AddEmailTemplateRequest)(nil),           // 43: authorizer.v1.AddEmailTemplateRequest
+	(*AddEmailTemplateResponse)(nil),          // 44: authorizer.v1.AddEmailTemplateResponse
+	(*UpdateEmailTemplateRequest)(nil),        // 45: authorizer.v1.UpdateEmailTemplateRequest
+	(*UpdateEmailTemplateResponse)(nil),       // 46: authorizer.v1.UpdateEmailTemplateResponse
+	(*DeleteEmailTemplateRequest)(nil),        // 47: authorizer.v1.DeleteEmailTemplateRequest
+	(*DeleteEmailTemplateResponse)(nil),       // 48: authorizer.v1.DeleteEmailTemplateResponse
+	(*EmailTemplatesRequest)(nil),             // 49: authorizer.v1.EmailTemplatesRequest
+	(*EmailTemplatesResponse)(nil),            // 50: authorizer.v1.EmailTemplatesResponse
+	(*AuditLog)(nil),                          // 51: authorizer.v1.AuditLog
+	(*AuditLogsRequest)(nil),                  // 52: authorizer.v1.AuditLogsRequest
+	(*AuditLogsResponse)(nil),                 // 53: authorizer.v1.AuditLogsResponse
+	(*FgaModel)(nil),                          // 54: authorizer.v1.FgaModel
+	(*FgaTuple)(nil),                          // 55: authorizer.v1.FgaTuple
+	(*FgaGetModelRequest)(nil),                // 56: authorizer.v1.FgaGetModelRequest
+	(*FgaGetModelResponse)(nil),               // 57: authorizer.v1.FgaGetModelResponse
+	(*FgaWriteModelRequest)(nil),              // 58: authorizer.v1.FgaWriteModelRequest
+	(*FgaWriteModelResponse)(nil),             // 59: authorizer.v1.FgaWriteModelResponse
+	(*FgaWriteTuplesRequest)(nil),             // 60: authorizer.v1.FgaWriteTuplesRequest
+	(*FgaWriteTuplesResponse)(nil),            // 61: authorizer.v1.FgaWriteTuplesResponse
+	(*FgaDeleteTuplesRequest)(nil),            // 62: authorizer.v1.FgaDeleteTuplesRequest
+	(*FgaDeleteTuplesResponse)(nil),           // 63: authorizer.v1.FgaDeleteTuplesResponse
+	(*FgaReadTuplesRequest)(nil),              // 64: authorizer.v1.FgaReadTuplesRequest
+	(*FgaReadTuplesResponse)(nil),             // 65: authorizer.v1.FgaReadTuplesResponse
+	(*FgaListUsersRequest)(nil),               // 66: authorizer.v1.FgaListUsersRequest
+	(*FgaListUsersResponse)(nil),              // 67: authorizer.v1.FgaListUsersResponse
+	(*FgaExpandRequest)(nil),                  // 68: authorizer.v1.FgaExpandRequest
+	(*FgaExpandResponse)(nil),                 // 69: authorizer.v1.FgaExpandResponse
+	(*FgaResetRequest)(nil),                   // 70: authorizer.v1.FgaResetRequest
+	(*FgaResetResponse)(nil),                  // 71: authorizer.v1.FgaResetResponse
+	(*Client)(nil),                            // 72: authorizer.v1.Client
+	(*CreateClientRequest)(nil),               // 73: authorizer.v1.CreateClientRequest
+	(*CreateClientResponse)(nil),              // 74: authorizer.v1.CreateClientResponse
+	(*UpdateClientRequest)(nil),               // 75: authorizer.v1.UpdateClientRequest
+	(*UpdateClientResponse)(nil),              // 76: authorizer.v1.UpdateClientResponse
+	(*DeleteClientRequest)(nil),               // 77: authorizer.v1.DeleteClientRequest
+	(*DeleteClientResponse)(nil),              // 78: authorizer.v1.DeleteClientResponse
+	(*RotateClientSecretRequest)(nil),         // 79: authorizer.v1.RotateClientSecretRequest
+	(*GetClientRequest)(nil),                  // 80: authorizer.v1.GetClientRequest
+	(*GetClientResponse)(nil),                 // 81: authorizer.v1.GetClientResponse
+	(*ClientsRequest)(nil),                    // 82: authorizer.v1.ClientsRequest
+	(*ClientsResponse)(nil),                   // 83: authorizer.v1.ClientsResponse
+	(*TrustedIssuer)(nil),                     // 84: authorizer.v1.TrustedIssuer
+	(*AddTrustedIssuerRequest)(nil),           // 85: authorizer.v1.AddTrustedIssuerRequest
+	(*AddTrustedIssuerResponse)(nil),          // 86: authorizer.v1.AddTrustedIssuerResponse
+	(*UpdateTrustedIssuerRequest)(nil),        // 87: authorizer.v1.UpdateTrustedIssuerRequest
+	(*UpdateTrustedIssuerResponse)(nil),       // 88: authorizer.v1.UpdateTrustedIssuerResponse
+	(*DeleteTrustedIssuerRequest)(nil),        // 89: authorizer.v1.DeleteTrustedIssuerRequest
+	(*DeleteTrustedIssuerResponse)(nil),       // 90: authorizer.v1.DeleteTrustedIssuerResponse
+	(*GetTrustedIssuerRequest)(nil),           // 91: authorizer.v1.GetTrustedIssuerRequest
+	(*GetTrustedIssuerResponse)(nil),          // 92: authorizer.v1.GetTrustedIssuerResponse
+	(*TrustedIssuersRequest)(nil),             // 93: authorizer.v1.TrustedIssuersRequest
+	(*TrustedIssuersResponse)(nil),            // 94: authorizer.v1.TrustedIssuersResponse
+	(*SamlServiceProvider)(nil),               // 95: authorizer.v1.SamlServiceProvider
+	(*SamlIdpKey)(nil),                        // 96: authorizer.v1.SamlIdpKey
+	(*SamlSpMetadataParseResult)(nil),         // 97: authorizer.v1.SamlSpMetadataParseResult
+	(*CreateSamlServiceProviderRequest)(nil),  // 98: authorizer.v1.CreateSamlServiceProviderRequest
+	(*CreateSamlServiceProviderResponse)(nil), // 99: authorizer.v1.CreateSamlServiceProviderResponse
+	(*UpdateSamlServiceProviderRequest)(nil),  // 100: authorizer.v1.UpdateSamlServiceProviderRequest
+	(*UpdateSamlServiceProviderResponse)(nil), // 101: authorizer.v1.UpdateSamlServiceProviderResponse
+	(*DeleteSamlServiceProviderRequest)(nil),  // 102: authorizer.v1.DeleteSamlServiceProviderRequest
+	(*DeleteSamlServiceProviderResponse)(nil), // 103: authorizer.v1.DeleteSamlServiceProviderResponse
+	(*GetSamlServiceProviderRequest)(nil),     // 104: authorizer.v1.GetSamlServiceProviderRequest
+	(*GetSamlServiceProviderResponse)(nil),    // 105: authorizer.v1.GetSamlServiceProviderResponse
+	(*ListSamlServiceProvidersRequest)(nil),   // 106: authorizer.v1.ListSamlServiceProvidersRequest
+	(*ListSamlServiceProvidersResponse)(nil),  // 107: authorizer.v1.ListSamlServiceProvidersResponse
+	(*RotateSamlIdpCertRequest)(nil),          // 108: authorizer.v1.RotateSamlIdpCertRequest
+	(*RotateSamlIdpCertResponse)(nil),         // 109: authorizer.v1.RotateSamlIdpCertResponse
+	(*RetireSamlIdpKeyRequest)(nil),           // 110: authorizer.v1.RetireSamlIdpKeyRequest
+	(*RetireSamlIdpKeyResponse)(nil),          // 111: authorizer.v1.RetireSamlIdpKeyResponse
+	(*ListSamlIdpKeysRequest)(nil),            // 112: authorizer.v1.ListSamlIdpKeysRequest
+	(*ListSamlIdpKeysResponse)(nil),           // 113: authorizer.v1.ListSamlIdpKeysResponse
+	(*ImportSamlSpMetadataRequest)(nil),       // 114: authorizer.v1.ImportSamlSpMetadataRequest
+	(*ImportSamlSpMetadataResponse)(nil),      // 115: authorizer.v1.ImportSamlSpMetadataResponse
+	(*PaginationRequest)(nil),                 // 116: authorizer.v1.PaginationRequest
+	(*User)(nil),                              // 117: authorizer.v1.User
+	(*Pagination)(nil),                        // 118: authorizer.v1.Pagination
+	(*AppData)(nil),                           // 119: authorizer.v1.AppData
+	(*FgaTupleInput)(nil),                     // 120: authorizer.v1.FgaTupleInput
 }
 var file_authorizer_v1_admin_proto_depIdxs = []int32{
-	8,  // 0: authorizer.v1.AdminMetaResponse.admin_meta:type_name -> authorizer.v1.AdminMeta
-	95, // 1: authorizer.v1.UsersRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	96, // 2: authorizer.v1.UsersResponse.users:type_name -> authorizer.v1.User
-	97, // 3: authorizer.v1.UsersResponse.pagination:type_name -> authorizer.v1.Pagination
-	96, // 4: authorizer.v1.UserResponse.user:type_name -> authorizer.v1.User
-	98, // 5: authorizer.v1.UpdateUserRequest.app_data:type_name -> authorizer.v1.AppData
-	96, // 6: authorizer.v1.UpdateUserResponse.user:type_name -> authorizer.v1.User
-	95, // 7: authorizer.v1.VerificationRequestsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	19, // 8: authorizer.v1.VerificationRequestsResponse.verification_requests:type_name -> authorizer.v1.VerificationRequest
-	97, // 9: authorizer.v1.VerificationRequestsResponse.pagination:type_name -> authorizer.v1.Pagination
-	96, // 10: authorizer.v1.InviteMembersResponse.users:type_name -> authorizer.v1.User
-	98, // 11: authorizer.v1.Webhook.headers:type_name -> authorizer.v1.AppData
-	98, // 12: authorizer.v1.AddWebhookRequest.headers:type_name -> authorizer.v1.AppData
-	98, // 13: authorizer.v1.UpdateWebhookRequest.headers:type_name -> authorizer.v1.AppData
-	26, // 14: authorizer.v1.GetWebhookResponse.webhook:type_name -> authorizer.v1.Webhook
-	95, // 15: authorizer.v1.WebhooksRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	26, // 16: authorizer.v1.WebhooksResponse.webhooks:type_name -> authorizer.v1.Webhook
-	97, // 17: authorizer.v1.WebhooksResponse.pagination:type_name -> authorizer.v1.Pagination
-	95, // 18: authorizer.v1.WebhookLogsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	27, // 19: authorizer.v1.WebhookLogsResponse.webhook_logs:type_name -> authorizer.v1.WebhookLog
-	97, // 20: authorizer.v1.WebhookLogsResponse.pagination:type_name -> authorizer.v1.Pagination
-	98, // 21: authorizer.v1.TestEndpointRequest.headers:type_name -> authorizer.v1.AppData
-	95, // 22: authorizer.v1.EmailTemplatesRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	42, // 23: authorizer.v1.EmailTemplatesResponse.email_templates:type_name -> authorizer.v1.EmailTemplate
-	97, // 24: authorizer.v1.EmailTemplatesResponse.pagination:type_name -> authorizer.v1.Pagination
-	95, // 25: authorizer.v1.AuditLogsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	51, // 26: authorizer.v1.AuditLogsResponse.audit_logs:type_name -> authorizer.v1.AuditLog
-	97, // 27: authorizer.v1.AuditLogsResponse.pagination:type_name -> authorizer.v1.Pagination
-	54, // 28: authorizer.v1.FgaGetModelResponse.model:type_name -> authorizer.v1.FgaModel
-	54, // 29: authorizer.v1.FgaWriteModelResponse.model:type_name -> authorizer.v1.FgaModel
-	99, // 30: authorizer.v1.FgaWriteTuplesRequest.tuples:type_name -> authorizer.v1.FgaTupleInput
-	99, // 31: authorizer.v1.FgaDeleteTuplesRequest.tuples:type_name -> authorizer.v1.FgaTupleInput
-	55, // 32: authorizer.v1.FgaReadTuplesResponse.tuples:type_name -> authorizer.v1.FgaTuple
-	72, // 33: authorizer.v1.CreateClientResponse.client:type_name -> authorizer.v1.Client
-	72, // 34: authorizer.v1.UpdateClientResponse.client:type_name -> authorizer.v1.Client
-	72, // 35: authorizer.v1.GetClientResponse.client:type_name -> authorizer.v1.Client
-	95, // 36: authorizer.v1.ClientsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	72, // 37: authorizer.v1.ClientsResponse.clients:type_name -> authorizer.v1.Client
-	97, // 38: authorizer.v1.ClientsResponse.pagination:type_name -> authorizer.v1.Pagination
-	84, // 39: authorizer.v1.AddTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
-	84, // 40: authorizer.v1.UpdateTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
-	84, // 41: authorizer.v1.GetTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
-	95, // 42: authorizer.v1.TrustedIssuersRequest.pagination:type_name -> authorizer.v1.PaginationRequest
-	84, // 43: authorizer.v1.TrustedIssuersResponse.trusted_issuers:type_name -> authorizer.v1.TrustedIssuer
-	97, // 44: authorizer.v1.TrustedIssuersResponse.pagination:type_name -> authorizer.v1.Pagination
-	0,  // 45: authorizer.v1.AuthorizerAdminService.AdminLogin:input_type -> authorizer.v1.AdminLoginRequest
-	2,  // 46: authorizer.v1.AuthorizerAdminService.AdminLogout:input_type -> authorizer.v1.AdminLogoutRequest
-	4,  // 47: authorizer.v1.AuthorizerAdminService.AdminSession:input_type -> authorizer.v1.AdminSessionRequest
-	6,  // 48: authorizer.v1.AuthorizerAdminService.AdminMeta:input_type -> authorizer.v1.AdminMetaRequest
-	9,  // 49: authorizer.v1.AuthorizerAdminService.Users:input_type -> authorizer.v1.UsersRequest
-	11, // 50: authorizer.v1.AuthorizerAdminService.User:input_type -> authorizer.v1.UserRequest
-	13, // 51: authorizer.v1.AuthorizerAdminService.UpdateUser:input_type -> authorizer.v1.UpdateUserRequest
-	15, // 52: authorizer.v1.AuthorizerAdminService.DeleteUser:input_type -> authorizer.v1.DeleteUserRequest
-	17, // 53: authorizer.v1.AuthorizerAdminService.VerificationRequests:input_type -> authorizer.v1.VerificationRequestsRequest
-	20, // 54: authorizer.v1.AuthorizerAdminService.RevokeAccess:input_type -> authorizer.v1.RevokeAccessRequest
-	22, // 55: authorizer.v1.AuthorizerAdminService.EnableAccess:input_type -> authorizer.v1.EnableAccessRequest
-	24, // 56: authorizer.v1.AuthorizerAdminService.InviteMembers:input_type -> authorizer.v1.InviteMembersRequest
-	28, // 57: authorizer.v1.AuthorizerAdminService.AddWebhook:input_type -> authorizer.v1.AddWebhookRequest
-	30, // 58: authorizer.v1.AuthorizerAdminService.UpdateWebhook:input_type -> authorizer.v1.UpdateWebhookRequest
-	32, // 59: authorizer.v1.AuthorizerAdminService.DeleteWebhook:input_type -> authorizer.v1.DeleteWebhookRequest
-	34, // 60: authorizer.v1.AuthorizerAdminService.GetWebhook:input_type -> authorizer.v1.GetWebhookRequest
-	36, // 61: authorizer.v1.AuthorizerAdminService.Webhooks:input_type -> authorizer.v1.WebhooksRequest
-	38, // 62: authorizer.v1.AuthorizerAdminService.WebhookLogs:input_type -> authorizer.v1.WebhookLogsRequest
-	40, // 63: authorizer.v1.AuthorizerAdminService.TestEndpoint:input_type -> authorizer.v1.TestEndpointRequest
-	43, // 64: authorizer.v1.AuthorizerAdminService.AddEmailTemplate:input_type -> authorizer.v1.AddEmailTemplateRequest
-	45, // 65: authorizer.v1.AuthorizerAdminService.UpdateEmailTemplate:input_type -> authorizer.v1.UpdateEmailTemplateRequest
-	47, // 66: authorizer.v1.AuthorizerAdminService.DeleteEmailTemplate:input_type -> authorizer.v1.DeleteEmailTemplateRequest
-	49, // 67: authorizer.v1.AuthorizerAdminService.EmailTemplates:input_type -> authorizer.v1.EmailTemplatesRequest
-	52, // 68: authorizer.v1.AuthorizerAdminService.AuditLogs:input_type -> authorizer.v1.AuditLogsRequest
-	56, // 69: authorizer.v1.AuthorizerAdminService.FgaGetModel:input_type -> authorizer.v1.FgaGetModelRequest
-	58, // 70: authorizer.v1.AuthorizerAdminService.FgaWriteModel:input_type -> authorizer.v1.FgaWriteModelRequest
-	60, // 71: authorizer.v1.AuthorizerAdminService.FgaWriteTuples:input_type -> authorizer.v1.FgaWriteTuplesRequest
-	62, // 72: authorizer.v1.AuthorizerAdminService.FgaDeleteTuples:input_type -> authorizer.v1.FgaDeleteTuplesRequest
-	64, // 73: authorizer.v1.AuthorizerAdminService.FgaReadTuples:input_type -> authorizer.v1.FgaReadTuplesRequest
-	66, // 74: authorizer.v1.AuthorizerAdminService.FgaListUsers:input_type -> authorizer.v1.FgaListUsersRequest
-	68, // 75: authorizer.v1.AuthorizerAdminService.FgaExpand:input_type -> authorizer.v1.FgaExpandRequest
-	70, // 76: authorizer.v1.AuthorizerAdminService.FgaReset:input_type -> authorizer.v1.FgaResetRequest
-	73, // 77: authorizer.v1.AuthorizerAdminService.CreateClient:input_type -> authorizer.v1.CreateClientRequest
-	75, // 78: authorizer.v1.AuthorizerAdminService.UpdateClient:input_type -> authorizer.v1.UpdateClientRequest
-	77, // 79: authorizer.v1.AuthorizerAdminService.DeleteClient:input_type -> authorizer.v1.DeleteClientRequest
-	79, // 80: authorizer.v1.AuthorizerAdminService.RotateClientSecret:input_type -> authorizer.v1.RotateClientSecretRequest
-	80, // 81: authorizer.v1.AuthorizerAdminService.GetClient:input_type -> authorizer.v1.GetClientRequest
-	82, // 82: authorizer.v1.AuthorizerAdminService.Clients:input_type -> authorizer.v1.ClientsRequest
-	85, // 83: authorizer.v1.AuthorizerAdminService.AddTrustedIssuer:input_type -> authorizer.v1.AddTrustedIssuerRequest
-	87, // 84: authorizer.v1.AuthorizerAdminService.UpdateTrustedIssuer:input_type -> authorizer.v1.UpdateTrustedIssuerRequest
-	89, // 85: authorizer.v1.AuthorizerAdminService.DeleteTrustedIssuer:input_type -> authorizer.v1.DeleteTrustedIssuerRequest
-	91, // 86: authorizer.v1.AuthorizerAdminService.GetTrustedIssuer:input_type -> authorizer.v1.GetTrustedIssuerRequest
-	93, // 87: authorizer.v1.AuthorizerAdminService.TrustedIssuers:input_type -> authorizer.v1.TrustedIssuersRequest
-	1,  // 88: authorizer.v1.AuthorizerAdminService.AdminLogin:output_type -> authorizer.v1.AdminLoginResponse
-	3,  // 89: authorizer.v1.AuthorizerAdminService.AdminLogout:output_type -> authorizer.v1.AdminLogoutResponse
-	5,  // 90: authorizer.v1.AuthorizerAdminService.AdminSession:output_type -> authorizer.v1.AdminSessionResponse
-	7,  // 91: authorizer.v1.AuthorizerAdminService.AdminMeta:output_type -> authorizer.v1.AdminMetaResponse
-	10, // 92: authorizer.v1.AuthorizerAdminService.Users:output_type -> authorizer.v1.UsersResponse
-	12, // 93: authorizer.v1.AuthorizerAdminService.User:output_type -> authorizer.v1.UserResponse
-	14, // 94: authorizer.v1.AuthorizerAdminService.UpdateUser:output_type -> authorizer.v1.UpdateUserResponse
-	16, // 95: authorizer.v1.AuthorizerAdminService.DeleteUser:output_type -> authorizer.v1.DeleteUserResponse
-	18, // 96: authorizer.v1.AuthorizerAdminService.VerificationRequests:output_type -> authorizer.v1.VerificationRequestsResponse
-	21, // 97: authorizer.v1.AuthorizerAdminService.RevokeAccess:output_type -> authorizer.v1.RevokeAccessResponse
-	23, // 98: authorizer.v1.AuthorizerAdminService.EnableAccess:output_type -> authorizer.v1.EnableAccessResponse
-	25, // 99: authorizer.v1.AuthorizerAdminService.InviteMembers:output_type -> authorizer.v1.InviteMembersResponse
-	29, // 100: authorizer.v1.AuthorizerAdminService.AddWebhook:output_type -> authorizer.v1.AddWebhookResponse
-	31, // 101: authorizer.v1.AuthorizerAdminService.UpdateWebhook:output_type -> authorizer.v1.UpdateWebhookResponse
-	33, // 102: authorizer.v1.AuthorizerAdminService.DeleteWebhook:output_type -> authorizer.v1.DeleteWebhookResponse
-	35, // 103: authorizer.v1.AuthorizerAdminService.GetWebhook:output_type -> authorizer.v1.GetWebhookResponse
-	37, // 104: authorizer.v1.AuthorizerAdminService.Webhooks:output_type -> authorizer.v1.WebhooksResponse
-	39, // 105: authorizer.v1.AuthorizerAdminService.WebhookLogs:output_type -> authorizer.v1.WebhookLogsResponse
-	41, // 106: authorizer.v1.AuthorizerAdminService.TestEndpoint:output_type -> authorizer.v1.TestEndpointResponse
-	44, // 107: authorizer.v1.AuthorizerAdminService.AddEmailTemplate:output_type -> authorizer.v1.AddEmailTemplateResponse
-	46, // 108: authorizer.v1.AuthorizerAdminService.UpdateEmailTemplate:output_type -> authorizer.v1.UpdateEmailTemplateResponse
-	48, // 109: authorizer.v1.AuthorizerAdminService.DeleteEmailTemplate:output_type -> authorizer.v1.DeleteEmailTemplateResponse
-	50, // 110: authorizer.v1.AuthorizerAdminService.EmailTemplates:output_type -> authorizer.v1.EmailTemplatesResponse
-	53, // 111: authorizer.v1.AuthorizerAdminService.AuditLogs:output_type -> authorizer.v1.AuditLogsResponse
-	57, // 112: authorizer.v1.AuthorizerAdminService.FgaGetModel:output_type -> authorizer.v1.FgaGetModelResponse
-	59, // 113: authorizer.v1.AuthorizerAdminService.FgaWriteModel:output_type -> authorizer.v1.FgaWriteModelResponse
-	61, // 114: authorizer.v1.AuthorizerAdminService.FgaWriteTuples:output_type -> authorizer.v1.FgaWriteTuplesResponse
-	63, // 115: authorizer.v1.AuthorizerAdminService.FgaDeleteTuples:output_type -> authorizer.v1.FgaDeleteTuplesResponse
-	65, // 116: authorizer.v1.AuthorizerAdminService.FgaReadTuples:output_type -> authorizer.v1.FgaReadTuplesResponse
-	67, // 117: authorizer.v1.AuthorizerAdminService.FgaListUsers:output_type -> authorizer.v1.FgaListUsersResponse
-	69, // 118: authorizer.v1.AuthorizerAdminService.FgaExpand:output_type -> authorizer.v1.FgaExpandResponse
-	71, // 119: authorizer.v1.AuthorizerAdminService.FgaReset:output_type -> authorizer.v1.FgaResetResponse
-	74, // 120: authorizer.v1.AuthorizerAdminService.CreateClient:output_type -> authorizer.v1.CreateClientResponse
-	76, // 121: authorizer.v1.AuthorizerAdminService.UpdateClient:output_type -> authorizer.v1.UpdateClientResponse
-	78, // 122: authorizer.v1.AuthorizerAdminService.DeleteClient:output_type -> authorizer.v1.DeleteClientResponse
-	74, // 123: authorizer.v1.AuthorizerAdminService.RotateClientSecret:output_type -> authorizer.v1.CreateClientResponse
-	81, // 124: authorizer.v1.AuthorizerAdminService.GetClient:output_type -> authorizer.v1.GetClientResponse
-	83, // 125: authorizer.v1.AuthorizerAdminService.Clients:output_type -> authorizer.v1.ClientsResponse
-	86, // 126: authorizer.v1.AuthorizerAdminService.AddTrustedIssuer:output_type -> authorizer.v1.AddTrustedIssuerResponse
-	88, // 127: authorizer.v1.AuthorizerAdminService.UpdateTrustedIssuer:output_type -> authorizer.v1.UpdateTrustedIssuerResponse
-	90, // 128: authorizer.v1.AuthorizerAdminService.DeleteTrustedIssuer:output_type -> authorizer.v1.DeleteTrustedIssuerResponse
-	92, // 129: authorizer.v1.AuthorizerAdminService.GetTrustedIssuer:output_type -> authorizer.v1.GetTrustedIssuerResponse
-	94, // 130: authorizer.v1.AuthorizerAdminService.TrustedIssuers:output_type -> authorizer.v1.TrustedIssuersResponse
-	88, // [88:131] is the sub-list for method output_type
-	45, // [45:88] is the sub-list for method input_type
-	45, // [45:45] is the sub-list for extension type_name
-	45, // [45:45] is the sub-list for extension extendee
-	0,  // [0:45] is the sub-list for field type_name
+	8,   // 0: authorizer.v1.AdminMetaResponse.admin_meta:type_name -> authorizer.v1.AdminMeta
+	116, // 1: authorizer.v1.UsersRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	117, // 2: authorizer.v1.UsersResponse.users:type_name -> authorizer.v1.User
+	118, // 3: authorizer.v1.UsersResponse.pagination:type_name -> authorizer.v1.Pagination
+	117, // 4: authorizer.v1.UserResponse.user:type_name -> authorizer.v1.User
+	119, // 5: authorizer.v1.UpdateUserRequest.app_data:type_name -> authorizer.v1.AppData
+	117, // 6: authorizer.v1.UpdateUserResponse.user:type_name -> authorizer.v1.User
+	116, // 7: authorizer.v1.VerificationRequestsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	19,  // 8: authorizer.v1.VerificationRequestsResponse.verification_requests:type_name -> authorizer.v1.VerificationRequest
+	118, // 9: authorizer.v1.VerificationRequestsResponse.pagination:type_name -> authorizer.v1.Pagination
+	117, // 10: authorizer.v1.InviteMembersResponse.users:type_name -> authorizer.v1.User
+	119, // 11: authorizer.v1.Webhook.headers:type_name -> authorizer.v1.AppData
+	119, // 12: authorizer.v1.AddWebhookRequest.headers:type_name -> authorizer.v1.AppData
+	119, // 13: authorizer.v1.UpdateWebhookRequest.headers:type_name -> authorizer.v1.AppData
+	26,  // 14: authorizer.v1.GetWebhookResponse.webhook:type_name -> authorizer.v1.Webhook
+	116, // 15: authorizer.v1.WebhooksRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	26,  // 16: authorizer.v1.WebhooksResponse.webhooks:type_name -> authorizer.v1.Webhook
+	118, // 17: authorizer.v1.WebhooksResponse.pagination:type_name -> authorizer.v1.Pagination
+	116, // 18: authorizer.v1.WebhookLogsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	27,  // 19: authorizer.v1.WebhookLogsResponse.webhook_logs:type_name -> authorizer.v1.WebhookLog
+	118, // 20: authorizer.v1.WebhookLogsResponse.pagination:type_name -> authorizer.v1.Pagination
+	119, // 21: authorizer.v1.TestEndpointRequest.headers:type_name -> authorizer.v1.AppData
+	116, // 22: authorizer.v1.EmailTemplatesRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	42,  // 23: authorizer.v1.EmailTemplatesResponse.email_templates:type_name -> authorizer.v1.EmailTemplate
+	118, // 24: authorizer.v1.EmailTemplatesResponse.pagination:type_name -> authorizer.v1.Pagination
+	116, // 25: authorizer.v1.AuditLogsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	51,  // 26: authorizer.v1.AuditLogsResponse.audit_logs:type_name -> authorizer.v1.AuditLog
+	118, // 27: authorizer.v1.AuditLogsResponse.pagination:type_name -> authorizer.v1.Pagination
+	54,  // 28: authorizer.v1.FgaGetModelResponse.model:type_name -> authorizer.v1.FgaModel
+	54,  // 29: authorizer.v1.FgaWriteModelResponse.model:type_name -> authorizer.v1.FgaModel
+	120, // 30: authorizer.v1.FgaWriteTuplesRequest.tuples:type_name -> authorizer.v1.FgaTupleInput
+	120, // 31: authorizer.v1.FgaDeleteTuplesRequest.tuples:type_name -> authorizer.v1.FgaTupleInput
+	55,  // 32: authorizer.v1.FgaReadTuplesResponse.tuples:type_name -> authorizer.v1.FgaTuple
+	72,  // 33: authorizer.v1.CreateClientResponse.client:type_name -> authorizer.v1.Client
+	72,  // 34: authorizer.v1.UpdateClientResponse.client:type_name -> authorizer.v1.Client
+	72,  // 35: authorizer.v1.GetClientResponse.client:type_name -> authorizer.v1.Client
+	116, // 36: authorizer.v1.ClientsRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	72,  // 37: authorizer.v1.ClientsResponse.clients:type_name -> authorizer.v1.Client
+	118, // 38: authorizer.v1.ClientsResponse.pagination:type_name -> authorizer.v1.Pagination
+	84,  // 39: authorizer.v1.AddTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
+	84,  // 40: authorizer.v1.UpdateTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
+	84,  // 41: authorizer.v1.GetTrustedIssuerResponse.trusted_issuer:type_name -> authorizer.v1.TrustedIssuer
+	116, // 42: authorizer.v1.TrustedIssuersRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	84,  // 43: authorizer.v1.TrustedIssuersResponse.trusted_issuers:type_name -> authorizer.v1.TrustedIssuer
+	118, // 44: authorizer.v1.TrustedIssuersResponse.pagination:type_name -> authorizer.v1.Pagination
+	95,  // 45: authorizer.v1.CreateSamlServiceProviderResponse.saml_service_provider:type_name -> authorizer.v1.SamlServiceProvider
+	95,  // 46: authorizer.v1.UpdateSamlServiceProviderResponse.saml_service_provider:type_name -> authorizer.v1.SamlServiceProvider
+	95,  // 47: authorizer.v1.GetSamlServiceProviderResponse.saml_service_provider:type_name -> authorizer.v1.SamlServiceProvider
+	116, // 48: authorizer.v1.ListSamlServiceProvidersRequest.pagination:type_name -> authorizer.v1.PaginationRequest
+	95,  // 49: authorizer.v1.ListSamlServiceProvidersResponse.saml_service_providers:type_name -> authorizer.v1.SamlServiceProvider
+	118, // 50: authorizer.v1.ListSamlServiceProvidersResponse.pagination:type_name -> authorizer.v1.Pagination
+	96,  // 51: authorizer.v1.RotateSamlIdpCertResponse.saml_idp_key:type_name -> authorizer.v1.SamlIdpKey
+	96,  // 52: authorizer.v1.ListSamlIdpKeysResponse.saml_idp_keys:type_name -> authorizer.v1.SamlIdpKey
+	97,  // 53: authorizer.v1.ImportSamlSpMetadataResponse.result:type_name -> authorizer.v1.SamlSpMetadataParseResult
+	0,   // 54: authorizer.v1.AuthorizerAdminService.AdminLogin:input_type -> authorizer.v1.AdminLoginRequest
+	2,   // 55: authorizer.v1.AuthorizerAdminService.AdminLogout:input_type -> authorizer.v1.AdminLogoutRequest
+	4,   // 56: authorizer.v1.AuthorizerAdminService.AdminSession:input_type -> authorizer.v1.AdminSessionRequest
+	6,   // 57: authorizer.v1.AuthorizerAdminService.AdminMeta:input_type -> authorizer.v1.AdminMetaRequest
+	9,   // 58: authorizer.v1.AuthorizerAdminService.Users:input_type -> authorizer.v1.UsersRequest
+	11,  // 59: authorizer.v1.AuthorizerAdminService.User:input_type -> authorizer.v1.UserRequest
+	13,  // 60: authorizer.v1.AuthorizerAdminService.UpdateUser:input_type -> authorizer.v1.UpdateUserRequest
+	15,  // 61: authorizer.v1.AuthorizerAdminService.DeleteUser:input_type -> authorizer.v1.DeleteUserRequest
+	17,  // 62: authorizer.v1.AuthorizerAdminService.VerificationRequests:input_type -> authorizer.v1.VerificationRequestsRequest
+	20,  // 63: authorizer.v1.AuthorizerAdminService.RevokeAccess:input_type -> authorizer.v1.RevokeAccessRequest
+	22,  // 64: authorizer.v1.AuthorizerAdminService.EnableAccess:input_type -> authorizer.v1.EnableAccessRequest
+	24,  // 65: authorizer.v1.AuthorizerAdminService.InviteMembers:input_type -> authorizer.v1.InviteMembersRequest
+	28,  // 66: authorizer.v1.AuthorizerAdminService.AddWebhook:input_type -> authorizer.v1.AddWebhookRequest
+	30,  // 67: authorizer.v1.AuthorizerAdminService.UpdateWebhook:input_type -> authorizer.v1.UpdateWebhookRequest
+	32,  // 68: authorizer.v1.AuthorizerAdminService.DeleteWebhook:input_type -> authorizer.v1.DeleteWebhookRequest
+	34,  // 69: authorizer.v1.AuthorizerAdminService.GetWebhook:input_type -> authorizer.v1.GetWebhookRequest
+	36,  // 70: authorizer.v1.AuthorizerAdminService.Webhooks:input_type -> authorizer.v1.WebhooksRequest
+	38,  // 71: authorizer.v1.AuthorizerAdminService.WebhookLogs:input_type -> authorizer.v1.WebhookLogsRequest
+	40,  // 72: authorizer.v1.AuthorizerAdminService.TestEndpoint:input_type -> authorizer.v1.TestEndpointRequest
+	43,  // 73: authorizer.v1.AuthorizerAdminService.AddEmailTemplate:input_type -> authorizer.v1.AddEmailTemplateRequest
+	45,  // 74: authorizer.v1.AuthorizerAdminService.UpdateEmailTemplate:input_type -> authorizer.v1.UpdateEmailTemplateRequest
+	47,  // 75: authorizer.v1.AuthorizerAdminService.DeleteEmailTemplate:input_type -> authorizer.v1.DeleteEmailTemplateRequest
+	49,  // 76: authorizer.v1.AuthorizerAdminService.EmailTemplates:input_type -> authorizer.v1.EmailTemplatesRequest
+	52,  // 77: authorizer.v1.AuthorizerAdminService.AuditLogs:input_type -> authorizer.v1.AuditLogsRequest
+	56,  // 78: authorizer.v1.AuthorizerAdminService.FgaGetModel:input_type -> authorizer.v1.FgaGetModelRequest
+	58,  // 79: authorizer.v1.AuthorizerAdminService.FgaWriteModel:input_type -> authorizer.v1.FgaWriteModelRequest
+	60,  // 80: authorizer.v1.AuthorizerAdminService.FgaWriteTuples:input_type -> authorizer.v1.FgaWriteTuplesRequest
+	62,  // 81: authorizer.v1.AuthorizerAdminService.FgaDeleteTuples:input_type -> authorizer.v1.FgaDeleteTuplesRequest
+	64,  // 82: authorizer.v1.AuthorizerAdminService.FgaReadTuples:input_type -> authorizer.v1.FgaReadTuplesRequest
+	66,  // 83: authorizer.v1.AuthorizerAdminService.FgaListUsers:input_type -> authorizer.v1.FgaListUsersRequest
+	68,  // 84: authorizer.v1.AuthorizerAdminService.FgaExpand:input_type -> authorizer.v1.FgaExpandRequest
+	70,  // 85: authorizer.v1.AuthorizerAdminService.FgaReset:input_type -> authorizer.v1.FgaResetRequest
+	73,  // 86: authorizer.v1.AuthorizerAdminService.CreateClient:input_type -> authorizer.v1.CreateClientRequest
+	75,  // 87: authorizer.v1.AuthorizerAdminService.UpdateClient:input_type -> authorizer.v1.UpdateClientRequest
+	77,  // 88: authorizer.v1.AuthorizerAdminService.DeleteClient:input_type -> authorizer.v1.DeleteClientRequest
+	79,  // 89: authorizer.v1.AuthorizerAdminService.RotateClientSecret:input_type -> authorizer.v1.RotateClientSecretRequest
+	80,  // 90: authorizer.v1.AuthorizerAdminService.GetClient:input_type -> authorizer.v1.GetClientRequest
+	82,  // 91: authorizer.v1.AuthorizerAdminService.Clients:input_type -> authorizer.v1.ClientsRequest
+	85,  // 92: authorizer.v1.AuthorizerAdminService.AddTrustedIssuer:input_type -> authorizer.v1.AddTrustedIssuerRequest
+	87,  // 93: authorizer.v1.AuthorizerAdminService.UpdateTrustedIssuer:input_type -> authorizer.v1.UpdateTrustedIssuerRequest
+	89,  // 94: authorizer.v1.AuthorizerAdminService.DeleteTrustedIssuer:input_type -> authorizer.v1.DeleteTrustedIssuerRequest
+	91,  // 95: authorizer.v1.AuthorizerAdminService.GetTrustedIssuer:input_type -> authorizer.v1.GetTrustedIssuerRequest
+	93,  // 96: authorizer.v1.AuthorizerAdminService.TrustedIssuers:input_type -> authorizer.v1.TrustedIssuersRequest
+	98,  // 97: authorizer.v1.AuthorizerAdminService.CreateSamlServiceProvider:input_type -> authorizer.v1.CreateSamlServiceProviderRequest
+	100, // 98: authorizer.v1.AuthorizerAdminService.UpdateSamlServiceProvider:input_type -> authorizer.v1.UpdateSamlServiceProviderRequest
+	102, // 99: authorizer.v1.AuthorizerAdminService.DeleteSamlServiceProvider:input_type -> authorizer.v1.DeleteSamlServiceProviderRequest
+	104, // 100: authorizer.v1.AuthorizerAdminService.GetSamlServiceProvider:input_type -> authorizer.v1.GetSamlServiceProviderRequest
+	106, // 101: authorizer.v1.AuthorizerAdminService.ListSamlServiceProviders:input_type -> authorizer.v1.ListSamlServiceProvidersRequest
+	108, // 102: authorizer.v1.AuthorizerAdminService.RotateSamlIdpCert:input_type -> authorizer.v1.RotateSamlIdpCertRequest
+	110, // 103: authorizer.v1.AuthorizerAdminService.RetireSamlIdpKey:input_type -> authorizer.v1.RetireSamlIdpKeyRequest
+	112, // 104: authorizer.v1.AuthorizerAdminService.ListSamlIdpKeys:input_type -> authorizer.v1.ListSamlIdpKeysRequest
+	114, // 105: authorizer.v1.AuthorizerAdminService.ImportSamlSpMetadata:input_type -> authorizer.v1.ImportSamlSpMetadataRequest
+	1,   // 106: authorizer.v1.AuthorizerAdminService.AdminLogin:output_type -> authorizer.v1.AdminLoginResponse
+	3,   // 107: authorizer.v1.AuthorizerAdminService.AdminLogout:output_type -> authorizer.v1.AdminLogoutResponse
+	5,   // 108: authorizer.v1.AuthorizerAdminService.AdminSession:output_type -> authorizer.v1.AdminSessionResponse
+	7,   // 109: authorizer.v1.AuthorizerAdminService.AdminMeta:output_type -> authorizer.v1.AdminMetaResponse
+	10,  // 110: authorizer.v1.AuthorizerAdminService.Users:output_type -> authorizer.v1.UsersResponse
+	12,  // 111: authorizer.v1.AuthorizerAdminService.User:output_type -> authorizer.v1.UserResponse
+	14,  // 112: authorizer.v1.AuthorizerAdminService.UpdateUser:output_type -> authorizer.v1.UpdateUserResponse
+	16,  // 113: authorizer.v1.AuthorizerAdminService.DeleteUser:output_type -> authorizer.v1.DeleteUserResponse
+	18,  // 114: authorizer.v1.AuthorizerAdminService.VerificationRequests:output_type -> authorizer.v1.VerificationRequestsResponse
+	21,  // 115: authorizer.v1.AuthorizerAdminService.RevokeAccess:output_type -> authorizer.v1.RevokeAccessResponse
+	23,  // 116: authorizer.v1.AuthorizerAdminService.EnableAccess:output_type -> authorizer.v1.EnableAccessResponse
+	25,  // 117: authorizer.v1.AuthorizerAdminService.InviteMembers:output_type -> authorizer.v1.InviteMembersResponse
+	29,  // 118: authorizer.v1.AuthorizerAdminService.AddWebhook:output_type -> authorizer.v1.AddWebhookResponse
+	31,  // 119: authorizer.v1.AuthorizerAdminService.UpdateWebhook:output_type -> authorizer.v1.UpdateWebhookResponse
+	33,  // 120: authorizer.v1.AuthorizerAdminService.DeleteWebhook:output_type -> authorizer.v1.DeleteWebhookResponse
+	35,  // 121: authorizer.v1.AuthorizerAdminService.GetWebhook:output_type -> authorizer.v1.GetWebhookResponse
+	37,  // 122: authorizer.v1.AuthorizerAdminService.Webhooks:output_type -> authorizer.v1.WebhooksResponse
+	39,  // 123: authorizer.v1.AuthorizerAdminService.WebhookLogs:output_type -> authorizer.v1.WebhookLogsResponse
+	41,  // 124: authorizer.v1.AuthorizerAdminService.TestEndpoint:output_type -> authorizer.v1.TestEndpointResponse
+	44,  // 125: authorizer.v1.AuthorizerAdminService.AddEmailTemplate:output_type -> authorizer.v1.AddEmailTemplateResponse
+	46,  // 126: authorizer.v1.AuthorizerAdminService.UpdateEmailTemplate:output_type -> authorizer.v1.UpdateEmailTemplateResponse
+	48,  // 127: authorizer.v1.AuthorizerAdminService.DeleteEmailTemplate:output_type -> authorizer.v1.DeleteEmailTemplateResponse
+	50,  // 128: authorizer.v1.AuthorizerAdminService.EmailTemplates:output_type -> authorizer.v1.EmailTemplatesResponse
+	53,  // 129: authorizer.v1.AuthorizerAdminService.AuditLogs:output_type -> authorizer.v1.AuditLogsResponse
+	57,  // 130: authorizer.v1.AuthorizerAdminService.FgaGetModel:output_type -> authorizer.v1.FgaGetModelResponse
+	59,  // 131: authorizer.v1.AuthorizerAdminService.FgaWriteModel:output_type -> authorizer.v1.FgaWriteModelResponse
+	61,  // 132: authorizer.v1.AuthorizerAdminService.FgaWriteTuples:output_type -> authorizer.v1.FgaWriteTuplesResponse
+	63,  // 133: authorizer.v1.AuthorizerAdminService.FgaDeleteTuples:output_type -> authorizer.v1.FgaDeleteTuplesResponse
+	65,  // 134: authorizer.v1.AuthorizerAdminService.FgaReadTuples:output_type -> authorizer.v1.FgaReadTuplesResponse
+	67,  // 135: authorizer.v1.AuthorizerAdminService.FgaListUsers:output_type -> authorizer.v1.FgaListUsersResponse
+	69,  // 136: authorizer.v1.AuthorizerAdminService.FgaExpand:output_type -> authorizer.v1.FgaExpandResponse
+	71,  // 137: authorizer.v1.AuthorizerAdminService.FgaReset:output_type -> authorizer.v1.FgaResetResponse
+	74,  // 138: authorizer.v1.AuthorizerAdminService.CreateClient:output_type -> authorizer.v1.CreateClientResponse
+	76,  // 139: authorizer.v1.AuthorizerAdminService.UpdateClient:output_type -> authorizer.v1.UpdateClientResponse
+	78,  // 140: authorizer.v1.AuthorizerAdminService.DeleteClient:output_type -> authorizer.v1.DeleteClientResponse
+	74,  // 141: authorizer.v1.AuthorizerAdminService.RotateClientSecret:output_type -> authorizer.v1.CreateClientResponse
+	81,  // 142: authorizer.v1.AuthorizerAdminService.GetClient:output_type -> authorizer.v1.GetClientResponse
+	83,  // 143: authorizer.v1.AuthorizerAdminService.Clients:output_type -> authorizer.v1.ClientsResponse
+	86,  // 144: authorizer.v1.AuthorizerAdminService.AddTrustedIssuer:output_type -> authorizer.v1.AddTrustedIssuerResponse
+	88,  // 145: authorizer.v1.AuthorizerAdminService.UpdateTrustedIssuer:output_type -> authorizer.v1.UpdateTrustedIssuerResponse
+	90,  // 146: authorizer.v1.AuthorizerAdminService.DeleteTrustedIssuer:output_type -> authorizer.v1.DeleteTrustedIssuerResponse
+	92,  // 147: authorizer.v1.AuthorizerAdminService.GetTrustedIssuer:output_type -> authorizer.v1.GetTrustedIssuerResponse
+	94,  // 148: authorizer.v1.AuthorizerAdminService.TrustedIssuers:output_type -> authorizer.v1.TrustedIssuersResponse
+	99,  // 149: authorizer.v1.AuthorizerAdminService.CreateSamlServiceProvider:output_type -> authorizer.v1.CreateSamlServiceProviderResponse
+	101, // 150: authorizer.v1.AuthorizerAdminService.UpdateSamlServiceProvider:output_type -> authorizer.v1.UpdateSamlServiceProviderResponse
+	103, // 151: authorizer.v1.AuthorizerAdminService.DeleteSamlServiceProvider:output_type -> authorizer.v1.DeleteSamlServiceProviderResponse
+	105, // 152: authorizer.v1.AuthorizerAdminService.GetSamlServiceProvider:output_type -> authorizer.v1.GetSamlServiceProviderResponse
+	107, // 153: authorizer.v1.AuthorizerAdminService.ListSamlServiceProviders:output_type -> authorizer.v1.ListSamlServiceProvidersResponse
+	109, // 154: authorizer.v1.AuthorizerAdminService.RotateSamlIdpCert:output_type -> authorizer.v1.RotateSamlIdpCertResponse
+	111, // 155: authorizer.v1.AuthorizerAdminService.RetireSamlIdpKey:output_type -> authorizer.v1.RetireSamlIdpKeyResponse
+	113, // 156: authorizer.v1.AuthorizerAdminService.ListSamlIdpKeys:output_type -> authorizer.v1.ListSamlIdpKeysResponse
+	115, // 157: authorizer.v1.AuthorizerAdminService.ImportSamlSpMetadata:output_type -> authorizer.v1.ImportSamlSpMetadataResponse
+	106, // [106:158] is the sub-list for method output_type
+	54,  // [54:106] is the sub-list for method input_type
+	54,  // [54:54] is the sub-list for extension type_name
+	54,  // [54:54] is the sub-list for extension extendee
+	0,   // [0:54] is the sub-list for field type_name
 }
 
 func init() { file_authorizer_v1_admin_proto_init() }
@@ -7034,13 +8637,15 @@ func file_authorizer_v1_admin_proto_init() {
 	file_authorizer_v1_admin_proto_msgTypes[85].OneofWrappers = []any{}
 	file_authorizer_v1_admin_proto_msgTypes[87].OneofWrappers = []any{}
 	file_authorizer_v1_admin_proto_msgTypes[93].OneofWrappers = []any{}
+	file_authorizer_v1_admin_proto_msgTypes[98].OneofWrappers = []any{}
+	file_authorizer_v1_admin_proto_msgTypes[100].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_authorizer_v1_admin_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   95,
+			NumMessages:   116,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/go/authorizer/v1/admin.pb.gw.go
+++ b/gen/go/authorizer/v1/admin.pb.gw.go
@@ -1117,6 +1117,240 @@ func local_request_AuthorizerAdminService_TrustedIssuers_0(ctx context.Context, 
 
 }
 
+func request_AuthorizerAdminService_CreateSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.CreateSamlServiceProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_CreateSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.CreateSamlServiceProvider(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_UpdateSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.UpdateSamlServiceProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_UpdateSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.UpdateSamlServiceProvider(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_DeleteSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.DeleteSamlServiceProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_DeleteSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.DeleteSamlServiceProvider(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_GetSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.GetSamlServiceProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_GetSamlServiceProvider_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetSamlServiceProviderRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.GetSamlServiceProvider(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_ListSamlServiceProviders_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListSamlServiceProvidersRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListSamlServiceProviders(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_ListSamlServiceProviders_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListSamlServiceProvidersRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListSamlServiceProviders(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_RotateSamlIdpCert_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RotateSamlIdpCertRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.RotateSamlIdpCert(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_RotateSamlIdpCert_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RotateSamlIdpCertRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.RotateSamlIdpCert(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_RetireSamlIdpKey_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RetireSamlIdpKeyRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.RetireSamlIdpKey(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_RetireSamlIdpKey_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RetireSamlIdpKeyRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.RetireSamlIdpKey(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_ListSamlIdpKeys_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListSamlIdpKeysRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListSamlIdpKeys(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_ListSamlIdpKeys_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListSamlIdpKeysRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListSamlIdpKeys(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_AuthorizerAdminService_ImportSamlSpMetadata_0(ctx context.Context, marshaler runtime.Marshaler, client AuthorizerAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ImportSamlSpMetadataRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ImportSamlSpMetadata(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_AuthorizerAdminService_ImportSamlSpMetadata_0(ctx context.Context, marshaler runtime.Marshaler, server AuthorizerAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ImportSamlSpMetadataRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ImportSamlSpMetadata(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterAuthorizerAdminServiceHandlerServer registers the http handlers for service AuthorizerAdminService to "mux".
 // UnaryRPC     :call AuthorizerAdminServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2199,6 +2433,231 @@ func RegisterAuthorizerAdminServiceHandlerServer(ctx context.Context, mux *runti
 
 	})
 
+	mux.Handle("POST", pattern_AuthorizerAdminService_CreateSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/CreateSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/create_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_CreateSamlServiceProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_CreateSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_UpdateSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/UpdateSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/update_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_UpdateSamlServiceProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_UpdateSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_DeleteSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/DeleteSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/delete_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_DeleteSamlServiceProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_DeleteSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_GetSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/GetSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_GetSamlServiceProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_GetSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ListSamlServiceProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ListSamlServiceProviders", runtime.WithHTTPPathPattern("/v1/admin/saml_service_providers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_ListSamlServiceProviders_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ListSamlServiceProviders_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_RotateSamlIdpCert_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/RotateSamlIdpCert", runtime.WithHTTPPathPattern("/v1/admin/rotate_saml_idp_cert"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_RotateSamlIdpCert_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_RotateSamlIdpCert_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_RetireSamlIdpKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/RetireSamlIdpKey", runtime.WithHTTPPathPattern("/v1/admin/retire_saml_idp_key"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_RetireSamlIdpKey_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_RetireSamlIdpKey_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ListSamlIdpKeys_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ListSamlIdpKeys", runtime.WithHTTPPathPattern("/v1/admin/saml_idp_keys"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_ListSamlIdpKeys_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ListSamlIdpKeys_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ImportSamlSpMetadata_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ImportSamlSpMetadata", runtime.WithHTTPPathPattern("/v1/admin/import_saml_sp_metadata"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AuthorizerAdminService_ImportSamlSpMetadata_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ImportSamlSpMetadata_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -3186,6 +3645,204 @@ func RegisterAuthorizerAdminServiceHandlerClient(ctx context.Context, mux *runti
 
 	})
 
+	mux.Handle("POST", pattern_AuthorizerAdminService_CreateSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/CreateSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/create_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_CreateSamlServiceProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_CreateSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_UpdateSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/UpdateSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/update_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_UpdateSamlServiceProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_UpdateSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_DeleteSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/DeleteSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/delete_saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_DeleteSamlServiceProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_DeleteSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_GetSamlServiceProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/GetSamlServiceProvider", runtime.WithHTTPPathPattern("/v1/admin/saml_service_provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_GetSamlServiceProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_GetSamlServiceProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ListSamlServiceProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ListSamlServiceProviders", runtime.WithHTTPPathPattern("/v1/admin/saml_service_providers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_ListSamlServiceProviders_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ListSamlServiceProviders_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_RotateSamlIdpCert_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/RotateSamlIdpCert", runtime.WithHTTPPathPattern("/v1/admin/rotate_saml_idp_cert"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_RotateSamlIdpCert_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_RotateSamlIdpCert_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_RetireSamlIdpKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/RetireSamlIdpKey", runtime.WithHTTPPathPattern("/v1/admin/retire_saml_idp_key"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_RetireSamlIdpKey_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_RetireSamlIdpKey_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ListSamlIdpKeys_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ListSamlIdpKeys", runtime.WithHTTPPathPattern("/v1/admin/saml_idp_keys"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_ListSamlIdpKeys_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ListSamlIdpKeys_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AuthorizerAdminService_ImportSamlSpMetadata_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/authorizer.v1.AuthorizerAdminService/ImportSamlSpMetadata", runtime.WithHTTPPathPattern("/v1/admin/import_saml_sp_metadata"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AuthorizerAdminService_ImportSamlSpMetadata_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AuthorizerAdminService_ImportSamlSpMetadata_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -3275,6 +3932,24 @@ var (
 	pattern_AuthorizerAdminService_GetTrustedIssuer_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "trusted_issuer"}, ""))
 
 	pattern_AuthorizerAdminService_TrustedIssuers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "trusted_issuers"}, ""))
+
+	pattern_AuthorizerAdminService_CreateSamlServiceProvider_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "create_saml_service_provider"}, ""))
+
+	pattern_AuthorizerAdminService_UpdateSamlServiceProvider_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "update_saml_service_provider"}, ""))
+
+	pattern_AuthorizerAdminService_DeleteSamlServiceProvider_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "delete_saml_service_provider"}, ""))
+
+	pattern_AuthorizerAdminService_GetSamlServiceProvider_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "saml_service_provider"}, ""))
+
+	pattern_AuthorizerAdminService_ListSamlServiceProviders_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "saml_service_providers"}, ""))
+
+	pattern_AuthorizerAdminService_RotateSamlIdpCert_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "rotate_saml_idp_cert"}, ""))
+
+	pattern_AuthorizerAdminService_RetireSamlIdpKey_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "retire_saml_idp_key"}, ""))
+
+	pattern_AuthorizerAdminService_ListSamlIdpKeys_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "saml_idp_keys"}, ""))
+
+	pattern_AuthorizerAdminService_ImportSamlSpMetadata_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "admin", "import_saml_sp_metadata"}, ""))
 )
 
 var (
@@ -3363,4 +4038,22 @@ var (
 	forward_AuthorizerAdminService_GetTrustedIssuer_0 = runtime.ForwardResponseMessage
 
 	forward_AuthorizerAdminService_TrustedIssuers_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_CreateSamlServiceProvider_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_UpdateSamlServiceProvider_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_DeleteSamlServiceProvider_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_GetSamlServiceProvider_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_ListSamlServiceProviders_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_RotateSamlIdpCert_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_RetireSamlIdpKey_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_ListSamlIdpKeys_0 = runtime.ForwardResponseMessage
+
+	forward_AuthorizerAdminService_ImportSamlSpMetadata_0 = runtime.ForwardResponseMessage
 )

--- a/gen/go/authorizer/v1/admin_grpc.pb.go
+++ b/gen/go/authorizer/v1/admin_grpc.pb.go
@@ -28,49 +28,58 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	AuthorizerAdminService_AdminLogin_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/AdminLogin"
-	AuthorizerAdminService_AdminLogout_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/AdminLogout"
-	AuthorizerAdminService_AdminSession_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/AdminSession"
-	AuthorizerAdminService_AdminMeta_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/AdminMeta"
-	AuthorizerAdminService_Users_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/Users"
-	AuthorizerAdminService_User_FullMethodName                 = "/authorizer.v1.AuthorizerAdminService/User"
-	AuthorizerAdminService_UpdateUser_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/UpdateUser"
-	AuthorizerAdminService_DeleteUser_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/DeleteUser"
-	AuthorizerAdminService_VerificationRequests_FullMethodName = "/authorizer.v1.AuthorizerAdminService/VerificationRequests"
-	AuthorizerAdminService_RevokeAccess_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/RevokeAccess"
-	AuthorizerAdminService_EnableAccess_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/EnableAccess"
-	AuthorizerAdminService_InviteMembers_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/InviteMembers"
-	AuthorizerAdminService_AddWebhook_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/AddWebhook"
-	AuthorizerAdminService_UpdateWebhook_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/UpdateWebhook"
-	AuthorizerAdminService_DeleteWebhook_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/DeleteWebhook"
-	AuthorizerAdminService_GetWebhook_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/GetWebhook"
-	AuthorizerAdminService_Webhooks_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/Webhooks"
-	AuthorizerAdminService_WebhookLogs_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/WebhookLogs"
-	AuthorizerAdminService_TestEndpoint_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/TestEndpoint"
-	AuthorizerAdminService_AddEmailTemplate_FullMethodName     = "/authorizer.v1.AuthorizerAdminService/AddEmailTemplate"
-	AuthorizerAdminService_UpdateEmailTemplate_FullMethodName  = "/authorizer.v1.AuthorizerAdminService/UpdateEmailTemplate"
-	AuthorizerAdminService_DeleteEmailTemplate_FullMethodName  = "/authorizer.v1.AuthorizerAdminService/DeleteEmailTemplate"
-	AuthorizerAdminService_EmailTemplates_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/EmailTemplates"
-	AuthorizerAdminService_AuditLogs_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/AuditLogs"
-	AuthorizerAdminService_FgaGetModel_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/FgaGetModel"
-	AuthorizerAdminService_FgaWriteModel_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/FgaWriteModel"
-	AuthorizerAdminService_FgaWriteTuples_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/FgaWriteTuples"
-	AuthorizerAdminService_FgaDeleteTuples_FullMethodName      = "/authorizer.v1.AuthorizerAdminService/FgaDeleteTuples"
-	AuthorizerAdminService_FgaReadTuples_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/FgaReadTuples"
-	AuthorizerAdminService_FgaListUsers_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/FgaListUsers"
-	AuthorizerAdminService_FgaExpand_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/FgaExpand"
-	AuthorizerAdminService_FgaReset_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/FgaReset"
-	AuthorizerAdminService_CreateClient_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/CreateClient"
-	AuthorizerAdminService_UpdateClient_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/UpdateClient"
-	AuthorizerAdminService_DeleteClient_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/DeleteClient"
-	AuthorizerAdminService_RotateClientSecret_FullMethodName   = "/authorizer.v1.AuthorizerAdminService/RotateClientSecret"
-	AuthorizerAdminService_GetClient_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/GetClient"
-	AuthorizerAdminService_Clients_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/Clients"
-	AuthorizerAdminService_AddTrustedIssuer_FullMethodName     = "/authorizer.v1.AuthorizerAdminService/AddTrustedIssuer"
-	AuthorizerAdminService_UpdateTrustedIssuer_FullMethodName  = "/authorizer.v1.AuthorizerAdminService/UpdateTrustedIssuer"
-	AuthorizerAdminService_DeleteTrustedIssuer_FullMethodName  = "/authorizer.v1.AuthorizerAdminService/DeleteTrustedIssuer"
-	AuthorizerAdminService_GetTrustedIssuer_FullMethodName     = "/authorizer.v1.AuthorizerAdminService/GetTrustedIssuer"
-	AuthorizerAdminService_TrustedIssuers_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/TrustedIssuers"
+	AuthorizerAdminService_AdminLogin_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/AdminLogin"
+	AuthorizerAdminService_AdminLogout_FullMethodName               = "/authorizer.v1.AuthorizerAdminService/AdminLogout"
+	AuthorizerAdminService_AdminSession_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/AdminSession"
+	AuthorizerAdminService_AdminMeta_FullMethodName                 = "/authorizer.v1.AuthorizerAdminService/AdminMeta"
+	AuthorizerAdminService_Users_FullMethodName                     = "/authorizer.v1.AuthorizerAdminService/Users"
+	AuthorizerAdminService_User_FullMethodName                      = "/authorizer.v1.AuthorizerAdminService/User"
+	AuthorizerAdminService_UpdateUser_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/UpdateUser"
+	AuthorizerAdminService_DeleteUser_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/DeleteUser"
+	AuthorizerAdminService_VerificationRequests_FullMethodName      = "/authorizer.v1.AuthorizerAdminService/VerificationRequests"
+	AuthorizerAdminService_RevokeAccess_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/RevokeAccess"
+	AuthorizerAdminService_EnableAccess_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/EnableAccess"
+	AuthorizerAdminService_InviteMembers_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/InviteMembers"
+	AuthorizerAdminService_AddWebhook_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/AddWebhook"
+	AuthorizerAdminService_UpdateWebhook_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/UpdateWebhook"
+	AuthorizerAdminService_DeleteWebhook_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/DeleteWebhook"
+	AuthorizerAdminService_GetWebhook_FullMethodName                = "/authorizer.v1.AuthorizerAdminService/GetWebhook"
+	AuthorizerAdminService_Webhooks_FullMethodName                  = "/authorizer.v1.AuthorizerAdminService/Webhooks"
+	AuthorizerAdminService_WebhookLogs_FullMethodName               = "/authorizer.v1.AuthorizerAdminService/WebhookLogs"
+	AuthorizerAdminService_TestEndpoint_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/TestEndpoint"
+	AuthorizerAdminService_AddEmailTemplate_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/AddEmailTemplate"
+	AuthorizerAdminService_UpdateEmailTemplate_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/UpdateEmailTemplate"
+	AuthorizerAdminService_DeleteEmailTemplate_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/DeleteEmailTemplate"
+	AuthorizerAdminService_EmailTemplates_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/EmailTemplates"
+	AuthorizerAdminService_AuditLogs_FullMethodName                 = "/authorizer.v1.AuthorizerAdminService/AuditLogs"
+	AuthorizerAdminService_FgaGetModel_FullMethodName               = "/authorizer.v1.AuthorizerAdminService/FgaGetModel"
+	AuthorizerAdminService_FgaWriteModel_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/FgaWriteModel"
+	AuthorizerAdminService_FgaWriteTuples_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/FgaWriteTuples"
+	AuthorizerAdminService_FgaDeleteTuples_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/FgaDeleteTuples"
+	AuthorizerAdminService_FgaReadTuples_FullMethodName             = "/authorizer.v1.AuthorizerAdminService/FgaReadTuples"
+	AuthorizerAdminService_FgaListUsers_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/FgaListUsers"
+	AuthorizerAdminService_FgaExpand_FullMethodName                 = "/authorizer.v1.AuthorizerAdminService/FgaExpand"
+	AuthorizerAdminService_FgaReset_FullMethodName                  = "/authorizer.v1.AuthorizerAdminService/FgaReset"
+	AuthorizerAdminService_CreateClient_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/CreateClient"
+	AuthorizerAdminService_UpdateClient_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/UpdateClient"
+	AuthorizerAdminService_DeleteClient_FullMethodName              = "/authorizer.v1.AuthorizerAdminService/DeleteClient"
+	AuthorizerAdminService_RotateClientSecret_FullMethodName        = "/authorizer.v1.AuthorizerAdminService/RotateClientSecret"
+	AuthorizerAdminService_GetClient_FullMethodName                 = "/authorizer.v1.AuthorizerAdminService/GetClient"
+	AuthorizerAdminService_Clients_FullMethodName                   = "/authorizer.v1.AuthorizerAdminService/Clients"
+	AuthorizerAdminService_AddTrustedIssuer_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/AddTrustedIssuer"
+	AuthorizerAdminService_UpdateTrustedIssuer_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/UpdateTrustedIssuer"
+	AuthorizerAdminService_DeleteTrustedIssuer_FullMethodName       = "/authorizer.v1.AuthorizerAdminService/DeleteTrustedIssuer"
+	AuthorizerAdminService_GetTrustedIssuer_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/GetTrustedIssuer"
+	AuthorizerAdminService_TrustedIssuers_FullMethodName            = "/authorizer.v1.AuthorizerAdminService/TrustedIssuers"
+	AuthorizerAdminService_CreateSamlServiceProvider_FullMethodName = "/authorizer.v1.AuthorizerAdminService/CreateSamlServiceProvider"
+	AuthorizerAdminService_UpdateSamlServiceProvider_FullMethodName = "/authorizer.v1.AuthorizerAdminService/UpdateSamlServiceProvider"
+	AuthorizerAdminService_DeleteSamlServiceProvider_FullMethodName = "/authorizer.v1.AuthorizerAdminService/DeleteSamlServiceProvider"
+	AuthorizerAdminService_GetSamlServiceProvider_FullMethodName    = "/authorizer.v1.AuthorizerAdminService/GetSamlServiceProvider"
+	AuthorizerAdminService_ListSamlServiceProviders_FullMethodName  = "/authorizer.v1.AuthorizerAdminService/ListSamlServiceProviders"
+	AuthorizerAdminService_RotateSamlIdpCert_FullMethodName         = "/authorizer.v1.AuthorizerAdminService/RotateSamlIdpCert"
+	AuthorizerAdminService_RetireSamlIdpKey_FullMethodName          = "/authorizer.v1.AuthorizerAdminService/RetireSamlIdpKey"
+	AuthorizerAdminService_ListSamlIdpKeys_FullMethodName           = "/authorizer.v1.AuthorizerAdminService/ListSamlIdpKeys"
+	AuthorizerAdminService_ImportSamlSpMetadata_FullMethodName      = "/authorizer.v1.AuthorizerAdminService/ImportSamlSpMetadata"
 )
 
 // AuthorizerAdminServiceClient is the client API for AuthorizerAdminService service.
@@ -213,6 +222,34 @@ type AuthorizerAdminServiceClient interface {
 	// TrustedIssuers returns a paginated list of trusted issuers, optionally
 	// filtered by service_account_id. Requires super-admin auth.
 	TrustedIssuers(ctx context.Context, in *TrustedIssuersRequest, opts ...grpc.CallOption) (*TrustedIssuersResponse, error)
+	// CreateSamlServiceProvider registers a downstream SAML 2.0 SP that Authorizer
+	// (acting as the IdP) issues signed assertions to. Requires super-admin auth.
+	CreateSamlServiceProvider(ctx context.Context, in *CreateSamlServiceProviderRequest, opts ...grpc.CallOption) (*CreateSamlServiceProviderResponse, error)
+	// UpdateSamlServiceProvider updates a downstream SP's name, endpoints,
+	// certificate, attribute mapping, or active state. Requires super-admin auth.
+	UpdateSamlServiceProvider(ctx context.Context, in *UpdateSamlServiceProviderRequest, opts ...grpc.CallOption) (*UpdateSamlServiceProviderResponse, error)
+	// DeleteSamlServiceProvider deletes a downstream SP by id. Requires
+	// super-admin auth.
+	DeleteSamlServiceProvider(ctx context.Context, in *DeleteSamlServiceProviderRequest, opts ...grpc.CallOption) (*DeleteSamlServiceProviderResponse, error)
+	// GetSamlServiceProvider returns a single downstream SP by id. Requires
+	// super-admin auth.
+	GetSamlServiceProvider(ctx context.Context, in *GetSamlServiceProviderRequest, opts ...grpc.CallOption) (*GetSamlServiceProviderResponse, error)
+	// ListSamlServiceProviders returns a paginated list of downstream SPs for an
+	// org. Requires super-admin auth.
+	ListSamlServiceProviders(ctx context.Context, in *ListSamlServiceProvidersRequest, opts ...grpc.CallOption) (*ListSamlServiceProvidersResponse, error)
+	// RotateSamlIdpCert generates a new current signing keypair for an org's SAML
+	// IdP, demoting the previous current key. Requires super-admin auth.
+	RotateSamlIdpCert(ctx context.Context, in *RotateSamlIdpCertRequest, opts ...grpc.CallOption) (*RotateSamlIdpCertResponse, error)
+	// RetireSamlIdpKey retires a published-but-not-signing SAML IdP key by id.
+	// Requires super-admin auth.
+	RetireSamlIdpKey(ctx context.Context, in *RetireSamlIdpKeyRequest, opts ...grpc.CallOption) (*RetireSamlIdpKeyResponse, error)
+	// ListSamlIdpKeys returns all SAML IdP signing keys for an org. Requires
+	// super-admin auth.
+	ListSamlIdpKeys(ctx context.Context, in *ListSamlIdpKeysRequest, opts ...grpc.CallOption) (*ListSamlIdpKeysResponse, error)
+	// ImportSamlSpMetadata parses pasted SP metadata XML and returns the fields to
+	// prefill a create call. It does NOT create a record and performs no remote
+	// fetch. Requires super-admin auth.
+	ImportSamlSpMetadata(ctx context.Context, in *ImportSamlSpMetadataRequest, opts ...grpc.CallOption) (*ImportSamlSpMetadataResponse, error)
 }
 
 type authorizerAdminServiceClient struct {
@@ -653,6 +690,96 @@ func (c *authorizerAdminServiceClient) TrustedIssuers(ctx context.Context, in *T
 	return out, nil
 }
 
+func (c *authorizerAdminServiceClient) CreateSamlServiceProvider(ctx context.Context, in *CreateSamlServiceProviderRequest, opts ...grpc.CallOption) (*CreateSamlServiceProviderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateSamlServiceProviderResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_CreateSamlServiceProvider_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) UpdateSamlServiceProvider(ctx context.Context, in *UpdateSamlServiceProviderRequest, opts ...grpc.CallOption) (*UpdateSamlServiceProviderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateSamlServiceProviderResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_UpdateSamlServiceProvider_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) DeleteSamlServiceProvider(ctx context.Context, in *DeleteSamlServiceProviderRequest, opts ...grpc.CallOption) (*DeleteSamlServiceProviderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteSamlServiceProviderResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_DeleteSamlServiceProvider_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) GetSamlServiceProvider(ctx context.Context, in *GetSamlServiceProviderRequest, opts ...grpc.CallOption) (*GetSamlServiceProviderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSamlServiceProviderResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_GetSamlServiceProvider_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) ListSamlServiceProviders(ctx context.Context, in *ListSamlServiceProvidersRequest, opts ...grpc.CallOption) (*ListSamlServiceProvidersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSamlServiceProvidersResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_ListSamlServiceProviders_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) RotateSamlIdpCert(ctx context.Context, in *RotateSamlIdpCertRequest, opts ...grpc.CallOption) (*RotateSamlIdpCertResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RotateSamlIdpCertResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_RotateSamlIdpCert_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) RetireSamlIdpKey(ctx context.Context, in *RetireSamlIdpKeyRequest, opts ...grpc.CallOption) (*RetireSamlIdpKeyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RetireSamlIdpKeyResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_RetireSamlIdpKey_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) ListSamlIdpKeys(ctx context.Context, in *ListSamlIdpKeysRequest, opts ...grpc.CallOption) (*ListSamlIdpKeysResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSamlIdpKeysResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_ListSamlIdpKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authorizerAdminServiceClient) ImportSamlSpMetadata(ctx context.Context, in *ImportSamlSpMetadataRequest, opts ...grpc.CallOption) (*ImportSamlSpMetadataResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ImportSamlSpMetadataResponse)
+	err := c.cc.Invoke(ctx, AuthorizerAdminService_ImportSamlSpMetadata_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AuthorizerAdminServiceServer is the server API for AuthorizerAdminService service.
 // All implementations should embed UnimplementedAuthorizerAdminServiceServer
 // for forward compatibility.
@@ -793,6 +920,34 @@ type AuthorizerAdminServiceServer interface {
 	// TrustedIssuers returns a paginated list of trusted issuers, optionally
 	// filtered by service_account_id. Requires super-admin auth.
 	TrustedIssuers(context.Context, *TrustedIssuersRequest) (*TrustedIssuersResponse, error)
+	// CreateSamlServiceProvider registers a downstream SAML 2.0 SP that Authorizer
+	// (acting as the IdP) issues signed assertions to. Requires super-admin auth.
+	CreateSamlServiceProvider(context.Context, *CreateSamlServiceProviderRequest) (*CreateSamlServiceProviderResponse, error)
+	// UpdateSamlServiceProvider updates a downstream SP's name, endpoints,
+	// certificate, attribute mapping, or active state. Requires super-admin auth.
+	UpdateSamlServiceProvider(context.Context, *UpdateSamlServiceProviderRequest) (*UpdateSamlServiceProviderResponse, error)
+	// DeleteSamlServiceProvider deletes a downstream SP by id. Requires
+	// super-admin auth.
+	DeleteSamlServiceProvider(context.Context, *DeleteSamlServiceProviderRequest) (*DeleteSamlServiceProviderResponse, error)
+	// GetSamlServiceProvider returns a single downstream SP by id. Requires
+	// super-admin auth.
+	GetSamlServiceProvider(context.Context, *GetSamlServiceProviderRequest) (*GetSamlServiceProviderResponse, error)
+	// ListSamlServiceProviders returns a paginated list of downstream SPs for an
+	// org. Requires super-admin auth.
+	ListSamlServiceProviders(context.Context, *ListSamlServiceProvidersRequest) (*ListSamlServiceProvidersResponse, error)
+	// RotateSamlIdpCert generates a new current signing keypair for an org's SAML
+	// IdP, demoting the previous current key. Requires super-admin auth.
+	RotateSamlIdpCert(context.Context, *RotateSamlIdpCertRequest) (*RotateSamlIdpCertResponse, error)
+	// RetireSamlIdpKey retires a published-but-not-signing SAML IdP key by id.
+	// Requires super-admin auth.
+	RetireSamlIdpKey(context.Context, *RetireSamlIdpKeyRequest) (*RetireSamlIdpKeyResponse, error)
+	// ListSamlIdpKeys returns all SAML IdP signing keys for an org. Requires
+	// super-admin auth.
+	ListSamlIdpKeys(context.Context, *ListSamlIdpKeysRequest) (*ListSamlIdpKeysResponse, error)
+	// ImportSamlSpMetadata parses pasted SP metadata XML and returns the fields to
+	// prefill a create call. It does NOT create a record and performs no remote
+	// fetch. Requires super-admin auth.
+	ImportSamlSpMetadata(context.Context, *ImportSamlSpMetadataRequest) (*ImportSamlSpMetadataResponse, error)
 }
 
 // UnimplementedAuthorizerAdminServiceServer should be embedded to have
@@ -930,6 +1085,33 @@ func (UnimplementedAuthorizerAdminServiceServer) GetTrustedIssuer(context.Contex
 }
 func (UnimplementedAuthorizerAdminServiceServer) TrustedIssuers(context.Context, *TrustedIssuersRequest) (*TrustedIssuersResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method TrustedIssuers not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) CreateSamlServiceProvider(context.Context, *CreateSamlServiceProviderRequest) (*CreateSamlServiceProviderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateSamlServiceProvider not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) UpdateSamlServiceProvider(context.Context, *UpdateSamlServiceProviderRequest) (*UpdateSamlServiceProviderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateSamlServiceProvider not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) DeleteSamlServiceProvider(context.Context, *DeleteSamlServiceProviderRequest) (*DeleteSamlServiceProviderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteSamlServiceProvider not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) GetSamlServiceProvider(context.Context, *GetSamlServiceProviderRequest) (*GetSamlServiceProviderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSamlServiceProvider not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) ListSamlServiceProviders(context.Context, *ListSamlServiceProvidersRequest) (*ListSamlServiceProvidersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSamlServiceProviders not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) RotateSamlIdpCert(context.Context, *RotateSamlIdpCertRequest) (*RotateSamlIdpCertResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RotateSamlIdpCert not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) RetireSamlIdpKey(context.Context, *RetireSamlIdpKeyRequest) (*RetireSamlIdpKeyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RetireSamlIdpKey not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) ListSamlIdpKeys(context.Context, *ListSamlIdpKeysRequest) (*ListSamlIdpKeysResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSamlIdpKeys not implemented")
+}
+func (UnimplementedAuthorizerAdminServiceServer) ImportSamlSpMetadata(context.Context, *ImportSamlSpMetadataRequest) (*ImportSamlSpMetadataResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ImportSamlSpMetadata not implemented")
 }
 func (UnimplementedAuthorizerAdminServiceServer) testEmbeddedByValue() {}
 
@@ -1725,6 +1907,168 @@ func _AuthorizerAdminService_TrustedIssuers_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AuthorizerAdminService_CreateSamlServiceProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateSamlServiceProviderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).CreateSamlServiceProvider(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_CreateSamlServiceProvider_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).CreateSamlServiceProvider(ctx, req.(*CreateSamlServiceProviderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_UpdateSamlServiceProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateSamlServiceProviderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).UpdateSamlServiceProvider(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_UpdateSamlServiceProvider_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).UpdateSamlServiceProvider(ctx, req.(*UpdateSamlServiceProviderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_DeleteSamlServiceProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteSamlServiceProviderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).DeleteSamlServiceProvider(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_DeleteSamlServiceProvider_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).DeleteSamlServiceProvider(ctx, req.(*DeleteSamlServiceProviderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_GetSamlServiceProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSamlServiceProviderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).GetSamlServiceProvider(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_GetSamlServiceProvider_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).GetSamlServiceProvider(ctx, req.(*GetSamlServiceProviderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_ListSamlServiceProviders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSamlServiceProvidersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).ListSamlServiceProviders(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_ListSamlServiceProviders_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).ListSamlServiceProviders(ctx, req.(*ListSamlServiceProvidersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_RotateSamlIdpCert_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RotateSamlIdpCertRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).RotateSamlIdpCert(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_RotateSamlIdpCert_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).RotateSamlIdpCert(ctx, req.(*RotateSamlIdpCertRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_RetireSamlIdpKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RetireSamlIdpKeyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).RetireSamlIdpKey(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_RetireSamlIdpKey_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).RetireSamlIdpKey(ctx, req.(*RetireSamlIdpKeyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_ListSamlIdpKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSamlIdpKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).ListSamlIdpKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_ListSamlIdpKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).ListSamlIdpKeys(ctx, req.(*ListSamlIdpKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuthorizerAdminService_ImportSamlSpMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ImportSamlSpMetadataRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthorizerAdminServiceServer).ImportSamlSpMetadata(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuthorizerAdminService_ImportSamlSpMetadata_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthorizerAdminServiceServer).ImportSamlSpMetadata(ctx, req.(*ImportSamlSpMetadataRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AuthorizerAdminService_ServiceDesc is the grpc.ServiceDesc for AuthorizerAdminService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1903,6 +2247,42 @@ var AuthorizerAdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "TrustedIssuers",
 			Handler:    _AuthorizerAdminService_TrustedIssuers_Handler,
+		},
+		{
+			MethodName: "CreateSamlServiceProvider",
+			Handler:    _AuthorizerAdminService_CreateSamlServiceProvider_Handler,
+		},
+		{
+			MethodName: "UpdateSamlServiceProvider",
+			Handler:    _AuthorizerAdminService_UpdateSamlServiceProvider_Handler,
+		},
+		{
+			MethodName: "DeleteSamlServiceProvider",
+			Handler:    _AuthorizerAdminService_DeleteSamlServiceProvider_Handler,
+		},
+		{
+			MethodName: "GetSamlServiceProvider",
+			Handler:    _AuthorizerAdminService_GetSamlServiceProvider_Handler,
+		},
+		{
+			MethodName: "ListSamlServiceProviders",
+			Handler:    _AuthorizerAdminService_ListSamlServiceProviders_Handler,
+		},
+		{
+			MethodName: "RotateSamlIdpCert",
+			Handler:    _AuthorizerAdminService_RotateSamlIdpCert_Handler,
+		},
+		{
+			MethodName: "RetireSamlIdpKey",
+			Handler:    _AuthorizerAdminService_RetireSamlIdpKey_Handler,
+		},
+		{
+			MethodName: "ListSamlIdpKeys",
+			Handler:    _AuthorizerAdminService_ListSamlIdpKeys_Handler,
+		},
+		{
+			MethodName: "ImportSamlSpMetadata",
+			Handler:    _AuthorizerAdminService_ImportSamlSpMetadata_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/gen/openapi/authorizer.swagger.json
+++ b/gen/openapi/authorizer.swagger.json
@@ -256,6 +256,40 @@
         ]
       }
     },
+    "/v1/admin/create_saml_service_provider": {
+      "post": {
+        "summary": "CreateSamlServiceProvider registers a downstream SAML 2.0 SP that Authorizer\n(acting as the IdP) issues signed assertions to. Requires super-admin auth.",
+        "operationId": "AuthorizerAdminService_CreateSamlServiceProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateSamlServiceProviderResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "CreateSamlServiceProviderRequest mirrors model.CreateSAMLServiceProviderRequest.\nsp_cert_pem, name_id_format, mapped_attributes, and allow_idp_initiated are\noptional.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSamlServiceProviderRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
     "/v1/admin/delete_client": {
       "post": {
         "summary": "DeleteClient deletes a service account by id, cascading to its\ntrusted issuers. Requires super-admin auth.",
@@ -316,6 +350,40 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1DeleteEmailTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/delete_saml_service_provider": {
+      "post": {
+        "summary": "DeleteSamlServiceProvider deletes a downstream SP by id. Requires\nsuper-admin auth.",
+        "operationId": "AuthorizerAdminService_DeleteSamlServiceProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteSamlServiceProviderResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "DeleteSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a\nsingle SP id). Kept distinct from GetSamlServiceProviderRequest per buf's\none-message-per-RPC rule.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteSamlServiceProviderRequest"
             }
           }
         ],
@@ -752,6 +820,40 @@
         ]
       }
     },
+    "/v1/admin/import_saml_sp_metadata": {
+      "post": {
+        "summary": "ImportSamlSpMetadata parses pasted SP metadata XML and returns the fields to\nprefill a create call. It does NOT create a record and performs no remote\nfetch. Requires super-admin auth.",
+        "operationId": "AuthorizerAdminService_ImportSamlSpMetadata",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ImportSamlSpMetadataResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ImportSamlSpMetadataRequest mirrors model.ImportSAMLSPMetadataRequest. The\nmetadata is pasted XML — NOT a URL; no remote fetch is performed.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ImportSamlSpMetadataRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
     "/v1/admin/invite_members": {
       "post": {
         "summary": "InviteMembers creates accounts for new emails and sends invite emails.\nRequires super-admin auth and a configured email service.",
@@ -865,6 +967,40 @@
         ]
       }
     },
+    "/v1/admin/retire_saml_idp_key": {
+      "post": {
+        "summary": "RetireSamlIdpKey retires a published-but-not-signing SAML IdP key by id.\nRequires super-admin auth.",
+        "operationId": "AuthorizerAdminService_RetireSamlIdpKey",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RetireSamlIdpKeyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "RetireSamlIdpKeyRequest mirrors model.RetireSAMLIDPKeyRequest (a single key id).",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1RetireSamlIdpKeyRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
     "/v1/admin/revoke_access": {
       "post": {
         "summary": "RevokeAccess revokes a user's access (sets the revoked timestamp), kills\ntheir sessions, and fires the access-revoked webhook. Requires super-admin\nauth.",
@@ -925,6 +1061,142 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1RotateClientSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/rotate_saml_idp_cert": {
+      "post": {
+        "summary": "RotateSamlIdpCert generates a new current signing keypair for an org's SAML\nIdP, demoting the previous current key. Requires super-admin auth.",
+        "operationId": "AuthorizerAdminService_RotateSamlIdpCert",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RotateSamlIdpCertResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "RotateSamlIdpCertRequest mirrors model.RotateSAMLIDPCertRequest.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1RotateSamlIdpCertRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/saml_idp_keys": {
+      "post": {
+        "summary": "ListSamlIdpKeys returns all SAML IdP signing keys for an org. Requires\nsuper-admin auth.",
+        "operationId": "AuthorizerAdminService_ListSamlIdpKeys",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSamlIdpKeysResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ListSamlIdpKeysRequest mirrors model.ListSAMLIDPKeysRequest.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListSamlIdpKeysRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/saml_service_provider": {
+      "post": {
+        "summary": "GetSamlServiceProvider returns a single downstream SP by id. Requires\nsuper-admin auth.",
+        "operationId": "AuthorizerAdminService_GetSamlServiceProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSamlServiceProviderResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a\nsingle SP id). Kept distinct from DeleteSamlServiceProviderRequest per buf's\none-message-per-RPC rule.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSamlServiceProviderRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/saml_service_providers": {
+      "post": {
+        "summary": "ListSamlServiceProviders returns a paginated list of downstream SPs for an\norg. Requires super-admin auth.",
+        "operationId": "AuthorizerAdminService_ListSamlServiceProviders",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSamlServiceProvidersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ListSamlServiceProvidersRequest mirrors model.ListSAMLServiceProvidersRequest.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListSamlServiceProvidersRequest"
             }
           }
         ],
@@ -1118,6 +1390,40 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1UpdateEmailTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AuthorizerAdminService"
+        ]
+      }
+    },
+    "/v1/admin/update_saml_service_provider": {
+      "post": {
+        "summary": "UpdateSamlServiceProvider updates a downstream SP's name, endpoints,\ncertificate, attribute mapping, or active state. Requires super-admin auth.",
+        "operationId": "AuthorizerAdminService_UpdateSamlServiceProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateSamlServiceProviderResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "UpdateSamlServiceProviderRequest mirrors model.UpdateSAMLServiceProviderRequest.\nNullable GraphQL inputs use proto3 `optional` so an unset field is\ndistinguishable from an empty value.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateSamlServiceProviderRequest"
             }
           }
         ],
@@ -2840,6 +3146,47 @@
       },
       "description": "CreateClientResponse carries the created service account plus the\nplaintext client_secret, returned exactly once. This is the ONLY admin\nmessage with a secret field; RotateClientSecret reuses it."
     },
+    "v1CreateSamlServiceProviderRequest": {
+      "type": "object",
+      "properties": {
+        "org_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "entity_id": {
+          "type": "string"
+        },
+        "acs_url": {
+          "type": "string"
+        },
+        "sp_cert_pem": {
+          "type": "string"
+        },
+        "name_id_format": {
+          "type": "string",
+          "description": "name_id_format: default urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress."
+        },
+        "mapped_attributes": {
+          "type": "string",
+          "description": "mapped_attributes: JSON, e.g. {\"email\":\"email\",\"given_name\":\"firstName\"}."
+        },
+        "allow_idp_initiated": {
+          "type": "boolean",
+          "description": "allow_idp_initiated: default false (SP-initiated only)."
+        }
+      },
+      "description": "CreateSamlServiceProviderRequest mirrors model.CreateSAMLServiceProviderRequest.\nsp_cert_pem, name_id_format, mapped_attributes, and allow_idp_initiated are\noptional."
+    },
+    "v1CreateSamlServiceProviderResponse": {
+      "type": "object",
+      "properties": {
+        "saml_service_provider": {
+          "$ref": "#/definitions/v1SamlServiceProvider"
+        }
+      }
+    },
     "v1DeactivateAccountRequest": {
       "type": "object"
     },
@@ -2878,6 +3225,23 @@
       "description": "DeleteEmailTemplateRequest mirrors model.DeleteEmailTemplateRequest (a single\nemail template id)."
     },
     "v1DeleteEmailTemplateResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "v1DeleteSamlServiceProviderRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "description": "DeleteSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a\nsingle SP id). Kept distinct from GetSamlServiceProviderRequest per buf's\none-message-per-RPC rule."
+    },
+    "v1DeleteSamlServiceProviderResponse": {
       "type": "object",
       "properties": {
         "message": {
@@ -3287,6 +3651,23 @@
         }
       }
     },
+    "v1GetSamlServiceProviderRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "description": "GetSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a\nsingle SP id). Kept distinct from DeleteSamlServiceProviderRequest per buf's\none-message-per-RPC rule."
+    },
+    "v1GetSamlServiceProviderResponse": {
+      "type": "object",
+      "properties": {
+        "saml_service_provider": {
+          "$ref": "#/definitions/v1SamlServiceProvider"
+        }
+      }
+    },
     "v1GetTrustedIssuerRequest": {
       "type": "object",
       "properties": {
@@ -3318,6 +3699,23 @@
       "properties": {
         "webhook": {
           "$ref": "#/definitions/v1Webhook"
+        }
+      }
+    },
+    "v1ImportSamlSpMetadataRequest": {
+      "type": "object",
+      "properties": {
+        "metadata_xml": {
+          "type": "string"
+        }
+      },
+      "description": "ImportSamlSpMetadataRequest mirrors model.ImportSAMLSPMetadataRequest. The\nmetadata is pasted XML — NOT a URL; no remote fetch is performed."
+    },
+    "v1ImportSamlSpMetadataResponse": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "$ref": "#/definitions/v1SamlSpMetadataParseResult"
         }
       }
     },
@@ -3390,6 +3788,54 @@
         "truncated": {
           "type": "boolean",
           "description": "True when the result was capped (1000 entries) and more permissions\nexist."
+        }
+      }
+    },
+    "v1ListSamlIdpKeysRequest": {
+      "type": "object",
+      "properties": {
+        "org_id": {
+          "type": "string"
+        }
+      },
+      "description": "ListSamlIdpKeysRequest mirrors model.ListSAMLIDPKeysRequest."
+    },
+    "v1ListSamlIdpKeysResponse": {
+      "type": "object",
+      "properties": {
+        "saml_idp_keys": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SamlIdpKey"
+          }
+        }
+      }
+    },
+    "v1ListSamlServiceProvidersRequest": {
+      "type": "object",
+      "properties": {
+        "org_id": {
+          "type": "string"
+        },
+        "pagination": {
+          "$ref": "#/definitions/v1PaginationRequest"
+        }
+      },
+      "description": "ListSamlServiceProvidersRequest mirrors model.ListSAMLServiceProvidersRequest."
+    },
+    "v1ListSamlServiceProvidersResponse": {
+      "type": "object",
+      "properties": {
+        "saml_service_providers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SamlServiceProvider"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/v1Pagination"
         }
       }
     },
@@ -3647,6 +4093,23 @@
         }
       }
     },
+    "v1RetireSamlIdpKeyRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "description": "RetireSamlIdpKeyRequest mirrors model.RetireSAMLIDPKeyRequest (a single key id)."
+    },
+    "v1RetireSamlIdpKeyResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }
+    },
     "v1RevokeAccessRequest": {
       "type": "object",
       "properties": {
@@ -3688,6 +4151,119 @@
         }
       },
       "description": "RotateClientSecretRequest mirrors model.ClientRequest (a\nsingle service account id). Kept distinct from DeleteClientRequest and\nGetClientRequest per buf's one-message-per-RPC rule."
+    },
+    "v1RotateSamlIdpCertRequest": {
+      "type": "object",
+      "properties": {
+        "org_id": {
+          "type": "string"
+        }
+      },
+      "description": "RotateSamlIdpCertRequest mirrors model.RotateSAMLIDPCertRequest."
+    },
+    "v1RotateSamlIdpCertResponse": {
+      "type": "object",
+      "properties": {
+        "saml_idp_key": {
+          "$ref": "#/definitions/v1SamlIdpKey"
+        }
+      }
+    },
+    "v1SamlIdpKey": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "org_id": {
+          "type": "string"
+        },
+        "cert_pem": {
+          "type": "string",
+          "description": "cert_pem: the self-signed X.509 signing certificate (PEM), pinned by SPs."
+        },
+        "algorithm": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "description": "status: \"current\" (signs new assertions), \"active\" (published in metadata,\nnot signing), or \"retired\" (neither)."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      },
+      "description": "SamlIdpKey mirrors model.SAMLIDPKey. The private key is NEVER projected — only\nthe certificate and rotation status."
+    },
+    "v1SamlServiceProvider": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "org_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "entity_id": {
+          "type": "string",
+          "description": "entity_id: the SP entity ID (the AuthnRequest Issuer and assertion Audience)."
+        },
+        "acs_url": {
+          "type": "string",
+          "description": "acs_url: the SP Assertion Consumer Service URL — the only place assertions\nare POSTed."
+        },
+        "sp_cert_pem": {
+          "type": "string",
+          "description": "sp_cert_pem: the SP's optional X.509 signing certificate (PEM)."
+        },
+        "name_id_format": {
+          "type": "string",
+          "description": "name_id_format: SAML NameID format for the Subject (default emailAddress)."
+        },
+        "mapped_attributes": {
+          "type": "string",
+          "description": "mapped_attributes: JSON mapping profile fields to emitted SAML attribute names."
+        },
+        "allow_idp_initiated": {
+          "type": "boolean",
+          "description": "allow_idp_initiated: whether unsolicited IdP-initiated SSO is permitted."
+        },
+        "is_active": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      },
+      "description": "SamlServiceProvider mirrors model.SAMLServiceProvider field-for-field. It is a\ndownstream SAML 2.0 SP that Authorizer (acting as the IdP) issues signed\nassertions to. Optional pointer fields collapse to zero values on the wire."
+    },
+    "v1SamlSpMetadataParseResult": {
+      "type": "object",
+      "properties": {
+        "entity_id": {
+          "type": "string"
+        },
+        "acs_url": {
+          "type": "string"
+        },
+        "certificate": {
+          "type": "string"
+        }
+      },
+      "description": "SamlSpMetadataParseResult mirrors model.SAMLSPMetadataParseResult. It does NOT\ncreate a record — it returns fields to prefill a create call."
     },
     "v1SessionRequest": {
       "type": "object",
@@ -4046,6 +4622,47 @@
       "properties": {
         "message": {
           "type": "string"
+        }
+      }
+    },
+    "v1UpdateSamlServiceProviderRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "entity_id": {
+          "type": "string"
+        },
+        "acs_url": {
+          "type": "string"
+        },
+        "sp_cert_pem": {
+          "type": "string"
+        },
+        "name_id_format": {
+          "type": "string"
+        },
+        "mapped_attributes": {
+          "type": "string"
+        },
+        "allow_idp_initiated": {
+          "type": "boolean"
+        },
+        "is_active": {
+          "type": "boolean"
+        }
+      },
+      "description": "UpdateSamlServiceProviderRequest mirrors model.UpdateSAMLServiceProviderRequest.\nNullable GraphQL inputs use proto3 `optional` so an unset field is\ndistinguishable from an empty value."
+    },
+    "v1UpdateSamlServiceProviderResponse": {
+      "type": "object",
+      "properties": {
+        "saml_service_provider": {
+          "$ref": "#/definitions/v1SamlServiceProvider"
         }
       }
     },

--- a/internal/constants/audit_event.go
+++ b/internal/constants/audit_event.go
@@ -152,6 +152,21 @@ const (
 	AuditSAMLACSSuccessEvent = "saml.acs_success"
 	// AuditSAMLACSFailedEvent is logged when an org SAML ACS assertion is rejected.
 	AuditSAMLACSFailedEvent = "saml.acs_failed"
+	// AuditSAMLIDPAssertionIssuedEvent is logged when Authorizer (as SAML IdP)
+	// issues a signed assertion to a registered downstream SP.
+	AuditSAMLIDPAssertionIssuedEvent = "saml.idp_assertion_issued"
+	// AuditSAMLIDPAssertionFailedEvent is logged when an IdP SSO request is
+	// rejected (unknown SP, ACS mismatch, IdP-initiated disabled, etc.).
+	AuditSAMLIDPAssertionFailedEvent = "saml.idp_assertion_failed"
+	// AuditSAMLIDPKeyRotatedEvent is logged when an org's SAML IdP signing key is
+	// rotated (a new current key generated).
+	AuditSAMLIDPKeyRotatedEvent = "saml.idp_key_rotated"
+	// AuditSAMLIDPKeyRetiredEvent is logged when a superseded SAML IdP signing key
+	// is explicitly retired.
+	AuditSAMLIDPKeyRetiredEvent = "saml.idp_key_retired"
+	// AuditSAMLIDPServiceProviderChangedEvent is logged when an admin creates,
+	// updates, or deletes a registered downstream SAML service provider.
+	AuditSAMLIDPServiceProviderChangedEvent = "saml.idp_service_provider_changed"
 
 	// AuditTokenIssuedEvent is logged when a new token is issued.
 	AuditTokenIssuedEvent = "token.issued"

--- a/internal/crypto/saml_x509.go
+++ b/internal/crypto/saml_x509.go
@@ -37,10 +37,10 @@ func NewSAMLSigningKeypair(commonName string) (privateKeyPEM string, certPEM str
 
 	now := time.Now()
 	template := x509.Certificate{
-		SerialNumber:          serial,
-		Subject:               pkix.Name{CommonName: commonName},
-		NotBefore:             now.Add(-1 * time.Minute),
-		NotAfter:              now.Add(samlIDPCertValidity),
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    now.Add(-1 * time.Minute),
+		NotAfter:     now.Add(samlIDPCertValidity),
 		// Least privilege: a leaf assertion-signing cert, not a CA. Some strict SP
 		// validators reject a signing cert whose KeyUsage isn't digitalSignature.
 		KeyUsage:              x509.KeyUsageDigitalSignature,

--- a/internal/crypto/saml_x509.go
+++ b/internal/crypto/saml_x509.go
@@ -41,9 +41,11 @@ func NewSAMLSigningKeypair(commonName string) (privateKeyPEM string, certPEM str
 		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             now.Add(-1 * time.Minute),
 		NotAfter:              now.Add(samlIDPCertValidity),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		// Least privilege: a leaf assertion-signing cert, not a CA. Some strict SP
+		// validators reject a signing cert whose KeyUsage isn't digitalSignature.
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA:                  false,
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)

--- a/internal/crypto/saml_x509.go
+++ b/internal/crypto/saml_x509.go
@@ -1,0 +1,66 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// samlIDPCertValidity is the lifetime of a generated SAML IdP signing cert.
+// SAML signing certs are typically long-lived; rotation is an explicit operator
+// action (see schemas.SAMLIDPKey), not driven by this expiry.
+const samlIDPCertValidity = 5 * 365 * 24 * time.Hour
+
+// NewSAMLSigningKeypair generates a fresh RSA-2048 private key and a self-signed
+// X.509 certificate wrapping its public key, suitable for signing SAML assertions
+// as an IdP. It returns the private key PEM (PKCS#1) and the certificate PEM.
+//
+// SAML XML-DSIG requires the X.509 certificate wrapper (SPs pin the
+// <X509Certificate>); the raw-PEM JWT signing key cannot be reused because it
+// carries no certificate. commonName is embedded as the cert subject/issuer CN
+// (e.g. "Authorizer SAML IdP <org>") purely as a human-readable label.
+func NewSAMLSigningKeypair(commonName string) (privateKeyPEM string, certPEM string, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", fmt.Errorf("generate rsa key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return "", "", fmt.Errorf("generate serial: %w", err)
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(samlIDPCertValidity),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return "", "", fmt.Errorf("create certificate: %w", err)
+	}
+
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	privateKeyPEM = ExportRsaPrivateKeyAsPemStr(key)
+	return privateKeyPEM, certPEM, nil
+}
+
+// ParseCertificateFromPemStr parses an X.509 certificate from its PEM encoding.
+func ParseCertificateFromPemStr(certPEM string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block containing the certificate")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}

--- a/internal/crypto/saml_x509_test.go
+++ b/internal/crypto/saml_x509_test.go
@@ -1,0 +1,45 @@
+package crypto
+
+import (
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSAMLSigningKeypair(t *testing.T) {
+	privPEM, certPEM, err := NewSAMLSigningKeypair("Authorizer SAML IdP test-org")
+	require.NoError(t, err)
+	require.NotEmpty(t, privPEM)
+	require.NotEmpty(t, certPEM)
+
+	// The private key must round-trip through the PKCS#1 PEM parser.
+	priv, err := ParseRsaPrivateKeyFromPemStr(privPEM)
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PrivateKey{}, priv)
+
+	// The certificate must parse and wrap the same public key as the private key.
+	cert, err := ParseCertificateFromPemStr(certPEM)
+	require.NoError(t, err)
+	assert.Equal(t, "Authorizer SAML IdP test-org", cert.Subject.CommonName)
+	assert.True(t, cert.NotAfter.After(time.Now().Add(365*24*time.Hour)), "cert should be long-lived")
+
+	certPub, ok := cert.PublicKey.(*rsa.PublicKey)
+	require.True(t, ok)
+	assert.Equal(t, priv.PublicKey.N, certPub.N, "cert public key must match the private key")
+}
+
+func TestNewSAMLSigningKeypair_Unique(t *testing.T) {
+	_, cert1, err := NewSAMLSigningKeypair("org")
+	require.NoError(t, err)
+	_, cert2, err := NewSAMLSigningKeypair("org")
+	require.NoError(t, err)
+	assert.NotEqual(t, cert1, cert2, "each rotation must produce a distinct keypair")
+}
+
+func TestParseCertificateFromPemStr_Invalid(t *testing.T) {
+	_, err := ParseCertificateFromPemStr("not a pem")
+	assert.Error(t, err)
+}

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -305,6 +305,7 @@ type ComplexityRoot struct {
 		CreateOrgOidcConnection     func(childComplexity int, params model.CreateOrgOIDCConnectionRequest) int
 		CreateOrgSamlConnection     func(childComplexity int, params model.CreateOrgSAMLConnectionRequest) int
 		CreateOrganization          func(childComplexity int, params model.CreateOrganizationRequest) int
+		CreateSamlServiceProvider   func(childComplexity int, params model.CreateSAMLServiceProviderRequest) int
 		CreateScimEndpoint          func(childComplexity int, params model.CreateScimEndpointRequest) int
 		DeactivateAccount           func(childComplexity int) int
 		DeleteClient                func(childComplexity int, params model.ClientRequest) int
@@ -313,6 +314,7 @@ type ComplexityRoot struct {
 		DeleteOrgOidcConnection     func(childComplexity int, params model.OrgOIDCConnectionRequest) int
 		DeleteOrgSamlConnection     func(childComplexity int, params model.OrgSAMLConnectionRequest) int
 		DeleteOrganization          func(childComplexity int, params model.OrganizationRequest) int
+		DeleteSamlServiceProvider   func(childComplexity int, params model.SAMLServiceProviderRequest) int
 		DeleteScimEndpoint          func(childComplexity int, params model.ScimEndpointRequest) int
 		DeleteTrustedIssuer         func(childComplexity int, params model.TrustedIssuerRequest) int
 		DeleteUser                  func(childComplexity int, params model.DeleteUserRequest) int
@@ -325,6 +327,7 @@ type ComplexityRoot struct {
 		FgaWriteTuples              func(childComplexity int, params model.FgaWriteTuplesInput) int
 		ForgotPassword              func(childComplexity int, params model.ForgotPasswordRequest) int
 		GenerateJwtKeys             func(childComplexity int, params model.GenerateJWTKeysRequest) int
+		ImportSamlSpMetadata        func(childComplexity int, params model.ImportSAMLSPMetadataRequest) int
 		InviteMembers               func(childComplexity int, params model.InviteMemberRequest) int
 		LockMfa                     func(childComplexity int, params model.LockMfaRequest) int
 		Login                       func(childComplexity int, params model.LoginRequest) int
@@ -337,9 +340,11 @@ type ComplexityRoot struct {
 		ResendOtp                   func(childComplexity int, params model.ResendOTPRequest) int
 		ResendVerifyEmail           func(childComplexity int, params model.ResendVerifyEmailRequest) int
 		ResetPassword               func(childComplexity int, params model.ResetPasswordRequest) int
+		RetireSamlIdpKey            func(childComplexity int, params model.RetireSAMLIDPKeyRequest) int
 		Revoke                      func(childComplexity int, params model.OAuthRevokeRequest) int
 		RevokeAccess                func(childComplexity int, param model.UpdateAccessRequest) int
 		RotateClientSecret          func(childComplexity int, params model.ClientRequest) int
+		RotateSamlIdpCert           func(childComplexity int, params model.RotateSAMLIDPCertRequest) int
 		RotateScimToken             func(childComplexity int, params model.ScimEndpointRequest) int
 		Signup                      func(childComplexity int, params model.SignUpRequest) int
 		SkipMfaSetup                func(childComplexity int, params model.SkipMfaSetupRequest) int
@@ -353,6 +358,7 @@ type ComplexityRoot struct {
 		UpdateOrgSamlConnection     func(childComplexity int, params model.UpdateOrgSAMLConnectionRequest) int
 		UpdateOrganization          func(childComplexity int, params model.UpdateOrganizationRequest) int
 		UpdateProfile               func(childComplexity int, params model.UpdateProfileRequest) int
+		UpdateSamlServiceProvider   func(childComplexity int, params model.UpdateSAMLServiceProviderRequest) int
 		UpdateTrustedIssuer         func(childComplexity int, params model.UpdateTrustedIssuerRequest) int
 		UpdateUser                  func(childComplexity int, params model.UpdateUserRequest) int
 		UpdateWebhook               func(childComplexity int, params model.UpdateWebhookRequest) int
@@ -464,45 +470,84 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		AdminMeta            func(childComplexity int) int
-		AdminSession         func(childComplexity int) int
-		AuditLogs            func(childComplexity int, params *model.ListAuditLogRequest) int
-		CheckPermissions     func(childComplexity int, params model.CheckPermissionsInput) int
-		Client               func(childComplexity int, params model.ClientRequest) int
-		Clients              func(childComplexity int, params *model.ListClientsRequest) int
-		EmailTemplates       func(childComplexity int, params *model.PaginatedRequest) int
-		Env                  func(childComplexity int) int
-		FgaExpand            func(childComplexity int, params model.FgaExpandInput) int
-		FgaGetModel          func(childComplexity int) int
-		FgaListUsers         func(childComplexity int, params model.FgaListUsersInput) int
-		FgaReadTuples        func(childComplexity int, params model.FgaReadTuplesInput) int
-		ListPermissions      func(childComplexity int, params model.ListPermissionsInput) int
-		Meta                 func(childComplexity int) int
-		OrgDomains           func(childComplexity int, params model.ListOrgDomainsRequest) int
-		OrgMembers           func(childComplexity int, params model.ListOrgMembersRequest) int
-		OrgOidcConnection    func(childComplexity int, params model.OrgOIDCConnectionRequest) int
-		OrgSamlConnection    func(childComplexity int, params model.OrgSAMLConnectionRequest) int
-		Organization         func(childComplexity int, params model.OrganizationRequest) int
-		Organizations        func(childComplexity int, params *model.ListOrganizationsRequest) int
-		Profile              func(childComplexity int) int
-		ScimEndpoint         func(childComplexity int, params model.ScimEndpointRequest) int
-		Session              func(childComplexity int, params *model.SessionQueryRequest) int
-		TrustedIssuer        func(childComplexity int, params model.TrustedIssuerRequest) int
-		TrustedIssuers       func(childComplexity int, params *model.ListTrustedIssuersRequest) int
-		User                 func(childComplexity int, params model.GetUserRequest) int
-		UserOrganizations    func(childComplexity int, params model.UserOrganizationsRequest) int
-		Users                func(childComplexity int, params *model.ListUsersRequest) int
-		ValidateJwtToken     func(childComplexity int, params model.ValidateJWTTokenRequest) int
-		ValidateSession      func(childComplexity int, params *model.ValidateSessionRequest) int
-		VerificationRequests func(childComplexity int, params *model.PaginatedRequest) int
-		WebauthnCredentials  func(childComplexity int) int
-		Webhook              func(childComplexity int, params model.WebhookRequest) int
-		WebhookLogs          func(childComplexity int, params *model.ListWebhookLogRequest) int
-		Webhooks             func(childComplexity int, params *model.PaginatedRequest) int
+		AdminMeta                func(childComplexity int) int
+		AdminSession             func(childComplexity int) int
+		AuditLogs                func(childComplexity int, params *model.ListAuditLogRequest) int
+		CheckPermissions         func(childComplexity int, params model.CheckPermissionsInput) int
+		Client                   func(childComplexity int, params model.ClientRequest) int
+		Clients                  func(childComplexity int, params *model.ListClientsRequest) int
+		EmailTemplates           func(childComplexity int, params *model.PaginatedRequest) int
+		Env                      func(childComplexity int) int
+		FgaExpand                func(childComplexity int, params model.FgaExpandInput) int
+		FgaGetModel              func(childComplexity int) int
+		FgaListUsers             func(childComplexity int, params model.FgaListUsersInput) int
+		FgaReadTuples            func(childComplexity int, params model.FgaReadTuplesInput) int
+		ListPermissions          func(childComplexity int, params model.ListPermissionsInput) int
+		ListSamlIdpKeys          func(childComplexity int, params model.ListSAMLIDPKeysRequest) int
+		ListSamlServiceProviders func(childComplexity int, params model.ListSAMLServiceProvidersRequest) int
+		Meta                     func(childComplexity int) int
+		OrgDomains               func(childComplexity int, params model.ListOrgDomainsRequest) int
+		OrgMembers               func(childComplexity int, params model.ListOrgMembersRequest) int
+		OrgOidcConnection        func(childComplexity int, params model.OrgOIDCConnectionRequest) int
+		OrgSamlConnection        func(childComplexity int, params model.OrgSAMLConnectionRequest) int
+		Organization             func(childComplexity int, params model.OrganizationRequest) int
+		Organizations            func(childComplexity int, params *model.ListOrganizationsRequest) int
+		Profile                  func(childComplexity int) int
+		SamlServiceProvider      func(childComplexity int, params model.SAMLServiceProviderRequest) int
+		ScimEndpoint             func(childComplexity int, params model.ScimEndpointRequest) int
+		Session                  func(childComplexity int, params *model.SessionQueryRequest) int
+		TrustedIssuer            func(childComplexity int, params model.TrustedIssuerRequest) int
+		TrustedIssuers           func(childComplexity int, params *model.ListTrustedIssuersRequest) int
+		User                     func(childComplexity int, params model.GetUserRequest) int
+		UserOrganizations        func(childComplexity int, params model.UserOrganizationsRequest) int
+		Users                    func(childComplexity int, params *model.ListUsersRequest) int
+		ValidateJwtToken         func(childComplexity int, params model.ValidateJWTTokenRequest) int
+		ValidateSession          func(childComplexity int, params *model.ValidateSessionRequest) int
+		VerificationRequests     func(childComplexity int, params *model.PaginatedRequest) int
+		WebauthnCredentials      func(childComplexity int) int
+		Webhook                  func(childComplexity int, params model.WebhookRequest) int
+		WebhookLogs              func(childComplexity int, params *model.ListWebhookLogRequest) int
+		Webhooks                 func(childComplexity int, params *model.PaginatedRequest) int
 	}
 
 	Response struct {
 		Message func(childComplexity int) int
+	}
+
+	SAMLIDPKey struct {
+		Algorithm func(childComplexity int) int
+		CertPem   func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		ID        func(childComplexity int) int
+		OrgID     func(childComplexity int) int
+		Status    func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+	}
+
+	SAMLSPMetadataParseResult struct {
+		AcsURL      func(childComplexity int) int
+		Certificate func(childComplexity int) int
+		EntityID    func(childComplexity int) int
+	}
+
+	SAMLServiceProvider struct {
+		AcsURL            func(childComplexity int) int
+		AllowIdpInitiated func(childComplexity int) int
+		CreatedAt         func(childComplexity int) int
+		EntityID          func(childComplexity int) int
+		ID                func(childComplexity int) int
+		IsActive          func(childComplexity int) int
+		MappedAttributes  func(childComplexity int) int
+		Name              func(childComplexity int) int
+		NameIDFormat      func(childComplexity int) int
+		OrgID             func(childComplexity int) int
+		SpCertPem         func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
+	}
+
+	SAMLServiceProviders struct {
+		Pagination           func(childComplexity int) int
+		SamlServiceProviders func(childComplexity int) int
 	}
 
 	ScimEndpoint struct {
@@ -711,6 +756,12 @@ type MutationResolver interface {
 	CreateOrgSamlConnection(ctx context.Context, params model.CreateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
 	UpdateOrgSamlConnection(ctx context.Context, params model.UpdateOrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
 	DeleteOrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.Response, error)
+	CreateSamlServiceProvider(ctx context.Context, params model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	UpdateSamlServiceProvider(ctx context.Context, params model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	DeleteSamlServiceProvider(ctx context.Context, params model.SAMLServiceProviderRequest) (*model.Response, error)
+	RotateSamlIdpCert(ctx context.Context, params model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, error)
+	RetireSamlIdpKey(ctx context.Context, params model.RetireSAMLIDPKeyRequest) (*model.Response, error)
+	ImportSamlSpMetadata(ctx context.Context, params model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, error)
 	CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error)
 	UpdateOrganization(ctx context.Context, params model.UpdateOrganizationRequest) (*model.Organization, error)
 	DeleteOrganization(ctx context.Context, params model.OrganizationRequest) (*model.Response, error)
@@ -755,6 +806,9 @@ type QueryResolver interface {
 	TrustedIssuers(ctx context.Context, params *model.ListTrustedIssuersRequest) (*model.TrustedIssuers, error)
 	OrgOidcConnection(ctx context.Context, params model.OrgOIDCConnectionRequest) (*model.OrgOIDCConnection, error)
 	OrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	SamlServiceProvider(ctx context.Context, params model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	ListSamlServiceProviders(ctx context.Context, params model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, error)
+	ListSamlIdpKeys(ctx context.Context, params model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, error)
 	Organization(ctx context.Context, params model.OrganizationRequest) (*model.Organization, error)
 	Organizations(ctx context.Context, params *model.ListOrganizationsRequest) (*model.Organizations, error)
 	OrgMembers(ctx context.Context, params model.ListOrgMembersRequest) (*model.OrgMembers, error)
@@ -2163,6 +2217,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateOrganization(childComplexity, args["params"].(model.CreateOrganizationRequest)), true
 
+	case "Mutation._create_saml_service_provider":
+		if e.complexity.Mutation.CreateSamlServiceProvider == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__create_saml_service_provider_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateSamlServiceProvider(childComplexity, args["params"].(model.CreateSAMLServiceProviderRequest)), true
+
 	case "Mutation._create_scim_endpoint":
 		if e.complexity.Mutation.CreateScimEndpoint == nil {
 			break
@@ -2253,6 +2319,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteOrganization(childComplexity, args["params"].(model.OrganizationRequest)), true
+
+	case "Mutation._delete_saml_service_provider":
+		if e.complexity.Mutation.DeleteSamlServiceProvider == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__delete_saml_service_provider_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteSamlServiceProvider(childComplexity, args["params"].(model.SAMLServiceProviderRequest)), true
 
 	case "Mutation._delete_scim_endpoint":
 		if e.complexity.Mutation.DeleteScimEndpoint == nil {
@@ -2393,6 +2471,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.GenerateJwtKeys(childComplexity, args["params"].(model.GenerateJWTKeysRequest)), true
 
+	case "Mutation._import_saml_sp_metadata":
+		if e.complexity.Mutation.ImportSamlSpMetadata == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__import_saml_sp_metadata_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ImportSamlSpMetadata(childComplexity, args["params"].(model.ImportSAMLSPMetadataRequest)), true
+
 	case "Mutation._invite_members":
 		if e.complexity.Mutation.InviteMembers == nil {
 			break
@@ -2532,6 +2622,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.ResetPassword(childComplexity, args["params"].(model.ResetPasswordRequest)), true
 
+	case "Mutation._retire_saml_idp_key":
+		if e.complexity.Mutation.RetireSamlIdpKey == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__retire_saml_idp_key_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RetireSamlIdpKey(childComplexity, args["params"].(model.RetireSAMLIDPKeyRequest)), true
+
 	case "Mutation.revoke":
 		if e.complexity.Mutation.Revoke == nil {
 			break
@@ -2567,6 +2669,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.RotateClientSecret(childComplexity, args["params"].(model.ClientRequest)), true
+
+	case "Mutation._rotate_saml_idp_cert":
+		if e.complexity.Mutation.RotateSamlIdpCert == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__rotate_saml_idp_cert_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RotateSamlIdpCert(childComplexity, args["params"].(model.RotateSAMLIDPCertRequest)), true
 
 	case "Mutation._rotate_scim_token":
 		if e.complexity.Mutation.RotateScimToken == nil {
@@ -2723,6 +2837,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateProfile(childComplexity, args["params"].(model.UpdateProfileRequest)), true
+
+	case "Mutation._update_saml_service_provider":
+		if e.complexity.Mutation.UpdateSamlServiceProvider == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation__update_saml_service_provider_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateSamlServiceProvider(childComplexity, args["params"].(model.UpdateSAMLServiceProviderRequest)), true
 
 	case "Mutation._update_trusted_issuer":
 		if e.complexity.Mutation.UpdateTrustedIssuer == nil {
@@ -3419,6 +3545,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.ListPermissions(childComplexity, args["params"].(model.ListPermissionsInput)), true
 
+	case "Query._list_saml_idp_keys":
+		if e.complexity.Query.ListSamlIdpKeys == nil {
+			break
+		}
+
+		args, err := ec.field_Query__list_saml_idp_keys_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ListSamlIdpKeys(childComplexity, args["params"].(model.ListSAMLIDPKeysRequest)), true
+
+	case "Query._list_saml_service_providers":
+		if e.complexity.Query.ListSamlServiceProviders == nil {
+			break
+		}
+
+		args, err := ec.field_Query__list_saml_service_providers_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ListSamlServiceProviders(childComplexity, args["params"].(model.ListSAMLServiceProvidersRequest)), true
+
 	case "Query.meta":
 		if e.complexity.Query.Meta == nil {
 			break
@@ -3504,6 +3654,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Profile(childComplexity), true
+
+	case "Query._saml_service_provider":
+		if e.complexity.Query.SamlServiceProvider == nil {
+			break
+		}
+
+		args, err := ec.field_Query__saml_service_provider_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SamlServiceProvider(childComplexity, args["params"].(model.SAMLServiceProviderRequest)), true
 
 	case "Query._scim_endpoint":
 		if e.complexity.Query.ScimEndpoint == nil {
@@ -3674,6 +3836,174 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Response.Message(childComplexity), true
+
+	case "SAMLIDPKey.algorithm":
+		if e.complexity.SAMLIDPKey.Algorithm == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.Algorithm(childComplexity), true
+
+	case "SAMLIDPKey.cert_pem":
+		if e.complexity.SAMLIDPKey.CertPem == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.CertPem(childComplexity), true
+
+	case "SAMLIDPKey.created_at":
+		if e.complexity.SAMLIDPKey.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.CreatedAt(childComplexity), true
+
+	case "SAMLIDPKey.id":
+		if e.complexity.SAMLIDPKey.ID == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.ID(childComplexity), true
+
+	case "SAMLIDPKey.org_id":
+		if e.complexity.SAMLIDPKey.OrgID == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.OrgID(childComplexity), true
+
+	case "SAMLIDPKey.status":
+		if e.complexity.SAMLIDPKey.Status == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.Status(childComplexity), true
+
+	case "SAMLIDPKey.updated_at":
+		if e.complexity.SAMLIDPKey.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.SAMLIDPKey.UpdatedAt(childComplexity), true
+
+	case "SAMLSPMetadataParseResult.acs_url":
+		if e.complexity.SAMLSPMetadataParseResult.AcsURL == nil {
+			break
+		}
+
+		return e.complexity.SAMLSPMetadataParseResult.AcsURL(childComplexity), true
+
+	case "SAMLSPMetadataParseResult.certificate":
+		if e.complexity.SAMLSPMetadataParseResult.Certificate == nil {
+			break
+		}
+
+		return e.complexity.SAMLSPMetadataParseResult.Certificate(childComplexity), true
+
+	case "SAMLSPMetadataParseResult.entity_id":
+		if e.complexity.SAMLSPMetadataParseResult.EntityID == nil {
+			break
+		}
+
+		return e.complexity.SAMLSPMetadataParseResult.EntityID(childComplexity), true
+
+	case "SAMLServiceProvider.acs_url":
+		if e.complexity.SAMLServiceProvider.AcsURL == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.AcsURL(childComplexity), true
+
+	case "SAMLServiceProvider.allow_idp_initiated":
+		if e.complexity.SAMLServiceProvider.AllowIdpInitiated == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.AllowIdpInitiated(childComplexity), true
+
+	case "SAMLServiceProvider.created_at":
+		if e.complexity.SAMLServiceProvider.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.CreatedAt(childComplexity), true
+
+	case "SAMLServiceProvider.entity_id":
+		if e.complexity.SAMLServiceProvider.EntityID == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.EntityID(childComplexity), true
+
+	case "SAMLServiceProvider.id":
+		if e.complexity.SAMLServiceProvider.ID == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.ID(childComplexity), true
+
+	case "SAMLServiceProvider.is_active":
+		if e.complexity.SAMLServiceProvider.IsActive == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.IsActive(childComplexity), true
+
+	case "SAMLServiceProvider.mapped_attributes":
+		if e.complexity.SAMLServiceProvider.MappedAttributes == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.MappedAttributes(childComplexity), true
+
+	case "SAMLServiceProvider.name":
+		if e.complexity.SAMLServiceProvider.Name == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.Name(childComplexity), true
+
+	case "SAMLServiceProvider.name_id_format":
+		if e.complexity.SAMLServiceProvider.NameIDFormat == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.NameIDFormat(childComplexity), true
+
+	case "SAMLServiceProvider.org_id":
+		if e.complexity.SAMLServiceProvider.OrgID == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.OrgID(childComplexity), true
+
+	case "SAMLServiceProvider.sp_cert_pem":
+		if e.complexity.SAMLServiceProvider.SpCertPem == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.SpCertPem(childComplexity), true
+
+	case "SAMLServiceProvider.updated_at":
+		if e.complexity.SAMLServiceProvider.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProvider.UpdatedAt(childComplexity), true
+
+	case "SAMLServiceProviders.pagination":
+		if e.complexity.SAMLServiceProviders.Pagination == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProviders.Pagination(childComplexity), true
+
+	case "SAMLServiceProviders.saml_service_providers":
+		if e.complexity.SAMLServiceProviders.SamlServiceProviders == nil {
+			break
+		}
+
+		return e.complexity.SAMLServiceProviders.SamlServiceProviders(childComplexity), true
 
 	case "ScimEndpoint.created_at":
 		if e.complexity.ScimEndpoint.CreatedAt == nil {
@@ -4368,6 +4698,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateOrgOIDCConnectionRequest,
 		ec.unmarshalInputCreateOrgSAMLConnectionRequest,
 		ec.unmarshalInputCreateOrganizationRequest,
+		ec.unmarshalInputCreateSAMLServiceProviderRequest,
 		ec.unmarshalInputCreateScimEndpointRequest,
 		ec.unmarshalInputDeleteEmailTemplateRequest,
 		ec.unmarshalInputDeleteOrgDomainRequest,
@@ -4382,6 +4713,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputForgotPasswordRequest,
 		ec.unmarshalInputGenerateJWTKeysRequest,
 		ec.unmarshalInputGetUserRequest,
+		ec.unmarshalInputImportSAMLSPMetadataRequest,
 		ec.unmarshalInputInviteMemberRequest,
 		ec.unmarshalInputListAuditLogRequest,
 		ec.unmarshalInputListClientsRequest,
@@ -4389,6 +4721,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputListOrgMembersRequest,
 		ec.unmarshalInputListOrganizationsRequest,
 		ec.unmarshalInputListPermissionsInput,
+		ec.unmarshalInputListSAMLIDPKeysRequest,
+		ec.unmarshalInputListSAMLServiceProvidersRequest,
 		ec.unmarshalInputListTrustedIssuersRequest,
 		ec.unmarshalInputListUsersRequest,
 		ec.unmarshalInputListWebhookLogRequest,
@@ -4410,6 +4744,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputResendOTPRequest,
 		ec.unmarshalInputResendVerifyEmailRequest,
 		ec.unmarshalInputResetPasswordRequest,
+		ec.unmarshalInputRetireSAMLIDPKeyRequest,
+		ec.unmarshalInputRotateSAMLIDPCertRequest,
+		ec.unmarshalInputSAMLServiceProviderRequest,
 		ec.unmarshalInputScimEndpointRequest,
 		ec.unmarshalInputSessionQueryRequest,
 		ec.unmarshalInputSignUpRequest,
@@ -4424,6 +4761,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateOrgSAMLConnectionRequest,
 		ec.unmarshalInputUpdateOrganizationRequest,
 		ec.unmarshalInputUpdateProfileRequest,
+		ec.unmarshalInputUpdateSAMLServiceProviderRequest,
 		ec.unmarshalInputUpdateTrustedIssuerRequest,
 		ec.unmarshalInputUpdateUserRequest,
 		ec.unmarshalInputUpdateWebhookRequest,
@@ -5039,6 +5377,58 @@ type OrgSAMLConnection {
   is_active: Boolean!
   created_at: Int64
   updated_at: Int64
+}
+
+# SAMLServiceProvider is a downstream SAML 2.0 SP that Authorizer (acting as the
+# IdP) issues signed assertions to. This is the inverse of OrgSAMLConnection.
+type SAMLServiceProvider {
+  id: ID!
+  org_id: String!
+  name: String!
+  # entity_id: the SP entity ID (the AuthnRequest Issuer and assertion Audience).
+  entity_id: String!
+  # acs_url: the SP Assertion Consumer Service URL — the only place assertions are
+  # POSTed. Never taken from the request.
+  acs_url: String!
+  # sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+  sp_cert_pem: String
+  # name_id_format: SAML NameID format for the Subject (default emailAddress).
+  name_id_format: String
+  # mapped_attributes: JSON mapping profile fields to emitted SAML attribute names.
+  mapped_attributes: String
+  # allow_idp_initiated: whether unsolicited IdP-initiated SSO is permitted.
+  allow_idp_initiated: Boolean!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type SAMLServiceProviders {
+  pagination: Pagination!
+  saml_service_providers: [SAMLServiceProvider!]!
+}
+
+# SAMLIDPKey is a per-org SAML IdP signing keypair. The private key is NEVER
+# projected — only the certificate and rotation status.
+type SAMLIDPKey {
+  id: ID!
+  org_id: String!
+  # cert_pem: the self-signed X.509 signing certificate (PEM), pinned by SPs.
+  cert_pem: String!
+  algorithm: String!
+  # status: "current" (signs new assertions), "active" (published in metadata,
+  # not signing), or "retired" (neither).
+  status: String!
+  created_at: Int64
+  updated_at: Int64
+}
+
+# SAMLSPMetadataParseResult is the parsed output of _import_saml_sp_metadata. It
+# does NOT create a record — it returns fields to prefill a create call.
+type SAMLSPMetadataParseResult {
+  entity_id: String!
+  acs_url: String!
+  certificate: String
 }
 
 type Organization {
@@ -5678,6 +6068,65 @@ input OrgSAMLConnectionRequest {
   org_id: String
 }
 
+# --- SAML IdP: registered downstream service providers ---
+
+input CreateSAMLServiceProviderRequest {
+  org_id: String!
+  name: String!
+  # entity_id: the SP entity ID (unique within the org).
+  entity_id: String!
+  # acs_url: the SP Assertion Consumer Service URL (https recommended).
+  acs_url: String!
+  # sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+  sp_cert_pem: String
+  # name_id_format: default urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress.
+  name_id_format: String
+  # mapped_attributes: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  mapped_attributes: String
+  # allow_idp_initiated: default false (SP-initiated only).
+  allow_idp_initiated: Boolean
+}
+
+input UpdateSAMLServiceProviderRequest {
+  id: ID!
+  name: String
+  entity_id: String
+  acs_url: String
+  sp_cert_pem: String
+  name_id_format: String
+  mapped_attributes: String
+  allow_idp_initiated: Boolean
+  is_active: Boolean
+}
+
+input SAMLServiceProviderRequest {
+  id: ID!
+}
+
+input ListSAMLServiceProvidersRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
+# --- SAML IdP: signing key rotation & SP-metadata import ---
+
+input RotateSAMLIDPCertRequest {
+  org_id: String!
+}
+
+input RetireSAMLIDPKeyRequest {
+  id: ID!
+}
+
+input ListSAMLIDPKeysRequest {
+  org_id: String!
+}
+
+input ImportSAMLSPMetadataRequest {
+  # metadata_xml: pasted SP metadata XML (NOT a URL — no remote fetch).
+  metadata_xml: String!
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -6025,6 +6474,20 @@ type Mutation {
   _create_org_saml_connection(params: CreateOrgSAMLConnectionRequest!): OrgSAMLConnection!
   _update_org_saml_connection(params: UpdateOrgSAMLConnectionRequest!): OrgSAMLConnection!
   _delete_org_saml_connection(params: OrgSAMLConnectionRequest!): Response!
+  # Per-organization SAML IdP: registered downstream SPs, signing-key rotation,
+  # and SP-metadata import (Authorizer as Identity Provider).
+  _create_saml_service_provider(params: CreateSAMLServiceProviderRequest!): SAMLServiceProvider!
+  _update_saml_service_provider(params: UpdateSAMLServiceProviderRequest!): SAMLServiceProvider!
+  _delete_saml_service_provider(params: SAMLServiceProviderRequest!): Response!
+  # _rotate_saml_idp_cert generates a new signing keypair (becomes "current");
+  # the previously-current key stays "active" (still published) until retired.
+  _rotate_saml_idp_cert(params: RotateSAMLIDPCertRequest!): SAMLIDPKey!
+  # _retire_saml_idp_key retires a published-but-superseded key so it stops
+  # appearing in IdP metadata. Cannot retire the current key.
+  _retire_saml_idp_key(params: RetireSAMLIDPKeyRequest!): Response!
+  # _import_saml_sp_metadata parses pasted SP metadata XML and returns the
+  # extracted entity_id / acs_url / certificate. It does NOT create a record.
+  _import_saml_sp_metadata(params: ImportSAMLSPMetadataRequest!): SAMLSPMetadataParseResult!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -6085,6 +6548,10 @@ type Query {
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
   _org_saml_connection(params: OrgSAMLConnectionRequest!): OrgSAMLConnection!
+  # Per-organization SAML IdP admin reads.
+  _saml_service_provider(params: SAMLServiceProviderRequest!): SAMLServiceProvider!
+  _list_saml_service_providers(params: ListSAMLServiceProvidersRequest!): SAMLServiceProviders!
+  _list_saml_idp_keys(params: ListSAMLIDPKeysRequest!): [SAMLIDPKey!]!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!
@@ -6420,6 +6887,34 @@ func (ec *executionContext) field_Mutation__create_organization_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__create_saml_service_provider_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__create_saml_service_provider_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__create_saml_service_provider_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CreateSAMLServiceProviderRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.CreateSAMLServiceProviderRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNCreateSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateSAMLServiceProviderRequest(ctx, tmp)
+	}
+
+	var zeroVal model.CreateSAMLServiceProviderRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__create_scim_endpoint_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6613,6 +7108,34 @@ func (ec *executionContext) field_Mutation__delete_organization_argsParams(
 	}
 
 	var zeroVal model.OrganizationRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__delete_saml_service_provider_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__delete_saml_service_provider_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__delete_saml_service_provider_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.SAMLServiceProviderRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.SAMLServiceProviderRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviderRequest(ctx, tmp)
+	}
+
+	var zeroVal model.SAMLServiceProviderRequest
 	return zeroVal, nil
 }
 
@@ -6868,6 +7391,34 @@ func (ec *executionContext) field_Mutation__generate_jwt_keys_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__import_saml_sp_metadata_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__import_saml_sp_metadata_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__import_saml_sp_metadata_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ImportSAMLSPMetadataRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ImportSAMLSPMetadataRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNImportSAMLSPMetadataRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐImportSAMLSPMetadataRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ImportSAMLSPMetadataRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__invite_members_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6952,6 +7503,34 @@ func (ec *executionContext) field_Mutation__request_org_domain_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation__retire_saml_idp_key_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__retire_saml_idp_key_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__retire_saml_idp_key_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.RetireSAMLIDPKeyRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.RetireSAMLIDPKeyRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNRetireSAMLIDPKeyRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRetireSAMLIDPKeyRequest(ctx, tmp)
+	}
+
+	var zeroVal model.RetireSAMLIDPKeyRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation__revoke_access_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -7005,6 +7584,34 @@ func (ec *executionContext) field_Mutation__rotate_client_secret_argsParams(
 	}
 
 	var zeroVal model.ClientRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__rotate_saml_idp_cert_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__rotate_saml_idp_cert_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__rotate_saml_idp_cert_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.RotateSAMLIDPCertRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.RotateSAMLIDPCertRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNRotateSAMLIDPCertRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRotateSAMLIDPCertRequest(ctx, tmp)
+	}
+
+	var zeroVal model.RotateSAMLIDPCertRequest
 	return zeroVal, nil
 }
 
@@ -7229,6 +7836,34 @@ func (ec *executionContext) field_Mutation__update_organization_argsParams(
 	}
 
 	var zeroVal model.UpdateOrganizationRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation__update_saml_service_provider_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation__update_saml_service_provider_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation__update_saml_service_provider_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UpdateSAMLServiceProviderRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.UpdateSAMLServiceProviderRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNUpdateSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateSAMLServiceProviderRequest(ctx, tmp)
+	}
+
+	var zeroVal model.UpdateSAMLServiceProviderRequest
 	return zeroVal, nil
 }
 
@@ -8235,6 +8870,62 @@ func (ec *executionContext) field_Query__fga_read_tuples_argsParams(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query__list_saml_idp_keys_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__list_saml_idp_keys_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__list_saml_idp_keys_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ListSAMLIDPKeysRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ListSAMLIDPKeysRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNListSAMLIDPKeysRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListSAMLIDPKeysRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ListSAMLIDPKeysRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__list_saml_service_providers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__list_saml_service_providers_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__list_saml_service_providers_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.ListSAMLServiceProvidersRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.ListSAMLServiceProvidersRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNListSAMLServiceProvidersRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListSAMLServiceProvidersRequest(ctx, tmp)
+	}
+
+	var zeroVal model.ListSAMLServiceProvidersRequest
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query__org_domains_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -8400,6 +9091,34 @@ func (ec *executionContext) field_Query__organizations_argsParams(
 	}
 
 	var zeroVal *model.ListOrganizationsRequest
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query__saml_service_provider_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query__saml_service_provider_argsParams(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["params"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query__saml_service_provider_argsParams(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.SAMLServiceProviderRequest, error) {
+	if _, ok := rawArgs["params"]; !ok {
+		var zeroVal model.SAMLServiceProviderRequest
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+	if tmp, ok := rawArgs["params"]; ok {
+		return ec.unmarshalNSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviderRequest(ctx, tmp)
+	}
+
+	var zeroVal model.SAMLServiceProviderRequest
 	return zeroVal, nil
 }
 
@@ -20159,6 +20878,420 @@ func (ec *executionContext) fieldContext_Mutation__delete_org_saml_connection(ct
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation__create_saml_service_provider(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__create_saml_service_provider(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateSamlServiceProvider(rctx, fc.Args["params"].(model.CreateSAMLServiceProviderRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLServiceProvider)
+	fc.Result = res
+	return ec.marshalNSAMLServiceProvider2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__create_saml_service_provider(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLServiceProvider_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLServiceProvider_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SAMLServiceProvider_name(ctx, field)
+			case "entity_id":
+				return ec.fieldContext_SAMLServiceProvider_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_SAMLServiceProvider_acs_url(ctx, field)
+			case "sp_cert_pem":
+				return ec.fieldContext_SAMLServiceProvider_sp_cert_pem(ctx, field)
+			case "name_id_format":
+				return ec.fieldContext_SAMLServiceProvider_name_id_format(ctx, field)
+			case "mapped_attributes":
+				return ec.fieldContext_SAMLServiceProvider_mapped_attributes(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_SAMLServiceProvider_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_SAMLServiceProvider_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLServiceProvider_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLServiceProvider_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLServiceProvider", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__create_saml_service_provider_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__update_saml_service_provider(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__update_saml_service_provider(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateSamlServiceProvider(rctx, fc.Args["params"].(model.UpdateSAMLServiceProviderRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLServiceProvider)
+	fc.Result = res
+	return ec.marshalNSAMLServiceProvider2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__update_saml_service_provider(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLServiceProvider_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLServiceProvider_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SAMLServiceProvider_name(ctx, field)
+			case "entity_id":
+				return ec.fieldContext_SAMLServiceProvider_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_SAMLServiceProvider_acs_url(ctx, field)
+			case "sp_cert_pem":
+				return ec.fieldContext_SAMLServiceProvider_sp_cert_pem(ctx, field)
+			case "name_id_format":
+				return ec.fieldContext_SAMLServiceProvider_name_id_format(ctx, field)
+			case "mapped_attributes":
+				return ec.fieldContext_SAMLServiceProvider_mapped_attributes(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_SAMLServiceProvider_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_SAMLServiceProvider_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLServiceProvider_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLServiceProvider_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLServiceProvider", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__update_saml_service_provider_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__delete_saml_service_provider(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__delete_saml_service_provider(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteSamlServiceProvider(rctx, fc.Args["params"].(model.SAMLServiceProviderRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__delete_saml_service_provider(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__delete_saml_service_provider_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__rotate_saml_idp_cert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__rotate_saml_idp_cert(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RotateSamlIdpCert(rctx, fc.Args["params"].(model.RotateSAMLIDPCertRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLIDPKey)
+	fc.Result = res
+	return ec.marshalNSAMLIDPKey2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__rotate_saml_idp_cert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLIDPKey_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLIDPKey_org_id(ctx, field)
+			case "cert_pem":
+				return ec.fieldContext_SAMLIDPKey_cert_pem(ctx, field)
+			case "algorithm":
+				return ec.fieldContext_SAMLIDPKey_algorithm(ctx, field)
+			case "status":
+				return ec.fieldContext_SAMLIDPKey_status(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLIDPKey_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLIDPKey_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLIDPKey", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__rotate_saml_idp_cert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__retire_saml_idp_key(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__retire_saml_idp_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RetireSamlIdpKey(rctx, fc.Args["params"].(model.RetireSAMLIDPKeyRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Response)
+	fc.Result = res
+	return ec.marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__retire_saml_idp_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "message":
+				return ec.fieldContext_Response_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Response", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__retire_saml_idp_key_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation__import_saml_sp_metadata(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation__import_saml_sp_metadata(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ImportSamlSpMetadata(rctx, fc.Args["params"].(model.ImportSAMLSPMetadataRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLSPMetadataParseResult)
+	fc.Result = res
+	return ec.marshalNSAMLSPMetadataParseResult2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLSPMetadataParseResult(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation__import_saml_sp_metadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "entity_id":
+				return ec.fieldContext_SAMLSPMetadataParseResult_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_SAMLSPMetadataParseResult_acs_url(ctx, field)
+			case "certificate":
+				return ec.fieldContext_SAMLSPMetadataParseResult_certificate(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLSPMetadataParseResult", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation__import_saml_sp_metadata_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation__create_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation__create_organization(ctx, field)
 	if err != nil {
@@ -25765,6 +26898,219 @@ func (ec *executionContext) fieldContext_Query__org_saml_connection(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Query__saml_service_provider(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__saml_service_provider(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SamlServiceProvider(rctx, fc.Args["params"].(model.SAMLServiceProviderRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLServiceProvider)
+	fc.Result = res
+	return ec.marshalNSAMLServiceProvider2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__saml_service_provider(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLServiceProvider_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLServiceProvider_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SAMLServiceProvider_name(ctx, field)
+			case "entity_id":
+				return ec.fieldContext_SAMLServiceProvider_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_SAMLServiceProvider_acs_url(ctx, field)
+			case "sp_cert_pem":
+				return ec.fieldContext_SAMLServiceProvider_sp_cert_pem(ctx, field)
+			case "name_id_format":
+				return ec.fieldContext_SAMLServiceProvider_name_id_format(ctx, field)
+			case "mapped_attributes":
+				return ec.fieldContext_SAMLServiceProvider_mapped_attributes(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_SAMLServiceProvider_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_SAMLServiceProvider_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLServiceProvider_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLServiceProvider_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLServiceProvider", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__saml_service_provider_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__list_saml_service_providers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__list_saml_service_providers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ListSamlServiceProviders(rctx, fc.Args["params"].(model.ListSAMLServiceProvidersRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SAMLServiceProviders)
+	fc.Result = res
+	return ec.marshalNSAMLServiceProviders2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviders(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__list_saml_service_providers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pagination":
+				return ec.fieldContext_SAMLServiceProviders_pagination(ctx, field)
+			case "saml_service_providers":
+				return ec.fieldContext_SAMLServiceProviders_saml_service_providers(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLServiceProviders", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__list_saml_service_providers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query__list_saml_idp_keys(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query__list_saml_idp_keys(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ListSamlIdpKeys(rctx, fc.Args["params"].(model.ListSAMLIDPKeysRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SAMLIDPKey)
+	fc.Result = res
+	return ec.marshalNSAMLIDPKey2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKeyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query__list_saml_idp_keys(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLIDPKey_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLIDPKey_org_id(ctx, field)
+			case "cert_pem":
+				return ec.fieldContext_SAMLIDPKey_cert_pem(ctx, field)
+			case "algorithm":
+				return ec.fieldContext_SAMLIDPKey_algorithm(ctx, field)
+			case "status":
+				return ec.fieldContext_SAMLIDPKey_status(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLIDPKey_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLIDPKey_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLIDPKey", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query__list_saml_idp_keys_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query__organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query__organization(ctx, field)
 	if err != nil {
@@ -26727,6 +28073,1074 @@ func (ec *executionContext) fieldContext_Response_message(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_org_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_cert_pem(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_cert_pem(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CertPem, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_cert_pem(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_algorithm(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_algorithm(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Algorithm, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_algorithm(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_status(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_created_at(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLIDPKey_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.SAMLIDPKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLIDPKey_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLIDPKey_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLIDPKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLSPMetadataParseResult_entity_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLSPMetadataParseResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLSPMetadataParseResult_entity_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EntityID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLSPMetadataParseResult_entity_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLSPMetadataParseResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLSPMetadataParseResult_acs_url(ctx context.Context, field graphql.CollectedField, obj *model.SAMLSPMetadataParseResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLSPMetadataParseResult_acs_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AcsURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLSPMetadataParseResult_acs_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLSPMetadataParseResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLSPMetadataParseResult_certificate(ctx context.Context, field graphql.CollectedField, obj *model.SAMLSPMetadataParseResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLSPMetadataParseResult_certificate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Certificate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLSPMetadataParseResult_certificate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLSPMetadataParseResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_org_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_org_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OrgID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_org_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_name(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_entity_id(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_entity_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EntityID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_entity_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_acs_url(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_acs_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AcsURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_acs_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_sp_cert_pem(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_sp_cert_pem(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpCertPem, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_sp_cert_pem(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_name_id_format(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_name_id_format(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NameIDFormat, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_name_id_format(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_mapped_attributes(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_mapped_attributes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MappedAttributes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_mapped_attributes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_allow_idp_initiated(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_allow_idp_initiated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllowIdpInitiated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_allow_idp_initiated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_is_active(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_is_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_is_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_created_at(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProvider_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProvider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProvider_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt642ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProvider_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProviders_pagination(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProviders) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProviders_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Pagination)
+	fc.Result = res
+	return ec.marshalNPagination2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProviders_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProviders",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_Pagination_limit(ctx, field)
+			case "page":
+				return ec.fieldContext_Pagination_page(ctx, field)
+			case "offset":
+				return ec.fieldContext_Pagination_offset(ctx, field)
+			case "total":
+				return ec.fieldContext_Pagination_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Pagination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SAMLServiceProviders_saml_service_providers(ctx context.Context, field graphql.CollectedField, obj *model.SAMLServiceProviders) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SAMLServiceProviders_saml_service_providers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SamlServiceProviders, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SAMLServiceProvider)
+	fc.Result = res
+	return ec.marshalNSAMLServiceProvider2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviderᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SAMLServiceProviders_saml_service_providers(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SAMLServiceProviders",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SAMLServiceProvider_id(ctx, field)
+			case "org_id":
+				return ec.fieldContext_SAMLServiceProvider_org_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SAMLServiceProvider_name(ctx, field)
+			case "entity_id":
+				return ec.fieldContext_SAMLServiceProvider_entity_id(ctx, field)
+			case "acs_url":
+				return ec.fieldContext_SAMLServiceProvider_acs_url(ctx, field)
+			case "sp_cert_pem":
+				return ec.fieldContext_SAMLServiceProvider_sp_cert_pem(ctx, field)
+			case "name_id_format":
+				return ec.fieldContext_SAMLServiceProvider_name_id_format(ctx, field)
+			case "mapped_attributes":
+				return ec.fieldContext_SAMLServiceProvider_mapped_attributes(ctx, field)
+			case "allow_idp_initiated":
+				return ec.fieldContext_SAMLServiceProvider_allow_idp_initiated(ctx, field)
+			case "is_active":
+				return ec.fieldContext_SAMLServiceProvider_is_active(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SAMLServiceProvider_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SAMLServiceProvider_updated_at(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SAMLServiceProvider", field.Name)
 		},
 	}
 	return fc, nil
@@ -33636,6 +36050,82 @@ func (ec *executionContext) unmarshalInputCreateOrganizationRequest(ctx context.
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateSAMLServiceProviderRequest(ctx context.Context, obj any) (model.CreateSAMLServiceProviderRequest, error) {
+	var it model.CreateSAMLServiceProviderRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "name", "entity_id", "acs_url", "sp_cert_pem", "name_id_format", "mapped_attributes", "allow_idp_initiated"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("entity_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EntityID = data
+		case "acs_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("acs_url"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AcsURL = data
+		case "sp_cert_pem":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sp_cert_pem"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpCertPem = data
+		case "name_id_format":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name_id_format"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NameIDFormat = data
+		case "mapped_attributes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mapped_attributes"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MappedAttributes = data
+		case "allow_idp_initiated":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_idp_initiated"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowIdpInitiated = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateScimEndpointRequest(ctx context.Context, obj any) (model.CreateScimEndpointRequest, error) {
 	var it model.CreateScimEndpointRequest
 	asMap := map[string]any{}
@@ -34112,6 +36602,33 @@ func (ec *executionContext) unmarshalInputGetUserRequest(ctx context.Context, ob
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputImportSAMLSPMetadataRequest(ctx context.Context, obj any) (model.ImportSAMLSPMetadataRequest, error) {
+	var it model.ImportSAMLSPMetadataRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"metadata_xml"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "metadata_xml":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metadata_xml"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MetadataXML = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputInviteMemberRequest(ctx context.Context, obj any) (model.InviteMemberRequest, error) {
 	var it model.InviteMemberRequest
 	asMap := map[string]any{}
@@ -34372,6 +36889,67 @@ func (ec *executionContext) unmarshalInputListPermissionsInput(ctx context.Conte
 				return it, err
 			}
 			it.User = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListSAMLIDPKeysRequest(ctx context.Context, obj any) (model.ListSAMLIDPKeysRequest, error) {
+	var it model.ListSAMLIDPKeysRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputListSAMLServiceProvidersRequest(ctx context.Context, obj any) (model.ListSAMLServiceProvidersRequest, error) {
+	var it model.ListSAMLServiceProvidersRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id", "pagination"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		case "pagination":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pagination"))
+			data, err := ec.unmarshalOPaginatedRequest2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐPaginatedRequest(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Pagination = data
 		}
 	}
 
@@ -35282,6 +37860,87 @@ func (ec *executionContext) unmarshalInputResetPasswordRequest(ctx context.Conte
 				return it, err
 			}
 			it.ConfirmPassword = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRetireSAMLIDPKeyRequest(ctx context.Context, obj any) (model.RetireSAMLIDPKeyRequest, error) {
+	var it model.RetireSAMLIDPKeyRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRotateSAMLIDPCertRequest(ctx context.Context, obj any) (model.RotateSAMLIDPCertRequest, error) {
+	var it model.RotateSAMLIDPCertRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"org_id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "org_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("org_id"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrgID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputSAMLServiceProviderRequest(ctx context.Context, obj any) (model.SAMLServiceProviderRequest, error) {
+	var it model.SAMLServiceProviderRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
 		}
 	}
 
@@ -36535,6 +39194,89 @@ func (ec *executionContext) unmarshalInputUpdateProfileRequest(ctx context.Conte
 				return it, err
 			}
 			it.AppData = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateSAMLServiceProviderRequest(ctx context.Context, obj any) (model.UpdateSAMLServiceProviderRequest, error) {
+	var it model.UpdateSAMLServiceProviderRequest
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "entity_id", "acs_url", "sp_cert_pem", "name_id_format", "mapped_attributes", "allow_idp_initiated", "is_active"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "entity_id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("entity_id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EntityID = data
+		case "acs_url":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("acs_url"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AcsURL = data
+		case "sp_cert_pem":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sp_cert_pem"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpCertPem = data
+		case "name_id_format":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name_id_format"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NameIDFormat = data
+		case "mapped_attributes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mapped_attributes"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MappedAttributes = data
+		case "allow_idp_initiated":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_idp_initiated"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowIdpInitiated = data
+		case "is_active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsActive = data
 		}
 	}
 
@@ -38956,6 +41698,48 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "_create_saml_service_provider":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__create_saml_service_provider(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_update_saml_service_provider":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__update_saml_service_provider(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_delete_saml_service_provider":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__delete_saml_service_provider(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_rotate_saml_idp_cert":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__rotate_saml_idp_cert(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_retire_saml_idp_key":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__retire_saml_idp_key(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "_import_saml_sp_metadata":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation__import_saml_sp_metadata(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "_create_organization":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation__create_organization(ctx, field)
@@ -40272,6 +43056,72 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_saml_service_provider":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__saml_service_provider(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_list_saml_service_providers":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__list_saml_service_providers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "_list_saml_idp_keys":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query__list_saml_idp_keys(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "_organization":
 			field := field
 
@@ -40602,6 +43452,238 @@ func (ec *executionContext) _Response(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("Response")
 		case "message":
 			out.Values[i] = ec._Response_message(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sAMLIDPKeyImplementors = []string{"SAMLIDPKey"}
+
+func (ec *executionContext) _SAMLIDPKey(ctx context.Context, sel ast.SelectionSet, obj *model.SAMLIDPKey) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sAMLIDPKeyImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SAMLIDPKey")
+		case "id":
+			out.Values[i] = ec._SAMLIDPKey_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._SAMLIDPKey_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cert_pem":
+			out.Values[i] = ec._SAMLIDPKey_cert_pem(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "algorithm":
+			out.Values[i] = ec._SAMLIDPKey_algorithm(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "status":
+			out.Values[i] = ec._SAMLIDPKey_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._SAMLIDPKey_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._SAMLIDPKey_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sAMLSPMetadataParseResultImplementors = []string{"SAMLSPMetadataParseResult"}
+
+func (ec *executionContext) _SAMLSPMetadataParseResult(ctx context.Context, sel ast.SelectionSet, obj *model.SAMLSPMetadataParseResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sAMLSPMetadataParseResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SAMLSPMetadataParseResult")
+		case "entity_id":
+			out.Values[i] = ec._SAMLSPMetadataParseResult_entity_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "acs_url":
+			out.Values[i] = ec._SAMLSPMetadataParseResult_acs_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "certificate":
+			out.Values[i] = ec._SAMLSPMetadataParseResult_certificate(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sAMLServiceProviderImplementors = []string{"SAMLServiceProvider"}
+
+func (ec *executionContext) _SAMLServiceProvider(ctx context.Context, sel ast.SelectionSet, obj *model.SAMLServiceProvider) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sAMLServiceProviderImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SAMLServiceProvider")
+		case "id":
+			out.Values[i] = ec._SAMLServiceProvider_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "org_id":
+			out.Values[i] = ec._SAMLServiceProvider_org_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._SAMLServiceProvider_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "entity_id":
+			out.Values[i] = ec._SAMLServiceProvider_entity_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "acs_url":
+			out.Values[i] = ec._SAMLServiceProvider_acs_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sp_cert_pem":
+			out.Values[i] = ec._SAMLServiceProvider_sp_cert_pem(ctx, field, obj)
+		case "name_id_format":
+			out.Values[i] = ec._SAMLServiceProvider_name_id_format(ctx, field, obj)
+		case "mapped_attributes":
+			out.Values[i] = ec._SAMLServiceProvider_mapped_attributes(ctx, field, obj)
+		case "allow_idp_initiated":
+			out.Values[i] = ec._SAMLServiceProvider_allow_idp_initiated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "is_active":
+			out.Values[i] = ec._SAMLServiceProvider_is_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "created_at":
+			out.Values[i] = ec._SAMLServiceProvider_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._SAMLServiceProvider_updated_at(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sAMLServiceProvidersImplementors = []string{"SAMLServiceProviders"}
+
+func (ec *executionContext) _SAMLServiceProviders(ctx context.Context, sel ast.SelectionSet, obj *model.SAMLServiceProviders) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sAMLServiceProvidersImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SAMLServiceProviders")
+		case "pagination":
+			out.Values[i] = ec._SAMLServiceProviders_pagination(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "saml_service_providers":
+			out.Values[i] = ec._SAMLServiceProviders_saml_service_providers(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -42238,6 +45320,11 @@ func (ec *executionContext) unmarshalNCreateOrganizationRequest2githubᚗcomᚋa
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNCreateSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateSAMLServiceProviderRequest(ctx context.Context, v any) (model.CreateSAMLServiceProviderRequest, error) {
+	res, err := ec.unmarshalInputCreateSAMLServiceProviderRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateScimEndpointRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐCreateScimEndpointRequest(ctx context.Context, v any) (model.CreateScimEndpointRequest, error) {
 	res, err := ec.unmarshalInputCreateScimEndpointRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -42573,6 +45660,11 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) unmarshalNImportSAMLSPMetadataRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐImportSAMLSPMetadataRequest(ctx context.Context, v any) (model.ImportSAMLSPMetadataRequest, error) {
+	res, err := ec.unmarshalInputImportSAMLSPMetadataRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNInt642int64(ctx context.Context, v any) (int64, error) {
 	res, err := graphql.UnmarshalInt64(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -42635,6 +45727,16 @@ func (ec *executionContext) marshalNListPermissionsResponse2ᚖgithubᚗcomᚋau
 		return graphql.Null
 	}
 	return ec._ListPermissionsResponse(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNListSAMLIDPKeysRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListSAMLIDPKeysRequest(ctx context.Context, v any) (model.ListSAMLIDPKeysRequest, error) {
+	res, err := ec.unmarshalInputListSAMLIDPKeysRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNListSAMLServiceProvidersRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐListSAMLServiceProvidersRequest(ctx context.Context, v any) (model.ListSAMLServiceProvidersRequest, error) {
+	res, err := ec.unmarshalInputListSAMLServiceProvidersRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNLockMfaRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐLockMfaRequest(ctx context.Context, v any) (model.LockMfaRequest, error) {
@@ -43126,6 +46228,165 @@ func (ec *executionContext) marshalNResponse2ᚖgithubᚗcomᚋauthorizerdevᚋa
 	return ec._Response(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNRetireSAMLIDPKeyRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRetireSAMLIDPKeyRequest(ctx context.Context, v any) (model.RetireSAMLIDPKeyRequest, error) {
+	res, err := ec.unmarshalInputRetireSAMLIDPKeyRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNRotateSAMLIDPCertRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐRotateSAMLIDPCertRequest(ctx context.Context, v any) (model.RotateSAMLIDPCertRequest, error) {
+	res, err := ec.unmarshalInputRotateSAMLIDPCertRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSAMLIDPKey2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKey(ctx context.Context, sel ast.SelectionSet, v model.SAMLIDPKey) graphql.Marshaler {
+	return ec._SAMLIDPKey(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSAMLIDPKey2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKeyᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SAMLIDPKey) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSAMLIDPKey2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKey(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSAMLIDPKey2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLIDPKey(ctx context.Context, sel ast.SelectionSet, v *model.SAMLIDPKey) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SAMLIDPKey(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSAMLSPMetadataParseResult2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLSPMetadataParseResult(ctx context.Context, sel ast.SelectionSet, v model.SAMLSPMetadataParseResult) graphql.Marshaler {
+	return ec._SAMLSPMetadataParseResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSAMLSPMetadataParseResult2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLSPMetadataParseResult(ctx context.Context, sel ast.SelectionSet, v *model.SAMLSPMetadataParseResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SAMLSPMetadataParseResult(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSAMLServiceProvider2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx context.Context, sel ast.SelectionSet, v model.SAMLServiceProvider) graphql.Marshaler {
+	return ec._SAMLServiceProvider(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSAMLServiceProvider2ᚕᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviderᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SAMLServiceProvider) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSAMLServiceProvider2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSAMLServiceProvider2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProvider(ctx context.Context, sel ast.SelectionSet, v *model.SAMLServiceProvider) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SAMLServiceProvider(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviderRequest(ctx context.Context, v any) (model.SAMLServiceProviderRequest, error) {
+	res, err := ec.unmarshalInputSAMLServiceProviderRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSAMLServiceProviders2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviders(ctx context.Context, sel ast.SelectionSet, v model.SAMLServiceProviders) graphql.Marshaler {
+	return ec._SAMLServiceProviders(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSAMLServiceProviders2ᚖgithubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐSAMLServiceProviders(ctx context.Context, sel ast.SelectionSet, v *model.SAMLServiceProviders) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SAMLServiceProviders(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNScimEndpoint2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐScimEndpoint(ctx context.Context, sel ast.SelectionSet, v model.ScimEndpoint) graphql.Marshaler {
 	return ec._ScimEndpoint(ctx, sel, &v)
 }
@@ -43334,6 +46595,11 @@ func (ec *executionContext) unmarshalNUpdateOrganizationRequest2githubᚗcomᚋa
 
 func (ec *executionContext) unmarshalNUpdateProfileRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateProfileRequest(ctx context.Context, v any) (model.UpdateProfileRequest, error) {
 	res, err := ec.unmarshalInputUpdateProfileRequest(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUpdateSAMLServiceProviderRequest2githubᚗcomᚋauthorizerdevᚋauthorizerᚋinternalᚋgraphᚋmodelᚐUpdateSAMLServiceProviderRequest(ctx context.Context, v any) (model.UpdateSAMLServiceProviderRequest, error) {
+	res, err := ec.unmarshalInputUpdateSAMLServiceProviderRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -164,6 +164,17 @@ type CreateOrganizationRequest struct {
 	DisplayName *string `json:"display_name,omitempty"`
 }
 
+type CreateSAMLServiceProviderRequest struct {
+	OrgID             string  `json:"org_id"`
+	Name              string  `json:"name"`
+	EntityID          string  `json:"entity_id"`
+	AcsURL            string  `json:"acs_url"`
+	SpCertPem         *string `json:"sp_cert_pem,omitempty"`
+	NameIDFormat      *string `json:"name_id_format,omitempty"`
+	MappedAttributes  *string `json:"mapped_attributes,omitempty"`
+	AllowIdpInitiated *bool   `json:"allow_idp_initiated,omitempty"`
+}
+
 type CreateScimEndpointRequest struct {
 	OrgID string `json:"org_id"`
 }
@@ -368,6 +379,10 @@ type GetUserRequest struct {
 	Email *string `json:"email,omitempty"`
 }
 
+type ImportSAMLSPMetadataRequest struct {
+	MetadataXML string `json:"metadata_xml"`
+}
+
 type InviteMemberRequest struct {
 	Emails      []string `json:"emails"`
 	RedirectURI *string  `json:"redirect_uri,omitempty"`
@@ -416,6 +431,15 @@ type ListPermissionsResponse struct {
 	Objects     []string      `json:"objects"`
 	Permissions []*Permission `json:"permissions"`
 	Truncated   bool          `json:"truncated"`
+}
+
+type ListSAMLIDPKeysRequest struct {
+	OrgID string `json:"org_id"`
+}
+
+type ListSAMLServiceProvidersRequest struct {
+	OrgID      string            `json:"org_id"`
+	Pagination *PaginatedRequest `json:"pagination,omitempty"`
 }
 
 type ListTrustedIssuersRequest struct {
@@ -687,6 +711,54 @@ type Response struct {
 	Message string `json:"message"`
 }
 
+type RetireSAMLIDPKeyRequest struct {
+	ID string `json:"id"`
+}
+
+type RotateSAMLIDPCertRequest struct {
+	OrgID string `json:"org_id"`
+}
+
+type SAMLIDPKey struct {
+	ID        string `json:"id"`
+	OrgID     string `json:"org_id"`
+	CertPem   string `json:"cert_pem"`
+	Algorithm string `json:"algorithm"`
+	Status    string `json:"status"`
+	CreatedAt *int64 `json:"created_at,omitempty"`
+	UpdatedAt *int64 `json:"updated_at,omitempty"`
+}
+
+type SAMLSPMetadataParseResult struct {
+	EntityID    string  `json:"entity_id"`
+	AcsURL      string  `json:"acs_url"`
+	Certificate *string `json:"certificate,omitempty"`
+}
+
+type SAMLServiceProvider struct {
+	ID                string  `json:"id"`
+	OrgID             string  `json:"org_id"`
+	Name              string  `json:"name"`
+	EntityID          string  `json:"entity_id"`
+	AcsURL            string  `json:"acs_url"`
+	SpCertPem         *string `json:"sp_cert_pem,omitempty"`
+	NameIDFormat      *string `json:"name_id_format,omitempty"`
+	MappedAttributes  *string `json:"mapped_attributes,omitempty"`
+	AllowIdpInitiated bool    `json:"allow_idp_initiated"`
+	IsActive          bool    `json:"is_active"`
+	CreatedAt         *int64  `json:"created_at,omitempty"`
+	UpdatedAt         *int64  `json:"updated_at,omitempty"`
+}
+
+type SAMLServiceProviderRequest struct {
+	ID string `json:"id"`
+}
+
+type SAMLServiceProviders struct {
+	Pagination           *Pagination            `json:"pagination"`
+	SamlServiceProviders []*SAMLServiceProvider `json:"saml_service_providers"`
+}
+
 type ScimEndpoint struct {
 	ID        string `json:"id"`
 	OrgID     string `json:"org_id"`
@@ -903,6 +975,18 @@ type UpdateProfileRequest struct {
 	Picture                  *string        `json:"picture,omitempty"`
 	IsMultiFactorAuthEnabled *bool          `json:"is_multi_factor_auth_enabled,omitempty"`
 	AppData                  map[string]any `json:"app_data,omitempty"`
+}
+
+type UpdateSAMLServiceProviderRequest struct {
+	ID                string  `json:"id"`
+	Name              *string `json:"name,omitempty"`
+	EntityID          *string `json:"entity_id,omitempty"`
+	AcsURL            *string `json:"acs_url,omitempty"`
+	SpCertPem         *string `json:"sp_cert_pem,omitempty"`
+	NameIDFormat      *string `json:"name_id_format,omitempty"`
+	MappedAttributes  *string `json:"mapped_attributes,omitempty"`
+	AllowIdpInitiated *bool   `json:"allow_idp_initiated,omitempty"`
+	IsActive          *bool   `json:"is_active,omitempty"`
 }
 
 type UpdateTrustedIssuerRequest struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -506,6 +506,58 @@ type OrgSAMLConnection {
   updated_at: Int64
 }
 
+# SAMLServiceProvider is a downstream SAML 2.0 SP that Authorizer (acting as the
+# IdP) issues signed assertions to. This is the inverse of OrgSAMLConnection.
+type SAMLServiceProvider {
+  id: ID!
+  org_id: String!
+  name: String!
+  # entity_id: the SP entity ID (the AuthnRequest Issuer and assertion Audience).
+  entity_id: String!
+  # acs_url: the SP Assertion Consumer Service URL — the only place assertions are
+  # POSTed. Never taken from the request.
+  acs_url: String!
+  # sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+  sp_cert_pem: String
+  # name_id_format: SAML NameID format for the Subject (default emailAddress).
+  name_id_format: String
+  # mapped_attributes: JSON mapping profile fields to emitted SAML attribute names.
+  mapped_attributes: String
+  # allow_idp_initiated: whether unsolicited IdP-initiated SSO is permitted.
+  allow_idp_initiated: Boolean!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type SAMLServiceProviders {
+  pagination: Pagination!
+  saml_service_providers: [SAMLServiceProvider!]!
+}
+
+# SAMLIDPKey is a per-org SAML IdP signing keypair. The private key is NEVER
+# projected — only the certificate and rotation status.
+type SAMLIDPKey {
+  id: ID!
+  org_id: String!
+  # cert_pem: the self-signed X.509 signing certificate (PEM), pinned by SPs.
+  cert_pem: String!
+  algorithm: String!
+  # status: "current" (signs new assertions), "active" (published in metadata,
+  # not signing), or "retired" (neither).
+  status: String!
+  created_at: Int64
+  updated_at: Int64
+}
+
+# SAMLSPMetadataParseResult is the parsed output of _import_saml_sp_metadata. It
+# does NOT create a record — it returns fields to prefill a create call.
+type SAMLSPMetadataParseResult {
+  entity_id: String!
+  acs_url: String!
+  certificate: String
+}
+
 type Organization {
   id: ID!
   # name is a unique, URL-safe slug identifying the organization.
@@ -1143,6 +1195,65 @@ input OrgSAMLConnectionRequest {
   org_id: String
 }
 
+# --- SAML IdP: registered downstream service providers ---
+
+input CreateSAMLServiceProviderRequest {
+  org_id: String!
+  name: String!
+  # entity_id: the SP entity ID (unique within the org).
+  entity_id: String!
+  # acs_url: the SP Assertion Consumer Service URL (https recommended).
+  acs_url: String!
+  # sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+  sp_cert_pem: String
+  # name_id_format: default urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress.
+  name_id_format: String
+  # mapped_attributes: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  mapped_attributes: String
+  # allow_idp_initiated: default false (SP-initiated only).
+  allow_idp_initiated: Boolean
+}
+
+input UpdateSAMLServiceProviderRequest {
+  id: ID!
+  name: String
+  entity_id: String
+  acs_url: String
+  sp_cert_pem: String
+  name_id_format: String
+  mapped_attributes: String
+  allow_idp_initiated: Boolean
+  is_active: Boolean
+}
+
+input SAMLServiceProviderRequest {
+  id: ID!
+}
+
+input ListSAMLServiceProvidersRequest {
+  org_id: String!
+  pagination: PaginatedRequest
+}
+
+# --- SAML IdP: signing key rotation & SP-metadata import ---
+
+input RotateSAMLIDPCertRequest {
+  org_id: String!
+}
+
+input RetireSAMLIDPKeyRequest {
+  id: ID!
+}
+
+input ListSAMLIDPKeysRequest {
+  org_id: String!
+}
+
+input ImportSAMLSPMetadataRequest {
+  # metadata_xml: pasted SP metadata XML (NOT a URL — no remote fetch).
+  metadata_xml: String!
+}
+
 input CreateOrganizationRequest {
   # name must be a unique, URL-safe slug.
   name: String!
@@ -1490,6 +1601,20 @@ type Mutation {
   _create_org_saml_connection(params: CreateOrgSAMLConnectionRequest!): OrgSAMLConnection!
   _update_org_saml_connection(params: UpdateOrgSAMLConnectionRequest!): OrgSAMLConnection!
   _delete_org_saml_connection(params: OrgSAMLConnectionRequest!): Response!
+  # Per-organization SAML IdP: registered downstream SPs, signing-key rotation,
+  # and SP-metadata import (Authorizer as Identity Provider).
+  _create_saml_service_provider(params: CreateSAMLServiceProviderRequest!): SAMLServiceProvider!
+  _update_saml_service_provider(params: UpdateSAMLServiceProviderRequest!): SAMLServiceProvider!
+  _delete_saml_service_provider(params: SAMLServiceProviderRequest!): Response!
+  # _rotate_saml_idp_cert generates a new signing keypair (becomes "current");
+  # the previously-current key stays "active" (still published) until retired.
+  _rotate_saml_idp_cert(params: RotateSAMLIDPCertRequest!): SAMLIDPKey!
+  # _retire_saml_idp_key retires a published-but-superseded key so it stops
+  # appearing in IdP metadata. Cannot retire the current key.
+  _retire_saml_idp_key(params: RetireSAMLIDPKeyRequest!): Response!
+  # _import_saml_sp_metadata parses pasted SP metadata XML and returns the
+  # extracted entity_id / acs_url / certificate. It does NOT create a record.
+  _import_saml_sp_metadata(params: ImportSAMLSPMetadataRequest!): SAMLSPMetadataParseResult!
   # Organizations and per-org membership
   _create_organization(params: CreateOrganizationRequest!): Organization!
   _update_organization(params: UpdateOrganizationRequest!): Organization!
@@ -1550,6 +1675,10 @@ type Query {
   _trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
   _org_oidc_connection(params: OrgOIDCConnectionRequest!): OrgOIDCConnection!
   _org_saml_connection(params: OrgSAMLConnectionRequest!): OrgSAMLConnection!
+  # Per-organization SAML IdP admin reads.
+  _saml_service_provider(params: SAMLServiceProviderRequest!): SAMLServiceProvider!
+  _list_saml_service_providers(params: ListSAMLServiceProvidersRequest!): SAMLServiceProviders!
+  _list_saml_idp_keys(params: ListSAMLIDPKeysRequest!): [SAMLIDPKey!]!
   # Organizations and per-org membership
   _organization(params: OrganizationRequest!): Organization!
   _organizations(params: ListOrganizationsRequest): Organizations!

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -267,6 +267,36 @@ func (r *mutationResolver) DeleteOrgSamlConnection(ctx context.Context, params m
 	return r.GraphQLProvider.DeleteOrgSamlConnection(ctx, &params)
 }
 
+// CreateSamlServiceProvider is the resolver for the _create_saml_service_provider field.
+func (r *mutationResolver) CreateSamlServiceProvider(ctx context.Context, params model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	return r.GraphQLProvider.CreateSamlServiceProvider(ctx, &params)
+}
+
+// UpdateSamlServiceProvider is the resolver for the _update_saml_service_provider field.
+func (r *mutationResolver) UpdateSamlServiceProvider(ctx context.Context, params model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	return r.GraphQLProvider.UpdateSamlServiceProvider(ctx, &params)
+}
+
+// DeleteSamlServiceProvider is the resolver for the _delete_saml_service_provider field.
+func (r *mutationResolver) DeleteSamlServiceProvider(ctx context.Context, params model.SAMLServiceProviderRequest) (*model.Response, error) {
+	return r.GraphQLProvider.DeleteSamlServiceProvider(ctx, &params)
+}
+
+// RotateSamlIdpCert is the resolver for the _rotate_saml_idp_cert field.
+func (r *mutationResolver) RotateSamlIdpCert(ctx context.Context, params model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, error) {
+	return r.GraphQLProvider.RotateSamlIdpCert(ctx, &params)
+}
+
+// RetireSamlIdpKey is the resolver for the _retire_saml_idp_key field.
+func (r *mutationResolver) RetireSamlIdpKey(ctx context.Context, params model.RetireSAMLIDPKeyRequest) (*model.Response, error) {
+	return r.GraphQLProvider.RetireSamlIdpKey(ctx, &params)
+}
+
+// ImportSamlSpMetadata is the resolver for the _import_saml_sp_metadata field.
+func (r *mutationResolver) ImportSamlSpMetadata(ctx context.Context, params model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, error) {
+	return r.GraphQLProvider.ImportSamlSpMetadata(ctx, &params)
+}
+
 // CreateOrganization is the resolver for the _create_organization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, params model.CreateOrganizationRequest) (*model.Organization, error) {
 	return r.GraphQLProvider.CreateOrganization(ctx, &params)
@@ -475,6 +505,21 @@ func (r *queryResolver) OrgOidcConnection(ctx context.Context, params model.OrgO
 // OrgSamlConnection is the resolver for the _org_saml_connection field.
 func (r *queryResolver) OrgSamlConnection(ctx context.Context, params model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error) {
 	return r.GraphQLProvider.OrgSamlConnection(ctx, &params)
+}
+
+// SamlServiceProvider is the resolver for the _saml_service_provider field.
+func (r *queryResolver) SamlServiceProvider(ctx context.Context, params model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	return r.GraphQLProvider.SamlServiceProvider(ctx, &params)
+}
+
+// ListSamlServiceProviders is the resolver for the _list_saml_service_providers field.
+func (r *queryResolver) ListSamlServiceProviders(ctx context.Context, params model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, error) {
+	return r.GraphQLProvider.ListSamlServiceProviders(ctx, &params)
+}
+
+// ListSamlIdpKeys is the resolver for the _list_saml_idp_keys field.
+func (r *queryResolver) ListSamlIdpKeys(ctx context.Context, params model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, error) {
+	return r.GraphQLProvider.ListSamlIdpKeys(ctx, &params)
 }
 
 // Organization is the resolver for the _organization field.

--- a/internal/graphql/provider.go
+++ b/internal/graphql/provider.go
@@ -312,6 +312,17 @@ type Provider interface {
 	// OrgSamlConnection returns a per-org SAML connection by id or org_id.
 	// Permissions: authorizer:admin
 	OrgSamlConnection(ctx context.Context, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, error)
+	// SAML IdP admin surface (Authorizer as Identity Provider).
+	// Permissions: super-admin or org-admin of the target org.
+	CreateSamlServiceProvider(ctx context.Context, params *model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	UpdateSamlServiceProvider(ctx context.Context, params *model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	DeleteSamlServiceProvider(ctx context.Context, params *model.SAMLServiceProviderRequest) (*model.Response, error)
+	SamlServiceProvider(ctx context.Context, params *model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, error)
+	ListSamlServiceProviders(ctx context.Context, params *model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, error)
+	RotateSamlIdpCert(ctx context.Context, params *model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, error)
+	RetireSamlIdpKey(ctx context.Context, params *model.RetireSAMLIDPKeyRequest) (*model.Response, error)
+	ListSamlIdpKeys(ctx context.Context, params *model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, error)
+	ImportSamlSpMetadata(ctx context.Context, params *model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, error)
 	// CreateOrganization creates a new organization.
 	// Permissions: authorizer:admin
 	CreateOrganization(ctx context.Context, params *model.CreateOrganizationRequest) (*model.Organization, error)

--- a/internal/graphql/saml_service_provider.go
+++ b/internal/graphql/saml_service_provider.go
@@ -1,0 +1,103 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/service"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// The SAML IdP admin resolvers delegate to the transport-agnostic admin service,
+// which enforces super-admin / org-admin permissions per operation.
+
+func (g *graphqlProvider) CreateSamlServiceProvider(ctx context.Context, params *model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().CreateSAMLServiceProvider(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) UpdateSamlServiceProvider(ctx context.Context, params *model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().UpdateSAMLServiceProvider(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) DeleteSamlServiceProvider(ctx context.Context, params *model.SAMLServiceProviderRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().DeleteSAMLServiceProvider(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) SamlServiceProvider(ctx context.Context, params *model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().SAMLServiceProvider(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) ListSamlServiceProviders(ctx context.Context, params *model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ListSAMLServiceProviders(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) RotateSamlIdpCert(ctx context.Context, params *model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RotateSAMLIDPCert(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) RetireSamlIdpKey(ctx context.Context, params *model.RetireSAMLIDPKeyRequest) (*model.Response, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().RetireSAMLIDPKey(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) ListSamlIdpKeys(ctx context.Context, params *model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ListSAMLIDPKeys(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}
+
+func (g *graphqlProvider) ImportSamlSpMetadata(ctx context.Context, params *model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, error) {
+	gc, err := utils.GinContextFromContext(ctx)
+	if err != nil {
+		metrics.RecordSecurityEvent(metrics.SecurityEventGinContextMissing, "graphql")
+		return nil, err
+	}
+	res, _, err := g.adminService().ImportSAMLSPMetadata(ctx, service.MetaFromGin(gc), params)
+	return res, err
+}

--- a/internal/grpcsrv/handlers/admin.go
+++ b/internal/grpcsrv/handlers/admin.go
@@ -611,3 +611,130 @@ func (h *AdminHandler) TrustedIssuers(ctx context.Context, req *authorizerv1.Tru
 	}
 	return projectTrustedIssuers(res), nil
 }
+
+// CreateSamlServiceProvider delegates to service.CreateSAMLServiceProvider. The
+// optional proto fields map 1:1 onto the model's nullable pointers. Requires
+// super-admin auth.
+func (h *AdminHandler) CreateSamlServiceProvider(ctx context.Context, req *authorizerv1.CreateSamlServiceProviderRequest) (*authorizerv1.CreateSamlServiceProviderResponse, error) {
+	res, _, err := h.Service.CreateSAMLServiceProvider(ctx, transport.MetaFromGRPC(ctx), &model.CreateSAMLServiceProviderRequest{
+		OrgID:             req.GetOrgId(),
+		Name:              req.GetName(),
+		EntityID:          req.GetEntityId(),
+		AcsURL:            req.GetAcsUrl(),
+		SpCertPem:         req.SpCertPem,
+		NameIDFormat:      req.NameIdFormat,
+		MappedAttributes:  req.MappedAttributes,
+		AllowIdpInitiated: req.AllowIdpInitiated,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.CreateSamlServiceProviderResponse{SamlServiceProvider: projectSamlServiceProvider(res)}, nil
+}
+
+// UpdateSamlServiceProvider delegates to service.UpdateSAMLServiceProvider.
+// Optional proto fields map 1:1 onto the model's nullable pointers. Requires
+// super-admin auth.
+func (h *AdminHandler) UpdateSamlServiceProvider(ctx context.Context, req *authorizerv1.UpdateSamlServiceProviderRequest) (*authorizerv1.UpdateSamlServiceProviderResponse, error) {
+	res, _, err := h.Service.UpdateSAMLServiceProvider(ctx, transport.MetaFromGRPC(ctx), &model.UpdateSAMLServiceProviderRequest{
+		ID:                req.GetId(),
+		Name:              req.Name,
+		EntityID:          req.EntityId,
+		AcsURL:            req.AcsUrl,
+		SpCertPem:         req.SpCertPem,
+		NameIDFormat:      req.NameIdFormat,
+		MappedAttributes:  req.MappedAttributes,
+		AllowIdpInitiated: req.AllowIdpInitiated,
+		IsActive:          req.IsActive,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.UpdateSamlServiceProviderResponse{SamlServiceProvider: projectSamlServiceProvider(res)}, nil
+}
+
+// DeleteSamlServiceProvider delegates to service.DeleteSAMLServiceProvider.
+// Requires super-admin auth.
+func (h *AdminHandler) DeleteSamlServiceProvider(ctx context.Context, req *authorizerv1.DeleteSamlServiceProviderRequest) (*authorizerv1.DeleteSamlServiceProviderResponse, error) {
+	res, _, err := h.Service.DeleteSAMLServiceProvider(ctx, transport.MetaFromGRPC(ctx), &model.SAMLServiceProviderRequest{
+		ID: req.GetId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.DeleteSamlServiceProviderResponse{Message: res.Message}, nil
+}
+
+// GetSamlServiceProvider delegates to service.SAMLServiceProvider and projects
+// the result. Requires super-admin auth.
+func (h *AdminHandler) GetSamlServiceProvider(ctx context.Context, req *authorizerv1.GetSamlServiceProviderRequest) (*authorizerv1.GetSamlServiceProviderResponse, error) {
+	res, _, err := h.Service.SAMLServiceProvider(ctx, transport.MetaFromGRPC(ctx), &model.SAMLServiceProviderRequest{
+		ID: req.GetId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.GetSamlServiceProviderResponse{SamlServiceProvider: projectSamlServiceProvider(res)}, nil
+}
+
+// ListSamlServiceProviders delegates to service.ListSAMLServiceProviders and
+// projects the paginated result. Requires super-admin auth.
+func (h *AdminHandler) ListSamlServiceProviders(ctx context.Context, req *authorizerv1.ListSamlServiceProvidersRequest) (*authorizerv1.ListSamlServiceProvidersResponse, error) {
+	res, _, err := h.Service.ListSAMLServiceProviders(ctx, transport.MetaFromGRPC(ctx), &model.ListSAMLServiceProvidersRequest{
+		OrgID:      req.GetOrgId(),
+		Pagination: modelPaginatedRequest(req.GetPagination()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return projectSamlServiceProviders(res), nil
+}
+
+// RotateSamlIdpCert delegates to service.RotateSAMLIDPCert and projects the new
+// current signing key. Requires super-admin auth.
+func (h *AdminHandler) RotateSamlIdpCert(ctx context.Context, req *authorizerv1.RotateSamlIdpCertRequest) (*authorizerv1.RotateSamlIdpCertResponse, error) {
+	res, _, err := h.Service.RotateSAMLIDPCert(ctx, transport.MetaFromGRPC(ctx), &model.RotateSAMLIDPCertRequest{
+		OrgID: req.GetOrgId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.RotateSamlIdpCertResponse{SamlIdpKey: projectSamlIdpKey(res)}, nil
+}
+
+// RetireSamlIdpKey delegates to service.RetireSAMLIDPKey. Requires super-admin
+// auth.
+func (h *AdminHandler) RetireSamlIdpKey(ctx context.Context, req *authorizerv1.RetireSamlIdpKeyRequest) (*authorizerv1.RetireSamlIdpKeyResponse, error) {
+	res, _, err := h.Service.RetireSAMLIDPKey(ctx, transport.MetaFromGRPC(ctx), &model.RetireSAMLIDPKeyRequest{
+		ID: req.GetId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.RetireSamlIdpKeyResponse{Message: res.Message}, nil
+}
+
+// ListSamlIdpKeys delegates to service.ListSAMLIDPKeys and projects the key set.
+// Requires super-admin auth.
+func (h *AdminHandler) ListSamlIdpKeys(ctx context.Context, req *authorizerv1.ListSamlIdpKeysRequest) (*authorizerv1.ListSamlIdpKeysResponse, error) {
+	res, _, err := h.Service.ListSAMLIDPKeys(ctx, transport.MetaFromGRPC(ctx), &model.ListSAMLIDPKeysRequest{
+		OrgID: req.GetOrgId(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.ListSamlIdpKeysResponse{SamlIdpKeys: projectSamlIdpKeys(res)}, nil
+}
+
+// ImportSamlSpMetadata delegates to service.ImportSAMLSPMetadata. It parses
+// pasted SP metadata XML and returns prefill fields; it creates no record.
+// Requires super-admin auth.
+func (h *AdminHandler) ImportSamlSpMetadata(ctx context.Context, req *authorizerv1.ImportSamlSpMetadataRequest) (*authorizerv1.ImportSamlSpMetadataResponse, error) {
+	res, _, err := h.Service.ImportSAMLSPMetadata(ctx, transport.MetaFromGRPC(ctx), &model.ImportSAMLSPMetadataRequest{
+		MetadataXML: req.GetMetadataXml(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.ImportSamlSpMetadataResponse{Result: projectSamlSpMetadataParseResult(res)}, nil
+}

--- a/internal/grpcsrv/handlers/admin_project.go
+++ b/internal/grpcsrv/handlers/admin_project.go
@@ -471,3 +471,82 @@ func projectTrustedIssuers(t *model.TrustedIssuers) *authorizerv1.TrustedIssuers
 		Pagination:     projectPagination(t.Pagination),
 	}
 }
+
+// projectSamlServiceProvider converts a single GraphQL SAMLServiceProvider model
+// into the proto message. Optional pointer fields collapse to zero values.
+func projectSamlServiceProvider(s *model.SAMLServiceProvider) *authorizerv1.SamlServiceProvider {
+	if s == nil {
+		return nil
+	}
+	return &authorizerv1.SamlServiceProvider{
+		Id:                s.ID,
+		OrgId:             s.OrgID,
+		Name:              s.Name,
+		EntityId:          s.EntityID,
+		AcsUrl:            s.AcsURL,
+		SpCertPem:         refs.StringValue(s.SpCertPem),
+		NameIdFormat:      refs.StringValue(s.NameIDFormat),
+		MappedAttributes:  refs.StringValue(s.MappedAttributes),
+		AllowIdpInitiated: s.AllowIdpInitiated,
+		IsActive:          s.IsActive,
+		CreatedAt:         refs.Int64Value(s.CreatedAt),
+		UpdatedAt:         refs.Int64Value(s.UpdatedAt),
+	}
+}
+
+// projectSamlServiceProviders converts the GraphQL SAMLServiceProviders model (a
+// page plus its pagination cursor) into the proto response.
+func projectSamlServiceProviders(s *model.SAMLServiceProviders) *authorizerv1.ListSamlServiceProvidersResponse {
+	if s == nil {
+		return &authorizerv1.ListSamlServiceProvidersResponse{}
+	}
+	sps := make([]*authorizerv1.SamlServiceProvider, 0, len(s.SamlServiceProviders))
+	for _, item := range s.SamlServiceProviders {
+		sps = append(sps, projectSamlServiceProvider(item))
+	}
+	return &authorizerv1.ListSamlServiceProvidersResponse{
+		SamlServiceProviders: sps,
+		Pagination:           projectPagination(s.Pagination),
+	}
+}
+
+// projectSamlIdpKey converts a single GraphQL SAMLIDPKey model into the proto
+// message. The private key is never projected — only the certificate and status.
+func projectSamlIdpKey(k *model.SAMLIDPKey) *authorizerv1.SamlIdpKey {
+	if k == nil {
+		return nil
+	}
+	return &authorizerv1.SamlIdpKey{
+		Id:        k.ID,
+		OrgId:     k.OrgID,
+		CertPem:   k.CertPem,
+		Algorithm: k.Algorithm,
+		Status:    k.Status,
+		CreatedAt: refs.Int64Value(k.CreatedAt),
+		UpdatedAt: refs.Int64Value(k.UpdatedAt),
+	}
+}
+
+// projectSamlIdpKeys converts a slice of GraphQL SAMLIDPKey models into the proto
+// slice. A nil input yields an empty (non-nil) slice.
+func projectSamlIdpKeys(keys []*model.SAMLIDPKey) []*authorizerv1.SamlIdpKey {
+	out := make([]*authorizerv1.SamlIdpKey, 0, len(keys))
+	for _, item := range keys {
+		out = append(out, projectSamlIdpKey(item))
+	}
+	return out
+}
+
+// projectSamlSpMetadataParseResult converts the GraphQL SAMLSPMetadataParseResult
+// model into the proto message. The optional certificate collapses to a zero
+// value.
+func projectSamlSpMetadataParseResult(r *model.SAMLSPMetadataParseResult) *authorizerv1.SamlSpMetadataParseResult {
+	if r == nil {
+		return nil
+	}
+	return &authorizerv1.SamlSpMetadataParseResult{
+		EntityId:    r.EntityID,
+		AcsUrl:      r.AcsURL,
+		Certificate: refs.StringValue(r.Certificate),
+	}
+}

--- a/internal/http_handlers/provider.go
+++ b/internal/http_handlers/provider.go
@@ -120,6 +120,13 @@ type Provider interface {
 	SAMLLoginHandler() gin.HandlerFunc
 	// SAMLACSHandler consumes a per-org SAML assertion (Assertion Consumer Service).
 	SAMLACSHandler() gin.HandlerFunc
+	// SAMLIDPMetadataHandler serves a per-org SAML IdP metadata document
+	// (Authorizer acting as the Identity Provider).
+	SAMLIDPMetadataHandler() gin.HandlerFunc
+	// SAMLIDPSSOHandler handles SP-initiated SAML SSO (Authorizer as IdP).
+	SAMLIDPSSOHandler() gin.HandlerFunc
+	// SAMLIDPInitiatedHandler handles IdP-initiated SAML SSO to a registered SP.
+	SAMLIDPInitiatedHandler() gin.HandlerFunc
 	// OpenIDConfigurationHandler is the main handler that handels all the openid configuration requests
 	OpenIDConfigurationHandler() gin.HandlerFunc
 	// PlaygroundHandler is the main handler that handels all the playground requests

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -467,7 +467,13 @@ func buildMappedAttributes(user *schemas.User, sp *schemas.SAMLServiceProvider) 
 			Values:     []saml.AttributeValue{{Type: "xs:string", Value: value}},
 		})
 	}
-	add("email", refs.StringValue(user.Email))
+	// Never emit an UNVERIFIED email as an attribute — an SP that keys off the
+	// email attribute (rather than the NameID) must not receive an address
+	// Authorizer has not verified. Same spoofing class the NameID guard in
+	// authorizeSAMLIssuance closes, but independent of the NameID format.
+	if user.EmailVerifiedAt != nil {
+		add("email", refs.StringValue(user.Email))
+	}
 	add("given_name", refs.StringValue(user.GivenName))
 	add("family_name", refs.StringValue(user.FamilyName))
 	add("nickname", refs.StringValue(user.Nickname))

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -181,6 +181,11 @@ func (h *httpProvider) SAMLIDPInitiatedHandler() gin.HandlerFunc {
 		slug := strings.TrimSpace(c.Param("org_slug"))
 		spID := strings.TrimSpace(c.Param("sp_id"))
 		relayState := strings.TrimSpace(c.Query("RelayState"))
+		// Bound RelayState: it is reflected into the delivered response form, so cap
+		// it well above the SAML 80-byte guidance but far below abuse territory.
+		if len(relayState) > 2048 {
+			relayState = ""
+		}
 		orgID, ok := h.resolveSAMLIDPOrg(c, slug, &log)
 		if !ok {
 			return
@@ -284,6 +289,9 @@ func (h *httpProvider) emitSAMLAssertion(c *gin.Context, idp *saml.IdentityProvi
 		h.samlIDPFail(c, log, slug, "unknown_service_provider", "unknown service provider")
 		return
 	}
+	if !h.authorizeSAMLIssuance(c, orgID, slug, sp, user, log) {
+		return
+	}
 	session := buildSAMLSession(user, sp)
 	maker := mappedAssertionMaker{attributes: buildMappedAttributes(user, sp)}
 	if err := maker.MakeAssertion(req, session); err != nil {
@@ -303,6 +311,9 @@ func (h *httpProvider) emitSAMLAssertion(c *gin.Context, idp *saml.IdentityProvi
 // SP's ACS. Mirrors crewjam ServeIDPInitiated, but with our session + mapped
 // attributes. No InResponseTo (there is no request to bind to).
 func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.IdentityProvider, sp *schemas.SAMLServiceProvider, orgID, slug, relayState string, user *schemas.User, log *zerolog.Logger) {
+	if !h.authorizeSAMLIssuance(c, orgID, slug, sp, user, log) {
+		return
+	}
 	spMetadata := buildSPEntityDescriptor(sp)
 	req := &saml.IdpAuthnRequest{
 		IDP:                     idp,
@@ -326,6 +337,45 @@ func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.Ident
 		return
 	}
 	h.auditSAMLIDPIssued(c, slug, sp, user)
+}
+
+// authorizeSAMLIssuance is the single chokepoint that decides whether an
+// authenticated user may receive an assertion for this org's SP. It enforces two
+// invariants that would otherwise let any logged-in user forge a cross-tenant
+// identity:
+//
+//   - Org membership: the user MUST belong to the org the assertion is minted for
+//     (mirrors the SP-side org-membership model in oauth_sso.go). Without this,
+//     any authenticated Authorizer user could drive /saml/idp/{otherOrg}/sso and
+//     obtain an assertion signed by another org's IdP key.
+//   - Verified email: when the Subject NameID would be the user's email address
+//     (the emailAddress format), that email MUST be verified — otherwise a member
+//     could register victim@org.com and be asserted as the victim to an SP that
+//     keys on email.
+func (h *httpProvider) authorizeSAMLIssuance(c *gin.Context, orgID, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User, log *zerolog.Logger) bool {
+	if _, err := h.StorageProvider.GetOrgMembership(c.Request.Context(), orgID, user.ID); err != nil {
+		metrics.RecordSecurityEvent("saml_idp_non_member", slug)
+		h.samlIDPFail(c, log, slug, "forbidden", "not a member of this organization")
+		return false
+	}
+	if samlNameIDWouldBeEmail(sp, user) && user.EmailVerifiedAt == nil {
+		metrics.RecordSecurityEvent("saml_idp_unverified_email", slug)
+		h.samlIDPFail(c, log, slug, "email_not_verified", "email address is not verified")
+		return false
+	}
+	return true
+}
+
+// samlNameIDWouldBeEmail reports whether the Subject NameID emitted for this SP
+// would be the user's email address (emailAddress format with a non-empty email).
+// It is the single source of truth shared by buildSAMLSession (which sets the
+// NameID) and authorizeSAMLIssuance (which requires that email be verified).
+func samlNameIDWouldBeEmail(sp *schemas.SAMLServiceProvider, user *schemas.User) bool {
+	format := strings.TrimSpace(sp.NameIDFormat)
+	if format == "" {
+		format = defaultSAMLNameIDFormat
+	}
+	return format == defaultSAMLNameIDFormat && strings.TrimSpace(refs.StringValue(user.Email)) != ""
 }
 
 // mappedAssertionMaker delegates to crewjam's DefaultAssertionMaker for the
@@ -356,7 +406,7 @@ func buildSAMLSession(user *schemas.User, sp *schemas.SAMLServiceProvider) *saml
 	// NameID: the email address for the emailAddress format, otherwise the stable
 	// user id (persistent/unspecified/transient SPs key off an opaque identifier).
 	nameID := user.ID
-	if format == defaultSAMLNameIDFormat && email != "" {
+	if samlNameIDWouldBeEmail(sp, user) {
 		nameID = email
 	}
 	now := saml.TimeNow()
@@ -579,11 +629,22 @@ func (h *httpProvider) getOrCreateCurrentSAMLKey(ctx context.Context, orgID, slu
 	if err != nil {
 		return nil, err
 	}
+	// Deterministic selection: the newest "current" key wins, so signing never
+	// depends on provider list ordering even if a rotation partial-failure left
+	// two current keys behind.
+	var current *schemas.SAMLIDPKey
 	for _, k := range keys {
-		if k.Status == schemas.SAMLIDPKeyStatusCurrent {
-			return k, nil
+		if k.Status == schemas.SAMLIDPKeyStatusCurrent && (current == nil || k.CreatedAt > current.CreatedAt) {
+			current = k
 		}
 	}
+	if current != nil {
+		return current, nil
+	}
+	// ponytail: two concurrent first-hits on a key-less org could both insert a
+	// "current" key (no cross-DB unique index). Harmless — both are legitimate
+	// org certs and the selection above is deterministic. Add a partial unique
+	// index on (org_id) where status='current' if this ever matters.
 	priv, certPEM, err := crypto.NewSAMLSigningKeypair("Authorizer SAML IdP " + slug)
 	if err != nil {
 		return nil, err

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -353,17 +353,36 @@ func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.Ident
 //     could register victim@org.com and be asserted as the victim to an SP that
 //     keys on email.
 func (h *httpProvider) authorizeSAMLIssuance(c *gin.Context, orgID, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User, log *zerolog.Logger) bool {
-	if _, err := h.StorageProvider.GetOrgMembership(c.Request.Context(), orgID, user.ID); err != nil {
+	membership, err := h.StorageProvider.GetOrgMembership(c.Request.Context(), orgID, user.ID)
+	code, desc := samlIssuanceDenyReason(membership, err, sp, user)
+	if code == "" {
+		return true
+	}
+	// Distinguish the two denial classes in the security metric.
+	if code == "forbidden" {
 		metrics.RecordSecurityEvent("saml_idp_non_member", slug)
-		h.samlIDPFail(c, log, slug, "forbidden", "not a member of this organization")
-		return false
+	} else {
+		metrics.RecordSecurityEvent("saml_idp_unverified_email", slug)
+	}
+	h.samlIDPFail(c, log, slug, code, desc)
+	return false
+}
+
+// samlIssuanceDenyReason is the pure decision behind authorizeSAMLIssuance,
+// factored out so the guard (including the defensive nil-membership case) is unit
+// testable without a live storage provider. Returns an empty code when issuance
+// is allowed. Membership is treated as absent on EITHER a non-nil error OR a nil
+// record — every storage provider returns an error for a missing membership
+// today, but denying on nil too closes the class of a provider ever returning
+// (nil, nil).
+func samlIssuanceDenyReason(membership *schemas.OrgMembership, membershipErr error, sp *schemas.SAMLServiceProvider, user *schemas.User) (code, desc string) {
+	if membershipErr != nil || membership == nil {
+		return "forbidden", "not a member of this organization"
 	}
 	if samlNameIDWouldBeEmail(sp, user) && user.EmailVerifiedAt == nil {
-		metrics.RecordSecurityEvent("saml_idp_unverified_email", slug)
-		h.samlIDPFail(c, log, slug, "email_not_verified", "email address is not verified")
-		return false
+		return "email_not_verified", "email address is not verified"
 	}
-	return true
+	return "", ""
 }
 
 // samlNameIDWouldBeEmail reports whether the Subject NameID emitted for this SP

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -1,0 +1,700 @@
+package http_handlers
+
+// Per-organization SAML 2.0 Identity Provider — Authorizer acting as the IdP that
+// issues signed assertions to downstream Service Providers (Zendesk, Notion, …).
+// This is the architectural inverse of saml_sp.go (Authorizer as SP): there we
+// CONSUME a signed assertion; here we PRODUCE one.
+//
+// SECURITY MODEL — the assertions this file emits must satisfy every check the SP
+// side documents (saml_sp.go header): a valid XML-DSIG signature over the
+// assertion, a tight Audience/Recipient/Destination/NotBefore/NotOnOrAfter, and
+// (SP-initiated) an InResponseTo bound to the SP's AuthnRequest.
+//
+//   - ACS/EntityID strict binding (open-redirect / exfiltration guard): the SP is
+//     resolved by the AuthnRequest Issuer against the org's REGISTERED
+//     SAMLServiceProvider rows via samlSPRegistry.GetServiceProvider. The ACS URL
+//     is taken ONLY from that record; crewjam's IdpAuthnRequest.Validate rejects a
+//     request-supplied AssertionConsumerServiceURL that does not match it. A
+//     request for an unregistered SP is refused (os.ErrNotExist).
+//   - Audience isolation: the assertion Audience is set to the resolved SP's
+//     EntityID, so an assertion minted for SP-A cannot validate at SP-B.
+//   - No unauthenticated issuance (SP-initiated): an assertion is only produced
+//     once the browser presents a valid Authorizer session; otherwise the flow
+//     bounces through the normal login UI and resumes.
+//   - IdP-initiated SSO is refused unless the registered SP opts in
+//     (AllowIDPInitiated). There is NO issuance-side replay guard for the
+//     unsolicited path: replay defence for an assertion is the CONSUMING SP's job
+//     (single-use AssertionID), and Authorizer is the issuer here — a tight
+//     NotBefore/NotOnOrAfter window bounds the assertion instead. (See PR notes.)
+//   - Signing uses ONLY the org's "current" key; metadata additionally publishes
+//     every "active" (superseded-but-not-retired) cert so SPs with cached metadata
+//     keep validating during a rotation overlap.
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/cookie"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/metrics"
+	"github.com/authorizerdev/authorizer/internal/parsers"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+const (
+	// samlIDPFlowPrefix namespaces a pending IdP SSO request stashed in the shared
+	// store while the browser completes login. Single-use, short OAuth-state TTL.
+	samlIDPFlowPrefix = "saml_idp_flow:"
+	// samlIDPContinueParam carries the opaque flow key back to the SSO endpoint
+	// after the login bounce.
+	samlIDPContinueParam = "saml_continue"
+	// defaultSAMLNameIDFormat is used when a registered SP specifies none.
+	defaultSAMLNameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+	// rsaSHA256SigMethod is dsig.RSASHA256SignatureMethod, inlined to avoid a
+	// direct goxmldsig import for a single constant. Assertions are signed
+	// RSA-SHA256 (stronger than the crewjam RSA-SHA1 default).
+	rsaSHA256SigMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+)
+
+// samlIDPFlowState is the pending IdP SSO request preserved across the login
+// bounce, stored single-use under an opaque key. It never contains a redirect
+// target — the ACS URL is always re-resolved from the registered SP record.
+type samlIDPFlowState struct {
+	OrgSlug      string `json:"org_slug"`
+	IdPInitiated bool   `json:"idp_initiated"`
+	SPEntityID   string `json:"sp_entity_id"` // IdP-initiated: the target SP
+	RelayState   string `json:"relay_state"`
+	RequestB64   string `json:"request_b64"` // SP-initiated: base64 of the raw AuthnRequest
+}
+
+// SAMLIDPMetadataHandler serves this org's IdP metadata (EntityDescriptor /
+// IDPSSODescriptor) so a downstream SP can register Authorizer as its IdP. Every
+// currently-published (current + active) signing certificate is emitted as a
+// separate <KeyDescriptor use="signing">.
+func (h *httpProvider) SAMLIDPMetadataHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLIDPMetadataHandler").Logger()
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		orgID, ok := h.resolveSAMLIDPOrg(c, slug, &log)
+		if !ok {
+			return
+		}
+		if _, err := h.getOrCreateCurrentSAMLKey(ctx, orgID, slug); err != nil {
+			log.Debug().Err(err).Msg("failed to ensure signing key")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		keys, err := h.StorageProvider.ListSAMLIDPKeys(ctx, orgID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		hostname := parsers.GetHost(c)
+		md := buildIDPMetadata(samlIDPEntityID(hostname, slug), samlIDPSSOURL(hostname, slug), publishedSAMLKeys(keys))
+		body, err := xml.MarshalIndent(md, "", "  ")
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		out := append([]byte(xml.Header), body...)
+		c.Data(http.StatusOK, "application/samlmetadata+xml", out)
+	}
+}
+
+// SAMLIDPSSOHandler is the SP-initiated SSO endpoint (GET HTTP-Redirect binding,
+// POST HTTP-POST binding). It also handles the post-login resume (?saml_continue).
+func (h *httpProvider) SAMLIDPSSOHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLIDPSSOHandler").Logger()
+	return func(c *gin.Context) {
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		orgID, ok := h.resolveSAMLIDPOrg(c, slug, &log)
+		if !ok {
+			return
+		}
+
+		// Resume path after a login bounce.
+		if key := strings.TrimSpace(c.Query(samlIDPContinueParam)); key != "" {
+			h.resumeSAMLIDPFlow(c, orgID, slug, key, &log)
+			return
+		}
+
+		idp, err := h.buildIdentityProvider(c, orgID, slug)
+		if err != nil {
+			h.samlIDPFail(c, &log, slug, "sso_config_error", "IdP not configured")
+			return
+		}
+
+		req, err := saml.NewIdpAuthnRequest(idp, c.Request)
+		if err != nil {
+			h.samlIDPFail(c, &log, slug, "invalid_request", "malformed AuthnRequest")
+			return
+		}
+		if err := req.Validate(); err != nil {
+			// Validate binds the SP + ACS URL against the registry; failure here is
+			// an unknown SP, an ACS/Destination mismatch, or an expired request.
+			log.Debug().Err(err).Msg("AuthnRequest validation failed")
+			metrics.RecordSecurityEvent("saml_idp_request_invalid", slug)
+			h.samlIDPFail(c, &log, slug, "invalid_authn_request", "authentication request rejected")
+			return
+		}
+
+		user, authed := h.currentSAMLUser(c)
+		if !authed {
+			flow := samlIDPFlowState{
+				OrgSlug:    slug,
+				RelayState: req.RelayState,
+				RequestB64: base64.StdEncoding.EncodeToString(req.RequestBuffer),
+			}
+			h.bounceSAMLIDPToLogin(c, slug, flow, &log)
+			return
+		}
+
+		h.emitSAMLAssertion(c, idp, req, orgID, slug, user, &log)
+	}
+}
+
+// SAMLIDPInitiatedHandler builds and POSTs an unsolicited assertion to a
+// registered SP's ACS. Gated by the SP's AllowIDPInitiated flag.
+// Route: GET /saml/idp/:org_slug/sso/:sp_id
+func (h *httpProvider) SAMLIDPInitiatedHandler() gin.HandlerFunc {
+	log := h.Log.With().Str("func", "SAMLIDPInitiatedHandler").Logger()
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		slug := strings.TrimSpace(c.Param("org_slug"))
+		spID := strings.TrimSpace(c.Param("sp_id"))
+		relayState := strings.TrimSpace(c.Query("RelayState"))
+		orgID, ok := h.resolveSAMLIDPOrg(c, slug, &log)
+		if !ok {
+			return
+		}
+
+		sp, err := h.StorageProvider.GetSAMLServiceProviderByID(ctx, spID)
+		if err != nil || sp == nil || sp.OrgID != orgID || !sp.IsActive {
+			h.samlIDPFail(c, &log, slug, "unknown_service_provider", "unknown service provider")
+			return
+		}
+		if !sp.AllowIDPInitiated {
+			metrics.RecordSecurityEvent("saml_idp_initiated_rejected", slug)
+			h.samlIDPFail(c, &log, slug, "idp_initiated_disabled", "IdP-initiated SSO is disabled for this service provider")
+			return
+		}
+
+		user, authed := h.currentSAMLUser(c)
+		if !authed {
+			flow := samlIDPFlowState{
+				OrgSlug:      slug,
+				IdPInitiated: true,
+				SPEntityID:   sp.EntityID,
+				RelayState:   relayState,
+			}
+			h.bounceSAMLIDPToLogin(c, slug, flow, &log)
+			return
+		}
+
+		idp, err := h.buildIdentityProvider(c, orgID, slug)
+		if err != nil {
+			h.samlIDPFail(c, &log, slug, "sso_config_error", "IdP not configured")
+			return
+		}
+		h.emitIDPInitiatedAssertion(c, idp, sp, orgID, slug, relayState, user, &log)
+	}
+}
+
+// resumeSAMLIDPFlow reloads a pending SSO request after the login bounce and, now
+// that a session exists, completes it.
+func (h *httpProvider) resumeSAMLIDPFlow(c *gin.Context, orgID, slug, key string, log *zerolog.Logger) {
+	ctx := c.Request.Context()
+	raw, err := h.MemoryStoreProvider.GetAndRemoveState(samlIDPFlowPrefix + key)
+	if err != nil || strings.TrimSpace(raw) == "" {
+		h.samlIDPFail(c, log, slug, "invalid_state", "the login request expired, please retry")
+		return
+	}
+	var flow samlIDPFlowState
+	if err := json.Unmarshal([]byte(raw), &flow); err != nil || flow.OrgSlug != slug {
+		h.samlIDPFail(c, log, slug, "invalid_state", "corrupt login state")
+		return
+	}
+	user, authed := h.currentSAMLUser(c)
+	if !authed {
+		// Login did not establish a session — do not loop back to login.
+		h.samlIDPFail(c, log, slug, "login_required", "authentication required")
+		return
+	}
+	idp, err := h.buildIdentityProvider(c, orgID, slug)
+	if err != nil {
+		h.samlIDPFail(c, log, slug, "sso_config_error", "IdP not configured")
+		return
+	}
+
+	if flow.IdPInitiated {
+		sp, err := h.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, orgID, flow.SPEntityID)
+		if err != nil || sp == nil || !sp.IsActive || !sp.AllowIDPInitiated {
+			h.samlIDPFail(c, log, slug, "unknown_service_provider", "service provider no longer available")
+			return
+		}
+		h.emitIDPInitiatedAssertion(c, idp, sp, orgID, slug, flow.RelayState, user, log)
+		return
+	}
+
+	buf, err := base64.StdEncoding.DecodeString(flow.RequestB64)
+	if err != nil {
+		h.samlIDPFail(c, log, slug, "invalid_state", "corrupt request")
+		return
+	}
+	req := &saml.IdpAuthnRequest{
+		IDP:           idp,
+		HTTPRequest:   c.Request,
+		RequestBuffer: buf,
+		RelayState:    flow.RelayState,
+		Now:           saml.TimeNow(),
+	}
+	if err := req.Validate(); err != nil {
+		metrics.RecordSecurityEvent("saml_idp_request_invalid", slug)
+		h.samlIDPFail(c, log, slug, "invalid_authn_request", "authentication request rejected")
+		return
+	}
+	h.emitSAMLAssertion(c, idp, req, orgID, slug, user, log)
+}
+
+// emitSAMLAssertion completes an SP-initiated flow: it maps attributes from the
+// registered SP record, builds the assertion, and writes the auto-POST form.
+func (h *httpProvider) emitSAMLAssertion(c *gin.Context, idp *saml.IdentityProvider, req *saml.IdpAuthnRequest, orgID, slug string, user *schemas.User, log *zerolog.Logger) {
+	ctx := c.Request.Context()
+	spEntityID := req.ServiceProviderMetadata.EntityID
+	sp, err := h.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, orgID, spEntityID)
+	if err != nil || sp == nil || !sp.IsActive {
+		h.samlIDPFail(c, log, slug, "unknown_service_provider", "unknown service provider")
+		return
+	}
+	session := buildSAMLSession(user, sp)
+	maker := mappedAssertionMaker{attributes: buildMappedAttributes(user, sp)}
+	if err := maker.MakeAssertion(req, session); err != nil {
+		log.Debug().Err(err).Msg("failed to build assertion")
+		h.samlIDPFail(c, log, slug, "assertion_error", "could not build assertion")
+		return
+	}
+	if err := req.WriteResponse(c.Writer); err != nil {
+		log.Debug().Err(err).Msg("failed to write assertion response")
+		h.samlIDPFail(c, log, slug, "assertion_error", "could not deliver assertion")
+		return
+	}
+	h.auditSAMLIDPIssued(c, slug, sp, user)
+}
+
+// emitIDPInitiatedAssertion produces an unsolicited assertion and POSTs it to the
+// SP's ACS. Mirrors crewjam ServeIDPInitiated, but with our session + mapped
+// attributes. No InResponseTo (there is no request to bind to).
+func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.IdentityProvider, sp *schemas.SAMLServiceProvider, orgID, slug, relayState string, user *schemas.User, log *zerolog.Logger) {
+	spMetadata := buildSPEntityDescriptor(sp)
+	req := &saml.IdpAuthnRequest{
+		IDP:                     idp,
+		HTTPRequest:             c.Request,
+		RelayState:              relayState,
+		ServiceProviderMetadata: spMetadata,
+		SPSSODescriptor:         &spMetadata.SPSSODescriptors[0],
+		ACSEndpoint:             &spMetadata.SPSSODescriptors[0].AssertionConsumerServices[0],
+		Now:                     saml.TimeNow(),
+	}
+	session := buildSAMLSession(user, sp)
+	maker := mappedAssertionMaker{attributes: buildMappedAttributes(user, sp)}
+	if err := maker.MakeAssertion(req, session); err != nil {
+		log.Debug().Err(err).Msg("failed to build idp-initiated assertion")
+		h.samlIDPFail(c, log, slug, "assertion_error", "could not build assertion")
+		return
+	}
+	if err := req.WriteResponse(c.Writer); err != nil {
+		log.Debug().Err(err).Msg("failed to write idp-initiated response")
+		h.samlIDPFail(c, log, slug, "assertion_error", "could not deliver assertion")
+		return
+	}
+	h.auditSAMLIDPIssued(c, slug, sp, user)
+}
+
+// mappedAssertionMaker delegates to crewjam's DefaultAssertionMaker for the
+// security-critical Subject/Conditions/InResponseTo/Audience/NotBefore
+// construction, then replaces the attribute statement with exactly the attributes
+// the registered SP was configured to receive.
+type mappedAssertionMaker struct {
+	attributes []saml.Attribute
+}
+
+func (m mappedAssertionMaker) MakeAssertion(req *saml.IdpAuthnRequest, session *saml.Session) error {
+	if err := (saml.DefaultAssertionMaker{}).MakeAssertion(req, session); err != nil {
+		return err
+	}
+	req.Assertion.AttributeStatements = []saml.AttributeStatement{{Attributes: m.attributes}}
+	return nil
+}
+
+// buildSAMLSession assembles the crewjam session that drives the assertion
+// Subject/NameID and AuthnStatement. Attributes are handled by
+// mappedAssertionMaker, not here.
+func buildSAMLSession(user *schemas.User, sp *schemas.SAMLServiceProvider) *saml.Session {
+	format := strings.TrimSpace(sp.NameIDFormat)
+	if format == "" {
+		format = defaultSAMLNameIDFormat
+	}
+	email := refs.StringValue(user.Email)
+	// NameID: the email address for the emailAddress format, otherwise the stable
+	// user id (persistent/unspecified/transient SPs key off an opaque identifier).
+	nameID := user.ID
+	if format == defaultSAMLNameIDFormat && email != "" {
+		nameID = email
+	}
+	now := saml.TimeNow()
+	return &saml.Session{
+		ID:            user.ID,
+		CreateTime:    now,
+		ExpireTime:    now.Add(time.Hour),
+		Index:         user.ID,
+		NameID:        nameID,
+		NameIDFormat:  format,
+		UserEmail:     email,
+		UserName:      nameID,
+		UserGivenName: refs.StringValue(user.GivenName),
+		UserSurname:   refs.StringValue(user.FamilyName),
+	}
+}
+
+// buildMappedAttributes emits the SAML attributes for the registered SP. The map
+// keys are Authorizer profile fields; the map VALUES are the SAML attribute names
+// this SP expects (the inverse of the SP-side attribute mapping). Empty/omitted
+// values are skipped.
+func buildMappedAttributes(user *schemas.User, sp *schemas.SAMLServiceProvider) []saml.Attribute {
+	mapping := samlDefaultAttributeMapping
+	if sp.MappedAttributes != nil && strings.TrimSpace(*sp.MappedAttributes) != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(*sp.MappedAttributes), &m); err == nil && len(m) > 0 {
+			mapping = m
+		}
+	}
+	attrs := []saml.Attribute{}
+	add := func(field string, value string) {
+		name := strings.TrimSpace(mapping[field])
+		if name == "" || strings.TrimSpace(value) == "" {
+			return
+		}
+		attrs = append(attrs, saml.Attribute{
+			Name:       name,
+			NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+			Values:     []saml.AttributeValue{{Type: "xs:string", Value: value}},
+		})
+	}
+	add("email", refs.StringValue(user.Email))
+	add("given_name", refs.StringValue(user.GivenName))
+	add("family_name", refs.StringValue(user.FamilyName))
+	add("nickname", refs.StringValue(user.Nickname))
+	add("picture", refs.StringValue(user.Picture))
+	return attrs
+}
+
+// samlSPRegistry implements crewjam's ServiceProviderProvider against the org's
+// registered SAMLServiceProvider rows. This is the strict binding: the returned
+// EntityDescriptor carries the SP's ACS URL from the DB, never from the request,
+// so Validate refuses a request that names a different ACS.
+type samlSPRegistry struct {
+	storage interface {
+		GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error)
+	}
+	orgID string
+	ctx   context.Context
+}
+
+func (r *samlSPRegistry) GetServiceProvider(_ *http.Request, serviceProviderID string) (*saml.EntityDescriptor, error) {
+	sp, err := r.storage.GetSAMLServiceProviderByOrgAndEntityID(r.ctx, r.orgID, serviceProviderID)
+	if err != nil || sp == nil || !sp.IsActive {
+		return nil, os.ErrNotExist
+	}
+	return buildSPEntityDescriptor(sp), nil
+}
+
+// buildSPEntityDescriptor builds the minimal SP metadata crewjam needs to bind an
+// assertion: the EntityID (assertion Audience) and the single trusted ACS URL. The
+// SP's optional signing cert is intentionally NOT wired as an encryption key here,
+// so assertions are signed but not encrypted (the compatible default); it is
+// retained on the record for future AuthnRequest-signature validation.
+func buildSPEntityDescriptor(sp *schemas.SAMLServiceProvider) *saml.EntityDescriptor {
+	isDefault := true
+	return &saml.EntityDescriptor{
+		EntityID: sp.EntityID,
+		SPSSODescriptors: []saml.SPSSODescriptor{{
+			SSODescriptor: saml.SSODescriptor{
+				RoleDescriptor: saml.RoleDescriptor{
+					ProtocolSupportEnumeration: "urn:oasis:names:tc:SAML:2.0:protocol",
+				},
+			},
+			AssertionConsumerServices: []saml.IndexedEndpoint{{
+				Binding:   saml.HTTPPostBinding,
+				Location:  sp.ACSURL,
+				Index:     0,
+				IsDefault: &isDefault,
+			}},
+		}},
+	}
+}
+
+// buildIDPMetadata renders the IdP EntityDescriptor with one signing
+// <KeyDescriptor> per published (current + active) certificate.
+func buildIDPMetadata(entityID, ssoURL string, keys []*schemas.SAMLIDPKey) *saml.EntityDescriptor {
+	keyDescriptors := make([]saml.KeyDescriptor, 0, len(keys))
+	for _, k := range keys {
+		block := pemCertB64(k.CertPEM)
+		if block == "" {
+			continue
+		}
+		keyDescriptors = append(keyDescriptors, saml.KeyDescriptor{
+			Use: "signing",
+			KeyInfo: saml.KeyInfo{
+				X509Data: saml.X509Data{
+					X509Certificates: []saml.X509Certificate{{Data: block}},
+				},
+			},
+		})
+	}
+	return &saml.EntityDescriptor{
+		EntityID: entityID,
+		IDPSSODescriptors: []saml.IDPSSODescriptor{{
+			SSODescriptor: saml.SSODescriptor{
+				RoleDescriptor: saml.RoleDescriptor{
+					ProtocolSupportEnumeration: "urn:oasis:names:tc:SAML:2.0:protocol",
+					KeyDescriptors:             keyDescriptors,
+				},
+				NameIDFormats: []saml.NameIDFormat{
+					saml.NameIDFormat(defaultSAMLNameIDFormat),
+					saml.NameIDFormat("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"),
+				},
+			},
+			SingleSignOnServices: []saml.Endpoint{
+				{Binding: saml.HTTPRedirectBinding, Location: ssoURL},
+				{Binding: saml.HTTPPostBinding, Location: ssoURL},
+			},
+		}},
+	}
+}
+
+// currentSAMLUser resolves the browser's authenticated Authorizer user from the
+// session cookie, or (nil,false) when there is no valid session.
+func (h *httpProvider) currentSAMLUser(c *gin.Context) (*schemas.User, bool) {
+	sessionToken, err := cookie.GetSession(c)
+	if err != nil || strings.TrimSpace(sessionToken) == "" {
+		return nil, false
+	}
+	claims, err := h.TokenProvider.ValidateBrowserSession(c, sessionToken)
+	if err != nil {
+		return nil, false
+	}
+	user, err := h.StorageProvider.GetUserByID(c, claims.Subject)
+	if err != nil || user == nil {
+		return nil, false
+	}
+	return user, true
+}
+
+// bounceSAMLIDPToLogin stashes the pending SSO request and redirects the browser
+// to the login UI, which returns to the SSO endpoint (?saml_continue) once a
+// session exists. The continue URL is always Authorizer's own SSO endpoint — never
+// a request-supplied redirect target.
+func (h *httpProvider) bounceSAMLIDPToLogin(c *gin.Context, slug string, flow samlIDPFlowState, log *zerolog.Logger) {
+	if h.MemoryStoreProvider == nil {
+		h.samlIDPFail(c, log, slug, "internal_error", "server error")
+		return
+	}
+	key, err := randURLString(32)
+	if err != nil {
+		h.samlIDPFail(c, log, slug, "internal_error", "server error")
+		return
+	}
+	payload, err := json.Marshal(flow)
+	if err != nil {
+		h.samlIDPFail(c, log, slug, "internal_error", "server error")
+		return
+	}
+	if err := h.MemoryStoreProvider.SetState(samlIDPFlowPrefix+key, string(payload)); err != nil {
+		h.samlIDPFail(c, log, slug, "internal_error", "server error")
+		return
+	}
+	hostname := parsers.GetHost(c)
+	continueURL := samlIDPSSOURL(hostname, slug) + "?" + samlIDPContinueParam + "=" + url.QueryEscape(key)
+	loginURL := "/app?redirect_uri=" + url.QueryEscape(continueURL)
+	c.Redirect(http.StatusFound, loginURL)
+}
+
+// buildIdentityProvider constructs a per-org crewjam IdentityProvider signed by
+// the org's current key and backed by the registry-based SP lookup.
+func (h *httpProvider) buildIdentityProvider(c *gin.Context, orgID, slug string) (*saml.IdentityProvider, error) {
+	ctx := c.Request.Context()
+	current, err := h.getOrCreateCurrentSAMLKey(ctx, orgID, slug)
+	if err != nil {
+		return nil, err
+	}
+	priv, cert, err := h.parseSigningKey(current)
+	if err != nil {
+		return nil, err
+	}
+	hostname := parsers.GetHost(c)
+	metadataURL, err := url.Parse(samlIDPEntityID(hostname, slug))
+	if err != nil {
+		return nil, err
+	}
+	ssoURL, err := url.Parse(samlIDPSSOURL(hostname, slug))
+	if err != nil {
+		return nil, err
+	}
+	return &saml.IdentityProvider{
+		Key:             priv,
+		Certificate:     cert,
+		MetadataURL:     *metadataURL,
+		SSOURL:          *ssoURL,
+		SignatureMethod: rsaSHA256SigMethod,
+		ServiceProviderProvider: &samlSPRegistry{
+			storage: h.StorageProvider,
+			orgID:   orgID,
+			ctx:     ctx,
+		},
+	}, nil
+}
+
+// getOrCreateCurrentSAMLKey returns the org's current signing key, lazily
+// generating the first keypair when none exists yet.
+func (h *httpProvider) getOrCreateCurrentSAMLKey(ctx context.Context, orgID, slug string) (*schemas.SAMLIDPKey, error) {
+	keys, err := h.StorageProvider.ListSAMLIDPKeys(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range keys {
+		if k.Status == schemas.SAMLIDPKeyStatusCurrent {
+			return k, nil
+		}
+	}
+	priv, certPEM, err := crypto.NewSAMLSigningKeypair("Authorizer SAML IdP " + slug)
+	if err != nil {
+		return nil, err
+	}
+	enc, err := crypto.EncryptAES(h.ClientSecret, priv)
+	if err != nil {
+		return nil, err
+	}
+	return h.StorageProvider.AddSAMLIDPKey(ctx, &schemas.SAMLIDPKey{
+		OrgID:         orgID,
+		CertPEM:       certPEM,
+		PrivateKeyEnc: enc,
+		Algorithm:     "RS256",
+		Status:        schemas.SAMLIDPKeyStatusCurrent,
+	})
+}
+
+// parseSigningKey decrypts and parses the RSA private key and X.509 cert of a key.
+func (h *httpProvider) parseSigningKey(k *schemas.SAMLIDPKey) (*rsa.PrivateKey, *x509.Certificate, error) {
+	privPEM, err := crypto.DecryptAES(h.ClientSecret, k.PrivateKeyEnc)
+	if err != nil {
+		return nil, nil, err
+	}
+	priv, err := crypto.ParseRsaPrivateKeyFromPemStr(privPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := crypto.ParseCertificateFromPemStr(k.CertPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	return priv, cert, nil
+}
+
+// resolveSAMLIDPOrg looks up an enabled org by slug and returns its ID.
+func (h *httpProvider) resolveSAMLIDPOrg(c *gin.Context, slug string, log *zerolog.Logger) (string, bool) {
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "error_description": "missing organization"})
+		return "", false
+	}
+	org, err := h.StorageProvider.GetOrganizationByName(c.Request.Context(), slug)
+	if err != nil || org == nil {
+		log.Debug().Err(err).Str("org", slug).Msg("organization not found")
+		c.JSON(http.StatusNotFound, gin.H{"error": "sso_not_configured", "error_description": "unknown organization"})
+		return "", false
+	}
+	if !org.Enabled {
+		c.JSON(http.StatusForbidden, gin.H{"error": "sso_not_configured", "error_description": "organization disabled"})
+		return "", false
+	}
+	return org.ID, true
+}
+
+// samlIDPFail writes a uniform error response and audits the rejection so
+// assertion-forgery attempts (unknown SP, ACS mismatch, IdP-initiated-disabled)
+// leave a trail.
+func (h *httpProvider) samlIDPFail(c *gin.Context, log *zerolog.Logger, slug, code, desc string) {
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusFailure)
+	log.Debug().Str("error", code).Str("org", slug).Msg("saml idp sso failed")
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditSAMLIDPAssertionFailedEvent,
+		ActorType:    constants.AuditActorTypeUser,
+		ResourceType: constants.AuditResourceTypeSession,
+		Metadata:     slug + ":" + code,
+		IPAddress:    utils.GetIP(c.Request),
+		UserAgent:    utils.GetUserAgent(c.Request),
+	})
+	c.JSON(http.StatusBadRequest, gin.H{"error": code, "error_description": desc})
+}
+
+func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User) {
+	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusSuccess)
+	h.AuditProvider.LogEvent(audit.Event{
+		Action:       constants.AuditSAMLIDPAssertionIssuedEvent,
+		ActorID:      user.ID,
+		ActorType:    constants.AuditActorTypeUser,
+		ActorEmail:   refs.StringValue(user.Email),
+		ResourceType: constants.AuditResourceTypeSession,
+		ResourceID:   sp.ID,
+		Metadata:     slug + ":" + sp.EntityID,
+		IPAddress:    utils.GetIP(c.Request),
+		UserAgent:    utils.GetUserAgent(c.Request),
+	})
+}
+
+// pemCertB64 extracts the base64 DER (single line) from a PEM certificate for
+// embedding in <X509Certificate>. Returns "" if the PEM cannot be decoded.
+func pemCertB64(certPEM string) string {
+	cert, err := crypto.ParseCertificateFromPemStr(strings.TrimSpace(certPEM))
+	if err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(cert.Raw)
+}
+
+// publishedSAMLKeys returns the keys published in IdP metadata: current + active
+// (never retired).
+func publishedSAMLKeys(keys []*schemas.SAMLIDPKey) []*schemas.SAMLIDPKey {
+	out := make([]*schemas.SAMLIDPKey, 0, len(keys))
+	for _, k := range keys {
+		if k.Status == schemas.SAMLIDPKeyStatusCurrent || k.Status == schemas.SAMLIDPKeyStatusActive {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func samlIDPEntityID(hostname, slug string) string {
+	return strings.TrimRight(hostname, "/") + "/saml/idp/" + url.PathEscape(slug) + "/metadata"
+}
+
+func samlIDPSSOURL(hostname, slug string) string {
+	return strings.TrimRight(hostname, "/") + "/saml/idp/" + url.PathEscape(slug) + "/sso"
+}

--- a/internal/http_handlers/saml_idp_test.go
+++ b/internal/http_handlers/saml_idp_test.go
@@ -247,6 +247,36 @@ func TestBuildSAMLSessionNameID(t *testing.T) {
 	assert.Equal(t, "user-1", sess.NameID)
 }
 
+func TestSAMLIssuanceDenyReason(t *testing.T) {
+	verified := &schemas.User{ID: "u1", Email: refs.NewStringRef("a@example.com"), EmailVerifiedAt: refs.NewInt64Ref(1)}
+	unverified := &schemas.User{ID: "u1", Email: refs.NewStringRef("a@example.com")}
+	member := &schemas.OrgMembership{ID: "m1"}
+	sp := testSPRecord() // emailAddress NameID format
+
+	// Allowed: a verified member.
+	code, _ := samlIssuanceDenyReason(member, nil, sp, verified)
+	assert.Equal(t, "", code)
+
+	// Denied: storage returned an error (the not-found contract on every DB).
+	code, _ = samlIssuanceDenyReason(nil, assert.AnError, sp, verified)
+	assert.Equal(t, "forbidden", code)
+
+	// Denied: defensive — a provider that ever returns (nil, nil) must still deny.
+	code, _ = samlIssuanceDenyReason(nil, nil, sp, verified)
+	assert.Equal(t, "forbidden", code)
+
+	// Denied: member, but an unverified email would be asserted as NameID.
+	code, _ = samlIssuanceDenyReason(member, nil, sp, unverified)
+	assert.Equal(t, "email_not_verified", code)
+
+	// Allowed: member with unverified email but a NON-email NameID format
+	// (the email is never asserted, so verification is not required).
+	spPersistent := testSPRecord()
+	spPersistent.NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+	code, _ = samlIssuanceDenyReason(member, nil, spPersistent, unverified)
+	assert.Equal(t, "", code)
+}
+
 func TestSAMLNameIDWouldBeEmail(t *testing.T) {
 	// emailAddress format (default) + a present email → email is asserted, so it
 	// must be verified before issuance.

--- a/internal/http_handlers/saml_idp_test.go
+++ b/internal/http_handlers/saml_idp_test.go
@@ -45,10 +45,11 @@ func mustURL(t *testing.T, raw string) url.URL {
 
 func testUser() *schemas.User {
 	return &schemas.User{
-		ID:         "user-1",
-		Email:      refs.NewStringRef("alice@example.com"),
-		GivenName:  refs.NewStringRef("Alice"),
-		FamilyName: refs.NewStringRef("Smith"),
+		ID:              "user-1",
+		Email:           refs.NewStringRef("alice@example.com"),
+		EmailVerifiedAt: refs.NewInt64Ref(1), // a logged-in member has a verified email
+		GivenName:       refs.NewStringRef("Alice"),
+		FamilyName:      refs.NewStringRef("Smith"),
 	}
 }
 
@@ -230,6 +231,14 @@ func TestBuildMappedAttributes(t *testing.T) {
 	// Empty profile fields are skipped.
 	empty := buildMappedAttributes(&schemas.User{ID: "u2"}, testSPRecord())
 	assert.Empty(t, empty, "no attributes when the profile has no mapped values")
+
+	// An UNVERIFIED email is never emitted as an attribute, even for a non-email
+	// NameID format (same spoofing class as the NameID guard).
+	unverified := &schemas.User{ID: "u3", Email: refs.NewStringRef("spoof@corp.example.com"), GivenName: refs.NewStringRef("Eve")}
+	got := buildMappedAttributes(unverified, testSPRecord())
+	for _, a := range got {
+		assert.NotEqual(t, "email", a.Name, "unverified email must not be emitted as an attribute")
+	}
 }
 
 func TestBuildSAMLSessionNameID(t *testing.T) {

--- a/internal/http_handlers/saml_idp_test.go
+++ b/internal/http_handlers/saml_idp_test.go
@@ -247,6 +247,20 @@ func TestBuildSAMLSessionNameID(t *testing.T) {
 	assert.Equal(t, "user-1", sess.NameID)
 }
 
+func TestSAMLNameIDWouldBeEmail(t *testing.T) {
+	// emailAddress format (default) + a present email → email is asserted, so it
+	// must be verified before issuance.
+	assert.True(t, samlNameIDWouldBeEmail(testSPRecord(), testUser()))
+
+	// A non-email format never asserts the email as NameID.
+	sp := testSPRecord()
+	sp.NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+	assert.False(t, samlNameIDWouldBeEmail(sp, testUser()))
+
+	// emailAddress format but no email → NameID falls back to user id, not email.
+	assert.False(t, samlNameIDWouldBeEmail(testSPRecord(), &schemas.User{ID: "u2"}))
+}
+
 func TestPublishedSAMLKeys(t *testing.T) {
 	keys := []*schemas.SAMLIDPKey{
 		{ID: "a", Status: schemas.SAMLIDPKeyStatusCurrent},

--- a/internal/http_handlers/saml_idp_test.go
+++ b/internal/http_handlers/saml_idp_test.go
@@ -1,0 +1,262 @@
+package http_handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/crewjam/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const (
+	testIDPEntityID = "https://idp.example.com/saml/idp/acme/metadata"
+	testIDPSSOURL   = "https://idp.example.com/saml/idp/acme/sso"
+	testSPEntityID  = "https://sp.example.com/saml/metadata"
+	testSPACSURL    = "https://sp.example.com/saml/acs"
+)
+
+// fakeSPStore satisfies samlSPRegistry.storage with a fixed set of SP records.
+type fakeSPStore struct {
+	byEntity map[string]*schemas.SAMLServiceProvider
+}
+
+func (f fakeSPStore) GetSAMLServiceProviderByOrgAndEntityID(_ context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	sp := f.byEntity[entityID]
+	if sp == nil || sp.OrgID != orgID {
+		return nil, assert.AnError
+	}
+	return sp, nil
+}
+
+func mustURL(t *testing.T, raw string) url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return *u
+}
+
+func testUser() *schemas.User {
+	return &schemas.User{
+		ID:         "user-1",
+		Email:      refs.NewStringRef("alice@example.com"),
+		GivenName:  refs.NewStringRef("Alice"),
+		FamilyName: refs.NewStringRef("Smith"),
+	}
+}
+
+func testSPRecord() *schemas.SAMLServiceProvider {
+	return &schemas.SAMLServiceProvider{
+		ID:           "sp-1",
+		OrgID:        "org-1",
+		EntityID:     testSPEntityID,
+		ACSURL:       testSPACSURL,
+		NameIDFormat: defaultSAMLNameIDFormat,
+		IsActive:     true,
+	}
+}
+
+// buildTestIDP wires a crewjam IdentityProvider signed by a fresh keypair and
+// backed by the given SP registry. Returns the IdP, its signing cert PEM, and the
+// consuming crewjam ServiceProvider that trusts it.
+func buildTestIDP(t *testing.T, store fakeSPStore) (*saml.IdentityProvider, *saml.ServiceProvider) {
+	t.Helper()
+	privPEM, certPEM, err := crypto.NewSAMLSigningKeypair("test idp")
+	require.NoError(t, err)
+	priv, err := crypto.ParseRsaPrivateKeyFromPemStr(privPEM)
+	require.NoError(t, err)
+	cert, err := crypto.ParseCertificateFromPemStr(certPEM)
+	require.NoError(t, err)
+
+	idp := &saml.IdentityProvider{
+		Key:             priv,
+		Certificate:     cert,
+		MetadataURL:     mustURL(t, testIDPEntityID),
+		SSOURL:          mustURL(t, testIDPSSOURL),
+		SignatureMethod: rsaSHA256SigMethod,
+		ServiceProviderProvider: &samlSPRegistry{
+			storage: store,
+			orgID:   "org-1",
+			ctx:     context.Background(),
+		},
+	}
+
+	consumingSP := &saml.ServiceProvider{
+		EntityID:    testSPEntityID,
+		MetadataURL: mustURL(t, testSPEntityID),
+		AcsURL:      mustURL(t, testSPACSURL),
+		IDPMetadata: buildIDPMetadata(testIDPEntityID, testIDPSSOURL, []*schemas.SAMLIDPKey{
+			{CertPEM: certPEM, Status: schemas.SAMLIDPKeyStatusCurrent},
+		}),
+	}
+	return idp, consumingSP
+}
+
+// samlResponseBytes builds the SAML response for an assertion-populated request
+// and base64-decodes it (PostBinding is what WriteResponse serialises into the
+// auto-POST form, minus the HTML layer).
+func samlResponseBytes(t *testing.T, idpReq *saml.IdpAuthnRequest) []byte {
+	t.Helper()
+	form, err := idpReq.PostBinding()
+	require.NoError(t, err)
+	decoded, err := base64.StdEncoding.DecodeString(form.SAMLResponse)
+	require.NoError(t, err)
+	return decoded
+}
+
+// TestSAMLIDPAssertionRoundTrip is the security-critical proof: an assertion this
+// package emits must pass every check the SP side relies on (signature bound to
+// the IdP cert, Audience/Recipient/Destination, and InResponseTo) — verified by
+// feeding it back through a real crewjam ServiceProvider.ParseXMLResponse.
+func TestSAMLIDPAssertionRoundTrip(t *testing.T) {
+	spRec := testSPRecord()
+	spRec.MappedAttributes = refs.NewStringRef(`{"email":"email","given_name":"firstName","family_name":"lastName"}`)
+	store := fakeSPStore{byEntity: map[string]*schemas.SAMLServiceProvider{testSPEntityID: spRec}}
+	idp, consumingSP := buildTestIDP(t, store)
+
+	// The SP starts an SP-initiated flow.
+	authnReq, err := consumingSP.MakeAuthenticationRequest(testIDPSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+	require.NoError(t, err)
+	redirectURL, err := authnReq.Redirect("relay-123", consumingSP)
+	require.NoError(t, err)
+
+	// The IdP parses and validates it (this binds the SP + ACS URL).
+	httpReq := httptest.NewRequest("GET", "/saml/idp/acme/sso?"+redirectURL.RawQuery, nil)
+	idpReq, err := saml.NewIdpAuthnRequest(idp, httpReq)
+	require.NoError(t, err)
+	require.NoError(t, idpReq.Validate(), "a registered SP with a matching ACS must validate")
+
+	// Emit the assertion with mapped attributes.
+	session := buildSAMLSession(testUser(), spRec)
+	maker := mappedAssertionMaker{attributes: buildMappedAttributes(testUser(), spRec)}
+	require.NoError(t, maker.MakeAssertion(idpReq, session))
+	// The SP consumes it — the assertion must satisfy signature + all bindings.
+	decoded := samlResponseBytes(t, idpReq)
+	assertion, err := consumingSP.ParseXMLResponse(decoded, []string{authnReq.ID}, consumingSP.AcsURL)
+	require.NoError(t, err, "the emitted assertion must pass the SP's XSW/signature/audience checks")
+
+	require.NotNil(t, assertion.Subject)
+	require.NotNil(t, assertion.Subject.NameID)
+	assert.Equal(t, "alice@example.com", assertion.Subject.NameID.Value)
+
+	got := map[string]string{}
+	for _, stmt := range assertion.AttributeStatements {
+		for _, attr := range stmt.Attributes {
+			if len(attr.Values) > 0 {
+				got[attr.Name] = attr.Values[0].Value
+			}
+		}
+	}
+	assert.Equal(t, "alice@example.com", got["email"])
+	assert.Equal(t, "Alice", got["firstName"])
+	assert.Equal(t, "Smith", got["lastName"])
+}
+
+// TestSAMLIDPAudienceIsolation proves an assertion minted for SP-A does not
+// validate at SP-B (Audience is bound to the requesting SP's EntityID).
+func TestSAMLIDPAudienceIsolation(t *testing.T) {
+	spRec := testSPRecord()
+	store := fakeSPStore{byEntity: map[string]*schemas.SAMLServiceProvider{testSPEntityID: spRec}}
+	idp, consumingSP := buildTestIDP(t, store)
+
+	authnReq, err := consumingSP.MakeAuthenticationRequest(testIDPSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+	require.NoError(t, err)
+	redirectURL, err := authnReq.Redirect("", consumingSP)
+	require.NoError(t, err)
+	idpReq, err := saml.NewIdpAuthnRequest(idp, httptest.NewRequest("GET", "/sso?"+redirectURL.RawQuery, nil))
+	require.NoError(t, err)
+	require.NoError(t, idpReq.Validate())
+	session := buildSAMLSession(testUser(), spRec)
+	require.NoError(t, mappedAssertionMaker{attributes: buildMappedAttributes(testUser(), spRec)}.MakeAssertion(idpReq, session))
+	decoded := samlResponseBytes(t, idpReq)
+
+	// A different SP (different EntityID/ACS) must reject the assertion.
+	otherSP := &saml.ServiceProvider{
+		EntityID:    "https://evil.example.com/saml/metadata",
+		MetadataURL: mustURL(t, "https://evil.example.com/saml/metadata"),
+		AcsURL:      mustURL(t, "https://evil.example.com/saml/acs"),
+		IDPMetadata: consumingSP.IDPMetadata,
+	}
+	_, err = otherSP.ParseXMLResponse(decoded, []string{authnReq.ID}, otherSP.AcsURL)
+	assert.Error(t, err, "an assertion for SP-A must not validate at SP-B")
+}
+
+// TestSAMLIDPUnknownServiceProviderRejected proves an AuthnRequest from an
+// unregistered SP is refused at Validate (the strict-binding guard).
+func TestSAMLIDPUnknownServiceProviderRejected(t *testing.T) {
+	store := fakeSPStore{byEntity: map[string]*schemas.SAMLServiceProvider{}} // registry is empty
+	idp, consumingSP := buildTestIDP(t, store)
+	authnReq, err := consumingSP.MakeAuthenticationRequest(testIDPSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+	require.NoError(t, err)
+	redirectURL, err := authnReq.Redirect("", consumingSP)
+	require.NoError(t, err)
+	idpReq, err := saml.NewIdpAuthnRequest(idp, httptest.NewRequest("GET", "/sso?"+redirectURL.RawQuery, nil))
+	require.NoError(t, err)
+	assert.Error(t, idpReq.Validate(), "an AuthnRequest from an unregistered SP must be rejected")
+}
+
+func TestBuildMappedAttributes(t *testing.T) {
+	user := testUser()
+
+	// Defaults (samlDefaultAttributeMapping) when no override is set.
+	def := buildMappedAttributes(user, testSPRecord())
+	defNames := map[string]string{}
+	for _, a := range def {
+		defNames[a.Name] = a.Values[0].Value
+	}
+	assert.Equal(t, "alice@example.com", defNames["email"])
+	assert.Equal(t, "Alice", defNames["firstName"])
+
+	// Custom mapping emits exactly the configured attribute names.
+	sp := testSPRecord()
+	sp.MappedAttributes = refs.NewStringRef(`{"email":"urn:mail","given_name":"gn"}`)
+	custom := buildMappedAttributes(user, sp)
+	names := map[string]string{}
+	for _, a := range custom {
+		names[a.Name] = a.Values[0].Value
+	}
+	assert.Equal(t, "alice@example.com", names["urn:mail"])
+	assert.Equal(t, "Alice", names["gn"])
+	_, hasDefault := names["email"]
+	assert.False(t, hasDefault, "custom mapping must not emit default attribute names")
+
+	// Empty profile fields are skipped.
+	empty := buildMappedAttributes(&schemas.User{ID: "u2"}, testSPRecord())
+	assert.Empty(t, empty, "no attributes when the profile has no mapped values")
+}
+
+func TestBuildSAMLSessionNameID(t *testing.T) {
+	user := testUser()
+
+	// emailAddress format → email as NameID.
+	sp := testSPRecord()
+	sess := buildSAMLSession(user, sp)
+	assert.Equal(t, "alice@example.com", sess.NameID)
+	assert.Equal(t, defaultSAMLNameIDFormat, sess.NameIDFormat)
+
+	// persistent format → stable user id as NameID.
+	sp.NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+	sess = buildSAMLSession(user, sp)
+	assert.Equal(t, "user-1", sess.NameID)
+}
+
+func TestPublishedSAMLKeys(t *testing.T) {
+	keys := []*schemas.SAMLIDPKey{
+		{ID: "a", Status: schemas.SAMLIDPKeyStatusCurrent},
+		{ID: "b", Status: schemas.SAMLIDPKeyStatusActive},
+		{ID: "c", Status: schemas.SAMLIDPKeyStatusRetired},
+	}
+	pub := publishedSAMLKeys(keys)
+	ids := []string{}
+	for _, k := range pub {
+		ids = append(ids, k.ID)
+	}
+	assert.ElementsMatch(t, []string{"a", "b"}, ids, "retired keys must not be published")
+}

--- a/internal/integration_tests/saml_idp_e2e_test.go
+++ b/internal/integration_tests/saml_idp_e2e_test.go
@@ -1,0 +1,232 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/base64"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+)
+
+// samlIDPTestHost is pinned via the X-Authorizer-URL header on every request so
+// the IdP's derived entity ID / SSO URL are deterministic and match the
+// consuming SP's AuthnRequest Destination.
+const samlIDPTestHost = "http://localhost:8080"
+
+// TestSAMLIDPEndToEnd drives the real IdP gin handlers end-to-end against SQLite
+// storage, a real token/session, and a real crewjam ServiceProvider consuming the
+// emitted assertion. It exercises: metadata, SP-initiated issuance for a member,
+// the unauthenticated login bounce, the C1 non-member denial, and IdP-initiated
+// gating.
+func TestSAMLIDPEndToEnd(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	ctx := context.Background()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/saml/idp/:org_slug/metadata", ts.HttpProvider.SAMLIDPMetadataHandler())
+	router.GET("/saml/idp/:org_slug/sso", ts.HttpProvider.SAMLIDPSSOHandler())
+	router.POST("/saml/idp/:org_slug/sso", ts.HttpProvider.SAMLIDPSSOHandler())
+	router.GET("/saml/idp/:org_slug/sso/:sp_id", ts.HttpProvider.SAMLIDPInitiatedHandler())
+
+	slug := "acme-idp-" + uuid.NewString()[:8]
+	org, err := ts.StorageProvider.AddOrganization(ctx, &schemas.Organization{Name: slug, Enabled: true})
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	memberEmail := "member-" + uuid.NewString()[:8] + "@acme.example.com"
+	member, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+		Email:           refs.NewStringRef(memberEmail),
+		EmailVerifiedAt: &now,
+		GivenName:       refs.NewStringRef("Mem"),
+		FamilyName:      refs.NewStringRef("Ber"),
+		SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+	})
+	require.NoError(t, err)
+	_, err = ts.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{OrgID: org.ID, UserID: member.ID, Roles: "member"})
+	require.NoError(t, err)
+
+	// A verified user who is NOT a member of the org (the C1 attacker).
+	outsider, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+		Email:           refs.NewStringRef("outsider-" + uuid.NewString()[:8] + "@evil.example.com"),
+		EmailVerifiedAt: &now,
+		SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+	})
+	require.NoError(t, err)
+
+	spEntityID := "https://sp.example.test/metadata"
+	spACS := "https://sp.example.test/acs"
+	sp, err := ts.StorageProvider.AddSAMLServiceProvider(ctx, &schemas.SAMLServiceProvider{
+		OrgID:        org.ID,
+		Name:         "TestSP",
+		EntityID:     spEntityID,
+		ACSURL:       spACS,
+		NameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+		IsActive:     true,
+	})
+	require.NoError(t, err)
+
+	idpEntityID := samlIDPTestHost + "/saml/idp/" + slug + "/metadata"
+	idpSSOURL := samlIDPTestHost + "/saml/idp/" + slug + "/sso"
+
+	// ---- 1. Metadata ----
+	t.Run("metadata publishes the signing cert", func(t *testing.T) {
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/metadata", "")
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "X509Certificate")
+		assert.Contains(t, w.Body.String(), idpEntityID)
+	})
+
+	// Consuming SP trusts the IdP by parsing the metadata we just served.
+	metaXML := samlIDPGet(router, "/saml/idp/"+slug+"/metadata", "").Body.Bytes()
+	idpMeta, err := samlsp.ParseMetadata(metaXML)
+	require.NoError(t, err)
+
+	newConsumingSP := func(allowIDPInitiated bool) *saml.ServiceProvider {
+		return &saml.ServiceProvider{
+			EntityID:          spEntityID,
+			MetadataURL:       mustURL(t, spEntityID),
+			AcsURL:            mustURL(t, spACS),
+			IDPMetadata:       idpMeta,
+			AllowIDPInitiated: allowIDPInitiated,
+		}
+	}
+
+	// ---- 2. SP-initiated, member session → valid signed assertion ----
+	t.Run("member receives a valid signed assertion", func(t *testing.T) {
+		consumingSP := newConsumingSP(false)
+		authnReq, err := consumingSP.MakeAuthenticationRequest(idpSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+		require.NoError(t, err)
+		redirect, err := authnReq.Redirect("relay-e2e", consumingSP)
+		require.NoError(t, err)
+
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/sso?"+redirect.RawQuery, samlIDPLoginCookie(t, ts, member))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		decoded := extractSAMLResponse(t, w.Body.String())
+		assertion, err := consumingSP.ParseXMLResponse(decoded, []string{authnReq.ID}, consumingSP.AcsURL)
+		require.NoError(t, err, "the emitted assertion must satisfy the SP's signature/audience/InResponseTo checks")
+		require.NotNil(t, assertion.Subject)
+		require.NotNil(t, assertion.Subject.NameID)
+		assert.Equal(t, memberEmail, assertion.Subject.NameID.Value)
+	})
+
+	// ---- 3. Unauthenticated → login bounce ----
+	t.Run("unauthenticated request bounces to the login UI", func(t *testing.T) {
+		consumingSP := newConsumingSP(false)
+		authnReq, err := consumingSP.MakeAuthenticationRequest(idpSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+		require.NoError(t, err)
+		redirect, err := authnReq.Redirect("", consumingSP)
+		require.NoError(t, err)
+
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/sso?"+redirect.RawQuery, "")
+		require.Equal(t, http.StatusFound, w.Code)
+		assert.Contains(t, w.Header().Get("Location"), "/app?redirect_uri=")
+	})
+
+	// ---- 4. C1: non-member session → issuance denied ----
+	t.Run("non-member is denied issuance (C1)", func(t *testing.T) {
+		consumingSP := newConsumingSP(false)
+		authnReq, err := consumingSP.MakeAuthenticationRequest(idpSSOURL, saml.HTTPRedirectBinding, saml.HTTPPostBinding)
+		require.NoError(t, err)
+		redirect, err := authnReq.Redirect("", consumingSP)
+		require.NoError(t, err)
+
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/sso?"+redirect.RawQuery, samlIDPLoginCookie(t, ts, outsider))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "forbidden")
+	})
+
+	// ---- 5. IdP-initiated gating ----
+	t.Run("idp-initiated is refused unless the SP opts in", func(t *testing.T) {
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/sso/"+sp.ID, samlIDPLoginCookie(t, ts, member))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "idp_initiated_disabled")
+	})
+
+	t.Run("idp-initiated issues an unsolicited assertion when enabled", func(t *testing.T) {
+		sp.AllowIDPInitiated = true
+		_, err := ts.StorageProvider.UpdateSAMLServiceProvider(ctx, sp)
+		require.NoError(t, err)
+
+		w := samlIDPGet(router, "/saml/idp/"+slug+"/sso/"+sp.ID, samlIDPLoginCookie(t, ts, member))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		consumingSP := newConsumingSP(true) // accept an unsolicited (no-InResponseTo) assertion
+		decoded := extractSAMLResponse(t, w.Body.String())
+		assertion, err := consumingSP.ParseXMLResponse(decoded, []string{}, consumingSP.AcsURL)
+		require.NoError(t, err)
+		assert.Equal(t, memberEmail, assertion.Subject.NameID.Value)
+	})
+}
+
+// samlIDPGet issues a GET through the router with the IdP host pinned and an
+// optional session cookie.
+func samlIDPGet(router *gin.Engine, path, cookie string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Authorizer-URL", samlIDPTestHost)
+	if cookie != "" {
+		req.Header.Set("Cookie", cookie)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// samlIDPLoginCookie mints a real browser session for the user (mirroring the
+// login flow: CreateAuthToken + memory-store session) and returns the session
+// cookie header value the IdP handler reads via cookie.GetSession.
+func samlIDPLoginCookie(t *testing.T, ts *testSetup, user *schemas.User) string {
+	t.Helper()
+	authToken, err := ts.TokenProvider.CreateAuthToken(nil, &token.AuthTokenConfig{
+		User:        user,
+		Roles:       []string{"user"},
+		Scope:       []string{"openid", "email"},
+		LoginMethod: constants.AuthRecipeMethodBasicAuth,
+		HostName:    samlIDPTestHost,
+	})
+	require.NoError(t, err)
+	sessionKey := constants.AuthRecipeMethodBasicAuth + ":" + user.ID
+	require.NoError(t, ts.MemoryStoreProvider.SetUserSession(
+		sessionKey,
+		constants.TokenTypeSessionToken+"_"+authToken.FingerPrint,
+		authToken.FingerPrintHash,
+		authToken.SessionTokenExpiresAt,
+	))
+	return constants.AppCookieName + "_session=" + url.PathEscape(authToken.FingerPrintHash)
+}
+
+// extractSAMLResponse pulls the base64 SAMLResponse out of the IdP's auto-POST
+// HTML form. html/template escapes attribute values, so unescape before decoding.
+func extractSAMLResponse(t *testing.T, body string) []byte {
+	t.Helper()
+	m := regexp.MustCompile(`name="SAMLResponse" value="([^"]*)"`).FindStringSubmatch(body)
+	require.Len(t, m, 2, "SAMLResponse form field not found: %s", body)
+	decoded, err := base64.StdEncoding.DecodeString(html.UnescapeString(m[1]))
+	require.NoError(t, err)
+	return decoded
+}
+
+func mustURL(t *testing.T, raw string) url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return *u
+}

--- a/internal/server/http_routes.go
+++ b/internal/server/http_routes.go
@@ -81,6 +81,13 @@ func (s *server) NewRouter() *gin.Engine {
 	router.GET("/oauth/saml/:org_slug/metadata", s.Dependencies.HTTPProvider.SAMLMetadataHandler())
 	router.GET("/oauth/saml/:org_slug/login", s.Dependencies.HTTPProvider.SAMLLoginHandler())
 	router.POST("/oauth/saml/:org_slug/acs", s.Dependencies.HTTPProvider.SAMLACSHandler())
+	// Per-organization enterprise SAML 2.0 SSO (Authorizer as Identity Provider):
+	// serves IdP metadata, SP-initiated SSO (GET redirect / POST bindings), and
+	// IdP-initiated SSO to a registered SP (/sso/:sp_id).
+	router.GET("/saml/idp/:org_slug/metadata", s.Dependencies.HTTPProvider.SAMLIDPMetadataHandler())
+	router.GET("/saml/idp/:org_slug/sso", s.Dependencies.HTTPProvider.SAMLIDPSSOHandler())
+	router.POST("/saml/idp/:org_slug/sso", s.Dependencies.HTTPProvider.SAMLIDPSSOHandler())
+	router.GET("/saml/idp/:org_slug/sso/:sp_id", s.Dependencies.HTTPProvider.SAMLIDPInitiatedHandler())
 	router.GET("/verify_email", s.Dependencies.HTTPProvider.VerifyEmailHandler())
 	// Public home-realm discovery: maps a login email's verified domain to the
 	// owning org's SSO login URL (routing hint only; unauthenticated).

--- a/internal/service/admin_provider.go
+++ b/internal/service/admin_provider.go
@@ -76,6 +76,17 @@ type AdminProvider interface {
 	DeleteOrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.Response, *ResponseSideEffects, error)
 	OrgSAMLConnection(ctx context.Context, meta RequestMetadata, params *model.OrgSAMLConnectionRequest) (*model.OrgSAMLConnection, *ResponseSideEffects, error)
 
+	// SAML IdP: registered downstream SPs, signing-key rotation, SP-metadata import.
+	CreateSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error)
+	UpdateSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error)
+	DeleteSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.Response, *ResponseSideEffects, error)
+	SAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error)
+	ListSAMLServiceProviders(ctx context.Context, meta RequestMetadata, params *model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, *ResponseSideEffects, error)
+	RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, params *model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, *ResponseSideEffects, error)
+	RetireSAMLIDPKey(ctx context.Context, meta RequestMetadata, params *model.RetireSAMLIDPKeyRequest) (*model.Response, *ResponseSideEffects, error)
+	ListSAMLIDPKeys(ctx context.Context, meta RequestMetadata, params *model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, *ResponseSideEffects, error)
+	ImportSAMLSPMetadata(ctx context.Context, meta RequestMetadata, params *model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, *ResponseSideEffects, error)
+
 	// Organizations and per-org membership.
 	CreateOrganization(ctx context.Context, meta RequestMetadata, params *model.CreateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)
 	UpdateOrganization(ctx context.Context, meta RequestMetadata, params *model.UpdateOrganizationRequest) (*model.Organization, *ResponseSideEffects, error)

--- a/internal/service/admin_saml_idp.go
+++ b/internal/service/admin_saml_idp.go
@@ -257,6 +257,19 @@ func (p *provider) RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, 
 	if err != nil {
 		return nil, nil, err
 	}
+	// Demote the previously-current key(s) to "active" BEFORE inserting the new
+	// current, so there is never more than one "current" key. A demotion failure
+	// is fatal (returned) rather than logged-and-ignored. If the insert below then
+	// fails the org is momentarily left with no current key — self-healing, since
+	// the next issuance lazily regenerates one; strictly safer than two currents.
+	for _, k := range keys {
+		if k.Status == schemas.SAMLIDPKeyStatusCurrent {
+			k.Status = schemas.SAMLIDPKeyStatusActive
+			if _, err := p.StorageProvider.UpdateSAMLIDPKey(ctx, k); err != nil {
+				return nil, nil, fmt.Errorf("failed to demote previous signing key: %w", err)
+			}
+		}
+	}
 	newKey, err := p.StorageProvider.AddSAMLIDPKey(ctx, &schemas.SAMLIDPKey{
 		OrgID:         orgID,
 		CertPEM:       certPEM,
@@ -266,15 +279,6 @@ func (p *provider) RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, 
 	})
 	if err != nil {
 		return nil, nil, err
-	}
-	// Demote the previously-current key to "active" (still published, not signing).
-	for _, k := range keys {
-		if k.Status == schemas.SAMLIDPKeyStatusCurrent {
-			k.Status = schemas.SAMLIDPKeyStatusActive
-			if _, err := p.StorageProvider.UpdateSAMLIDPKey(ctx, k); err != nil {
-				p.Log.Debug().Err(err).Msg("failed to demote previous SAML signing key")
-			}
-		}
 	}
 	p.auditSAMLIDP(meta, constants.AuditSAMLIDPKeyRotatedEvent, newKey.ID, orgID)
 	return asAPISAMLIDPKey(newKey), nil, nil

--- a/internal/service/admin_saml_idp.go
+++ b/internal/service/admin_saml_idp.go
@@ -1,0 +1,427 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/utils"
+)
+
+// asAPISAMLIDPKey projects a signing-key row onto the GraphQL model. The private
+// key is NEVER surfaced.
+func asAPISAMLIDPKey(k *schemas.SAMLIDPKey) *model.SAMLIDPKey {
+	id := k.ID
+	if strings.Contains(id, schemas.Collections.SAMLIDPKey+"/") {
+		id = strings.TrimPrefix(id, schemas.Collections.SAMLIDPKey+"/")
+	}
+	return &model.SAMLIDPKey{
+		ID:        id,
+		OrgID:     k.OrgID,
+		CertPem:   k.CertPEM,
+		Algorithm: k.Algorithm,
+		Status:    k.Status,
+		CreatedAt: refs.NewInt64Ref(k.CreatedAt),
+		UpdatedAt: refs.NewInt64Ref(k.UpdatedAt),
+	}
+}
+
+// validateSAMLACSURL rejects a non-http(s) or hostless ACS URL. http is permitted
+// (local/testing SPs); https is expected in production.
+func validateSAMLACSURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return fmt.Errorf("acs_url must be a valid http(s) URL")
+	}
+	return nil
+}
+
+// CreateSAMLServiceProvider registers a downstream SP (Authorizer as IdP).
+//
+// Permissions: super-admin or org-admin of params.OrgID.
+func (p *provider) CreateSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.CreateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error) {
+	log := p.Log.With().Str("func", "CreateSAMLServiceProvider").Logger()
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	orgID := strings.TrimSpace(params.OrgID)
+	name := strings.TrimSpace(params.Name)
+	entityID := strings.TrimSpace(params.EntityID)
+	acsURL := strings.TrimSpace(params.AcsURL)
+	if orgID == "" || name == "" || entityID == "" || acsURL == "" {
+		return nil, nil, fmt.Errorf("org_id, name, entity_id and acs_url are required")
+	}
+	if err := validateSAMLACSURL(acsURL); err != nil {
+		return nil, nil, err
+	}
+	if params.SpCertPem != nil && strings.TrimSpace(*params.SpCertPem) != "" {
+		if err := validateSAMLCertPEM(*params.SpCertPem); err != nil {
+			return nil, nil, fmt.Errorf("sp_cert_pem is not a valid X.509 certificate: %w", err)
+		}
+	}
+	if params.MappedAttributes != nil {
+		if err := validateSAMLAttributeMapping(*params.MappedAttributes); err != nil {
+			return nil, nil, err
+		}
+	}
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+	}
+	if existing, _ := p.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, orgID, entityID); existing != nil {
+		return nil, nil, fmt.Errorf("a service provider with entity_id %q is already registered for this organization", entityID)
+	}
+
+	sp := &schemas.SAMLServiceProvider{
+		OrgID:             orgID,
+		Name:              name,
+		EntityID:          entityID,
+		ACSURL:            acsURL,
+		SPCertPEM:         trimmedRef(params.SpCertPem),
+		NameIDFormat:      strings.TrimSpace(refs.StringValue(params.NameIDFormat)),
+		MappedAttributes:  trimmedRef(params.MappedAttributes),
+		AllowIDPInitiated: params.AllowIdpInitiated != nil && *params.AllowIdpInitiated,
+		IsActive:          true,
+	}
+	saved, err := p.StorageProvider.AddSAMLServiceProvider(ctx, sp)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed AddSAMLServiceProvider")
+		return nil, nil, err
+	}
+	p.auditSAMLIDP(meta, constants.AuditSAMLIDPServiceProviderChangedEvent, saved.ID, "created")
+	return saved.AsAPISAMLServiceProvider(), nil, nil
+}
+
+// UpdateSAMLServiceProvider mutates the provided fields of a registered SP.
+//
+// Permissions: super-admin or org-admin of the SP's org.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error) {
+	id := strings.TrimSpace(params.ID)
+	if id == "" {
+		return nil, nil, fmt.Errorf("id is required")
+	}
+	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, id)
+	if err != nil || existing == nil {
+		return nil, nil, fmt.Errorf("service provider not found: %s", id)
+	}
+	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
+		return nil, nil, err
+	}
+
+	if params.Name != nil {
+		if v := strings.TrimSpace(*params.Name); v != "" {
+			existing.Name = v
+		}
+	}
+	if params.EntityID != nil {
+		v := strings.TrimSpace(*params.EntityID)
+		if v != "" && v != existing.EntityID {
+			if conflict, _ := p.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, existing.OrgID, v); conflict != nil && conflict.ID != existing.ID {
+				return nil, nil, fmt.Errorf("a service provider with entity_id %q is already registered for this organization", v)
+			}
+			existing.EntityID = v
+		}
+	}
+	if params.AcsURL != nil {
+		v := strings.TrimSpace(*params.AcsURL)
+		if v != "" {
+			if err := validateSAMLACSURL(v); err != nil {
+				return nil, nil, err
+			}
+			existing.ACSURL = v
+		}
+	}
+	if params.SpCertPem != nil {
+		v := strings.TrimSpace(*params.SpCertPem)
+		if v != "" {
+			if err := validateSAMLCertPEM(v); err != nil {
+				return nil, nil, fmt.Errorf("sp_cert_pem is not a valid X.509 certificate: %w", err)
+			}
+			existing.SPCertPEM = refs.NewStringRef(v)
+		} else {
+			existing.SPCertPEM = nil
+		}
+	}
+	if params.NameIDFormat != nil {
+		existing.NameIDFormat = strings.TrimSpace(*params.NameIDFormat)
+	}
+	if params.MappedAttributes != nil {
+		v := strings.TrimSpace(*params.MappedAttributes)
+		if v != "" {
+			if err := validateSAMLAttributeMapping(v); err != nil {
+				return nil, nil, err
+			}
+			existing.MappedAttributes = refs.NewStringRef(v)
+		} else {
+			existing.MappedAttributes = nil
+		}
+	}
+	if params.AllowIdpInitiated != nil {
+		existing.AllowIDPInitiated = *params.AllowIdpInitiated
+	}
+	if params.IsActive != nil {
+		existing.IsActive = *params.IsActive
+	}
+
+	saved, err := p.StorageProvider.UpdateSAMLServiceProvider(ctx, existing)
+	if err != nil {
+		return nil, nil, err
+	}
+	p.auditSAMLIDP(meta, constants.AuditSAMLIDPServiceProviderChangedEvent, saved.ID, "updated")
+	return saved.AsAPISAMLServiceProvider(), nil, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+//
+// Permissions: super-admin or org-admin of the SP's org.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.Response, *ResponseSideEffects, error) {
+	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, strings.TrimSpace(params.ID))
+	if err != nil || existing == nil {
+		return nil, nil, fmt.Errorf("service provider not found: %s", params.ID)
+	}
+	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if err := p.StorageProvider.DeleteSAMLServiceProvider(ctx, existing); err != nil {
+		return nil, nil, err
+	}
+	p.auditSAMLIDP(meta, constants.AuditSAMLIDPServiceProviderChangedEvent, existing.ID, "deleted")
+	return &model.Response{Message: "service provider deleted"}, nil, nil
+}
+
+// SAMLServiceProvider returns a registered SP by id.
+//
+// Permissions: super-admin or org-admin of the SP's org.
+func (p *provider) SAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error) {
+	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, strings.TrimSpace(params.ID))
+	if err != nil || existing == nil {
+		return nil, nil, fmt.Errorf("service provider not found: %s", params.ID)
+	}
+	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
+		return nil, nil, err
+	}
+	return existing.AsAPISAMLServiceProvider(), nil, nil
+}
+
+// ListSAMLServiceProviders returns an org's registered SPs (paginated).
+//
+// Permissions: super-admin or org-admin of params.OrgID.
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, meta RequestMetadata, params *model.ListSAMLServiceProvidersRequest) (*model.SAMLServiceProviders, *ResponseSideEffects, error) {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	pagination := utils.GetPagination(params.Pagination)
+	rows, page, err := p.StorageProvider.ListSAMLServiceProviders(ctx, strings.TrimSpace(params.OrgID), pagination)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := make([]*model.SAMLServiceProvider, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.AsAPISAMLServiceProvider())
+	}
+	return &model.SAMLServiceProviders{Pagination: page, SamlServiceProviders: out}, nil, nil
+}
+
+// RotateSAMLIDPCert generates a new "current" signing keypair; the previously
+// current key becomes "active" (still published in metadata) until retired.
+//
+// Permissions: super-admin or org-admin of params.OrgID.
+func (p *provider) RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, params *model.RotateSAMLIDPCertRequest) (*model.SAMLIDPKey, *ResponseSideEffects, error) {
+	orgID := strings.TrimSpace(params.OrgID)
+	if err := p.requireOrgAdmin(ctx, meta, orgID); err != nil {
+		return nil, nil, err
+	}
+	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
+		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+	}
+	keys, err := p.StorageProvider.ListSAMLIDPKeys(ctx, orgID)
+	if err != nil {
+		return nil, nil, err
+	}
+	privPEM, certPEM, err := crypto.NewSAMLSigningKeypair("Authorizer SAML IdP " + orgID)
+	if err != nil {
+		return nil, nil, err
+	}
+	enc, err := crypto.EncryptAES(p.ClientSecret, privPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	newKey, err := p.StorageProvider.AddSAMLIDPKey(ctx, &schemas.SAMLIDPKey{
+		OrgID:         orgID,
+		CertPEM:       certPEM,
+		PrivateKeyEnc: enc,
+		Algorithm:     "RS256",
+		Status:        schemas.SAMLIDPKeyStatusCurrent,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	// Demote the previously-current key to "active" (still published, not signing).
+	for _, k := range keys {
+		if k.Status == schemas.SAMLIDPKeyStatusCurrent {
+			k.Status = schemas.SAMLIDPKeyStatusActive
+			if _, err := p.StorageProvider.UpdateSAMLIDPKey(ctx, k); err != nil {
+				p.Log.Debug().Err(err).Msg("failed to demote previous SAML signing key")
+			}
+		}
+	}
+	p.auditSAMLIDP(meta, constants.AuditSAMLIDPKeyRotatedEvent, newKey.ID, orgID)
+	return asAPISAMLIDPKey(newKey), nil, nil
+}
+
+// RetireSAMLIDPKey retires a superseded ("active") key so it stops appearing in
+// IdP metadata. The current key cannot be retired.
+//
+// Permissions: super-admin or org-admin of the key's org.
+func (p *provider) RetireSAMLIDPKey(ctx context.Context, meta RequestMetadata, params *model.RetireSAMLIDPKeyRequest) (*model.Response, *ResponseSideEffects, error) {
+	key, err := p.StorageProvider.GetSAMLIDPKeyByID(ctx, strings.TrimSpace(params.ID))
+	if err != nil || key == nil {
+		return nil, nil, fmt.Errorf("signing key not found: %s", params.ID)
+	}
+	if err := p.requireOrgAdmin(ctx, meta, key.OrgID); err != nil {
+		return nil, nil, err
+	}
+	if key.Status == schemas.SAMLIDPKeyStatusCurrent {
+		return nil, nil, fmt.Errorf("cannot retire the current signing key; rotate to a new key first")
+	}
+	if key.Status == schemas.SAMLIDPKeyStatusRetired {
+		return &model.Response{Message: "signing key already retired"}, nil, nil
+	}
+	key.Status = schemas.SAMLIDPKeyStatusRetired
+	if _, err := p.StorageProvider.UpdateSAMLIDPKey(ctx, key); err != nil {
+		return nil, nil, err
+	}
+	p.auditSAMLIDP(meta, constants.AuditSAMLIDPKeyRetiredEvent, key.ID, key.OrgID)
+	return &model.Response{Message: "signing key retired"}, nil, nil
+}
+
+// ListSAMLIDPKeys returns an org's signing keys (current, active, retired).
+//
+// Permissions: super-admin or org-admin of params.OrgID.
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, meta RequestMetadata, params *model.ListSAMLIDPKeysRequest) ([]*model.SAMLIDPKey, *ResponseSideEffects, error) {
+	if err := p.requireOrgAdmin(ctx, meta, params.OrgID); err != nil {
+		return nil, nil, err
+	}
+	keys, err := p.StorageProvider.ListSAMLIDPKeys(ctx, strings.TrimSpace(params.OrgID))
+	if err != nil {
+		return nil, nil, err
+	}
+	out := make([]*model.SAMLIDPKey, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, asAPISAMLIDPKey(k))
+	}
+	return out, nil, nil
+}
+
+// ImportSAMLSPMetadata parses pasted SP metadata XML and returns the extracted
+// entity_id / acs_url / certificate. It does NOT create a record.
+//
+// Security: parsing uses crewjam/samlsp.ParseMetadata over Go's encoding/xml,
+// which ignores DTDs and does not resolve external entities — no XXE surface.
+//
+// Permissions: super-admin (no org context).
+func (p *provider) ImportSAMLSPMetadata(ctx context.Context, meta RequestMetadata, params *model.ImportSAMLSPMetadataRequest) (*model.SAMLSPMetadataParseResult, *ResponseSideEffects, error) {
+	if err := p.requireSuperAdmin(ctx, meta); err != nil {
+		return nil, nil, err
+	}
+	raw := strings.TrimSpace(params.MetadataXML)
+	if raw == "" {
+		return nil, nil, fmt.Errorf("metadata_xml is required")
+	}
+	ed, err := samlsp.ParseMetadata([]byte(raw))
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not parse SP metadata XML: %w", err)
+	}
+	acsURL := ""
+	certPEM := ""
+	for _, spd := range ed.SPSSODescriptors {
+		for _, acs := range spd.AssertionConsumerServices {
+			if acs.Binding == saml.HTTPPostBinding && acs.Location != "" {
+				acsURL = acs.Location
+				break
+			}
+		}
+		if acsURL == "" && len(spd.AssertionConsumerServices) > 0 {
+			acsURL = spd.AssertionConsumerServices[0].Location
+		}
+		if certPEM == "" {
+			certPEM = firstSigningCertPEM(spd.KeyDescriptors)
+		}
+	}
+	if ed.EntityID == "" || acsURL == "" {
+		return nil, nil, fmt.Errorf("metadata did not contain an SP entity ID and Assertion Consumer Service URL")
+	}
+	res := &model.SAMLSPMetadataParseResult{EntityID: ed.EntityID, AcsURL: acsURL}
+	if certPEM != "" {
+		res.Certificate = refs.NewStringRef(certPEM)
+	}
+	return res, nil, nil
+}
+
+// firstSigningCertPEM returns the first usable X.509 certificate from an SP's key
+// descriptors as PEM, preferring the "signing" use.
+func firstSigningCertPEM(kds []saml.KeyDescriptor) string {
+	pick := func(uses ...string) string {
+		for _, kd := range kds {
+			match := len(uses) == 0
+			for _, u := range uses {
+				if kd.Use == u {
+					match = true
+				}
+			}
+			if !match {
+				continue
+			}
+			for _, c := range kd.KeyInfo.X509Data.X509Certificates {
+				if data := strings.TrimSpace(c.Data); data != "" {
+					der, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(data), ""))
+					if err != nil {
+						continue
+					}
+					return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+				}
+			}
+		}
+		return ""
+	}
+	if pem := pick("signing"); pem != "" {
+		return pem
+	}
+	return pick()
+}
+
+// trimmedRef returns a trimmed *string, or nil when the input is nil/blank.
+func trimmedRef(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	if v := strings.TrimSpace(*s); v != "" {
+		return refs.NewStringRef(v)
+	}
+	return nil
+}
+
+// auditSAMLIDP records an admin SAML-IdP configuration change.
+func (p *provider) auditSAMLIDP(meta RequestMetadata, action, resourceID, detail string) {
+	p.AuditProvider.LogEvent(audit.Event{
+		Action:       action,
+		Protocol:     meta.Protocol,
+		ActorType:    constants.AuditActorTypeAdmin,
+		ResourceType: constants.AuditResourceTypeOrgSAMLConnection,
+		ResourceID:   resourceID,
+		Metadata:     detail,
+		IPAddress:    meta.IPAddress,
+		UserAgent:    meta.UserAgent,
+	})
+}

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -517,6 +517,40 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	}
 	_, _, _ = orgDomainCollection.EnsurePersistentIndex(ctx, []string{"org_id"}, &arangoDriver.EnsurePersistentIndexOptions{})
 
+	// SAMLServiceProvider collection and indexes (registered downstream SPs).
+	samlSPCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.SAMLServiceProvider)
+	if err != nil {
+		return nil, err
+	}
+	if !samlSPCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.SAMLServiceProvider, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	samlSPCollection, err := arangodb.Collection(ctx, schemas.Collections.SAMLServiceProvider)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = samlSPCollection.EnsurePersistentIndex(ctx, []string{"org_id"}, &arangoDriver.EnsurePersistentIndexOptions{})
+
+	// SAMLIDPKey collection and indexes (per-org signing keypairs).
+	samlIDPKeyCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.SAMLIDPKey)
+	if err != nil {
+		return nil, err
+	}
+	if !samlIDPKeyCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.SAMLIDPKey, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	samlIDPKeyCollection, err := arangodb.Collection(ctx, schemas.Collections.SAMLIDPKey)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = samlIDPKeyCollection.EnsurePersistentIndex(ctx, []string{"org_id"}, &arangoDriver.EnsurePersistentIndexOptions{})
+
 	return &provider{
 		config:       cfg,
 		dependencies: deps,

--- a/internal/storage/db/arangodb/saml_idp.go
+++ b/internal/storage/db/arangodb/saml_idp.go
@@ -1,0 +1,278 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	arangoDriver "github.com/arangodb/go-driver"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	spCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLServiceProvider)
+	doc, err := structToDocument(sp)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := spCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	sp.Key = meta.Key
+	sp.ID = meta.ID.String()
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider updates a registered SP record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct, per this
+// method's "callers must load record first" contract.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	spCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLServiceProvider)
+	doc, err := structToDocument(sp)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := spCollection.UpdateDocument(ctx, sp.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	sp.Key = meta.Key
+	sp.ID = meta.ID.String()
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	spCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLServiceProvider)
+	_, err := spCollection.RemoveDocument(ctx, sp.Key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+// Filters on _key, not _id: every real caller holds the bare id
+// AsAPISAMLServiceProvider exposes, never the full "collection/key" handle.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	var sp *schemas.SAMLServiceProvider
+	query := fmt.Sprintf("FOR d in %s FILTER d._key == @id LIMIT 1 RETURN d", schemas.Collections.SAMLServiceProvider)
+	bindVars := map[string]interface{}{
+		"id": id,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if sp == nil {
+				return nil, fmt.Errorf("saml service provider not found")
+			}
+			break
+		}
+		s := &schemas.SAMLServiceProvider{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		sp = s
+	}
+	return sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	var sp *schemas.SAMLServiceProvider
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.entity_id == @entity_id LIMIT 1 RETURN d", schemas.Collections.SAMLServiceProvider)
+	bindVars := map[string]interface{}{
+		"org_id":    orgID,
+		"entity_id": entityID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if sp == nil {
+				return nil, fmt.Errorf("saml service provider not found")
+			}
+			break
+		}
+		s := &schemas.SAMLServiceProvider{}
+		if _, err := readDocument(ctx, cursor, s); err != nil {
+			return nil, err
+		}
+		sp = s
+	}
+	return sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	sps := []*schemas.SAMLServiceProvider{}
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id SORT d.created_at DESC LIMIT %d, %d RETURN d", schemas.Collections.SAMLServiceProvider, pagination.Offset, pagination.Limit)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+	}
+	sctx := arangoDriver.WithQueryFullCount(ctx)
+	cursor, err := p.db.Query(sctx, query, bindVars)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	paginationClone := pagination
+	paginationClone.Total = cursor.Statistics().FullCount()
+	for {
+		sp := &schemas.SAMLServiceProvider{}
+		meta, err := readDocument(ctx, cursor, sp)
+		if arangoDriver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, nil, err
+		}
+		if meta.Key != "" {
+			sps = append(sps, sp)
+		}
+	}
+	return sps, paginationClone, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	keyCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLIDPKey)
+	doc, err := structToDocument(key)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := keyCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	key.Key = meta.Key
+	key.ID = meta.ID.String()
+	return key, nil
+}
+
+// UpdateSAMLIDPKey updates a signing key record (used to flip rotation status).
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct, per this
+// method's "callers must load record first" contract.
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	keyCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLIDPKey)
+	doc, err := structToDocument(key)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := keyCollection.UpdateDocument(ctx, key.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	key.Key = meta.Key
+	key.ID = meta.ID.String()
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	keyCollection, _ := p.db.Collection(ctx, schemas.Collections.SAMLIDPKey)
+	_, err := keyCollection.RemoveDocument(ctx, key.Key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+// Filters on _key, not _id: every real caller holds the bare id, never the
+// full "collection/key" handle.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	var key *schemas.SAMLIDPKey
+	query := fmt.Sprintf("FOR d in %s FILTER d._key == @id LIMIT 1 RETURN d", schemas.Collections.SAMLIDPKey)
+	bindVars := map[string]interface{}{
+		"id": id,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if key == nil {
+				return nil, fmt.Errorf("saml idp key not found")
+			}
+			break
+		}
+		k := &schemas.SAMLIDPKey{}
+		if _, err := readDocument(ctx, cursor, k); err != nil {
+			return nil, err
+		}
+		key = k
+	}
+	return key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org (newest first).
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	keys := []*schemas.SAMLIDPKey{}
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id SORT d.created_at DESC RETURN d", schemas.Collections.SAMLIDPKey)
+	bindVars := map[string]interface{}{
+		"org_id": orgID,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		key := &schemas.SAMLIDPKey{}
+		meta, err := readDocument(ctx, cursor, key)
+		if arangoDriver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if meta.Key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return keys, nil
+}

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -466,6 +466,36 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	// index (hot path for client_assertion validation) to become queryable.
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.TrustedIssuer, "issuer_url", 30*time.Second)
 
+	// SAMLServiceProvider table and indexes (registered downstream SPs; Authorizer as IdP)
+	samlServiceProviderCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, name text, entity_id text, acs_url text, sp_cert_pem text, name_id_format text, mapped_attributes text, allow_idp_initiated boolean, is_active boolean, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.SAMLServiceProvider)
+	if err = session.Query(samlServiceProviderCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	samlServiceProviderOrgIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_saml_service_provider_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.SAMLServiceProvider)
+	if err = session.Query(samlServiceProviderOrgIDIndex).Exec(); err != nil {
+		return nil, err
+	}
+	samlServiceProviderEntityIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_saml_service_provider_entity_id ON %s.%s (entity_id)", KeySpace, schemas.Collections.SAMLServiceProvider)
+	if err = session.Query(samlServiceProviderEntityIDIndex).Exec(); err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for the org_id index
+	// (used to resolve an incoming AuthnRequest to its registered SP) to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.SAMLServiceProvider, "org_id", 30*time.Second)
+
+	// SAMLIDPKey table and index (per-org signing keypairs with rotation)
+	samlIDPKeyCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, cert_pem text, private_key_enc text, algorithm text, status text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.SAMLIDPKey)
+	if err = session.Query(samlIDPKeyCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	samlIDPKeyOrgIDIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_saml_idp_key_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.SAMLIDPKey)
+	if err = session.Query(samlIDPKeyOrgIDIndex).Exec(); err != nil {
+		return nil, err
+	}
+	// ScyllaDB builds secondary indexes asynchronously; wait for the org_id index
+	// (used to enumerate an org's signing keys for metadata publishing) to become queryable.
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.SAMLIDPKey, "org_id", 30*time.Second)
+
 	// WebauthnCredential table and indexes
 	webauthnCredentialCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, user_id text, credential_id text, public_key text, sign_count bigint, flags bigint, transports text, aaguid text, name text, created_at bigint, updated_at bigint, last_used_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.WebauthnCredential)
 	err = session.Query(webauthnCredentialCollectionQuery).Exec()

--- a/internal/storage/db/cassandradb/saml_idp.go
+++ b/internal/storage/db/cassandradb/saml_idp.go
@@ -1,0 +1,230 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+const samlServiceProviderColumns = "id, org_id, name, entity_id, acs_url, sp_cert_pem, name_id_format, mapped_attributes, allow_idp_initiated, is_active, created_at, updated_at"
+
+// scanSAMLServiceProvider maps the samlServiceProviderColumns projection onto a struct.
+func scanSAMLServiceProvider(scan func(...interface{}) error, sp *schemas.SAMLServiceProvider) error {
+	return scan(&sp.ID, &sp.OrgID, &sp.Name, &sp.EntityID, &sp.ACSURL, &sp.SPCertPEM, &sp.NameIDFormat, &sp.MappedAttributes, &sp.AllowIDPInitiated, &sp.IsActive, &sp.CreatedAt, &sp.UpdatedAt)
+}
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.SAMLServiceProvider, samlServiceProviderColumns)
+	err := p.db.Query(insertQuery, sp.ID, sp.OrgID, sp.Name, sp.EntityID, sp.ACSURL, sp.SPCertPEM, sp.NameIDFormat, sp.MappedAttributes, sp.AllowIDPInitiated, sp.IsActive, sp.CreatedAt, sp.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider updates a registered SP.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	spMap := buildCQLColumnMap(sp)
+	updateFields := ""
+	var updateValues []interface{}
+	for key, value := range spMap {
+		if key == "id" || key == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", key)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", key)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, sp.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.SAMLServiceProvider, updateFields)
+	err := p.db.Query(query, updateValues...).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.SAMLServiceProvider)
+	return p.db.Query(query, sp.ID).Exec()
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	var sp schemas.SAMLServiceProvider
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", samlServiceProviderColumns, KeySpace+"."+schemas.Collections.SAMLServiceProvider)
+	err := scanSAMLServiceProvider(p.db.Query(query, id).Consistency(gocql.One).Scan, &sp)
+	if err != nil {
+		return nil, err
+	}
+	return &sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	var sp schemas.SAMLServiceProvider
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND entity_id = ? LIMIT 1 ALLOW FILTERING", samlServiceProviderColumns, KeySpace+"."+schemas.Collections.SAMLServiceProvider)
+	err := scanSAMLServiceProvider(p.db.Query(query, orgID, entityID).Consistency(gocql.One).Scan, &sp)
+	if err != nil {
+		return nil, err
+	}
+	return &sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	sps := []*schemas.SAMLServiceProvider{}
+	paginationClone := pagination
+	table := KeySpace + "." + schemas.Collections.SAMLServiceProvider
+
+	totalCountQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE org_id = ? ALLOW FILTERING", table)
+	err := p.db.Query(totalCountQuery, orgID).Consistency(gocql.One).Scan(&paginationClone.Total)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// there is no offset in cassandra
+	// so we fetch till limit + offset
+	// and return the results from offset to limit
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? LIMIT %d ALLOW FILTERING", samlServiceProviderColumns, table, pagination.Limit+pagination.Offset)
+	scanner := p.db.Query(query, orgID).Iter().Scanner()
+	counter := int64(0)
+	for scanner.Next() {
+		if counter >= pagination.Offset {
+			var sp schemas.SAMLServiceProvider
+			if err := scanSAMLServiceProvider(scanner.Scan, &sp); err != nil {
+				return nil, nil, err
+			}
+			sps = append(sps, &sp)
+		}
+		counter++
+	}
+	return sps, paginationClone, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+const samlIDPKeyColumns = "id, org_id, cert_pem, private_key_enc, algorithm, status, created_at, updated_at"
+
+// scanSAMLIDPKey maps the samlIDPKeyColumns projection onto a struct.
+func scanSAMLIDPKey(scan func(...interface{}) error, key *schemas.SAMLIDPKey) error {
+	return scan(&key.ID, &key.OrgID, &key.CertPEM, &key.PrivateKeyEnc, &key.Algorithm, &key.Status, &key.CreatedAt, &key.UpdatedAt)
+}
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.SAMLIDPKey, samlIDPKeyColumns)
+	err := p.db.Query(insertQuery, key.ID, key.OrgID, key.CertPEM, key.PrivateKeyEnc, key.Algorithm, key.Status, key.CreatedAt, key.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// UpdateSAMLIDPKey updates a signing key (used to flip status).
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	keyMap := buildCQLColumnMap(key)
+	updateFields := ""
+	var updateValues []interface{}
+	for k, value := range keyMap {
+		if k == "id" || k == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", k)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", k)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, key.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.SAMLIDPKey, updateFields)
+	err := p.db.Query(query, updateValues...).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.SAMLIDPKey)
+	return p.db.Query(query, key.ID).Exec()
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	var key schemas.SAMLIDPKey
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", samlIDPKeyColumns, KeySpace+"."+schemas.Collections.SAMLIDPKey)
+	err := scanSAMLIDPKey(p.db.Query(query, id).Consistency(gocql.One).Scan, &key)
+	if err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org.
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	keys := []*schemas.SAMLIDPKey{}
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? ALLOW FILTERING", samlIDPKeyColumns, KeySpace+"."+schemas.Collections.SAMLIDPKey)
+	// ponytail: Cassandra can't ORDER BY a non-clustering column, so the SQL
+	// side's created_at DESC ordering isn't replicated here; callers that need
+	// ordering sort in-memory (key sets are tiny — a handful per org).
+	scanner := p.db.Query(query, orgID).Iter().Scanner()
+	for scanner.Next() {
+		var key schemas.SAMLIDPKey
+		if err := scanSAMLIDPKey(scanner.Scan, &key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, &key)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -291,6 +291,14 @@ func getIndex(scopeName string) map[string][]string {
 	trustedIssuerIndex2 := fmt.Sprintf("CREATE INDEX TrustedIssuerClientIdIndex ON %s.%s(client_id)", scopeName, schemas.Collections.TrustedIssuer)
 	indices[schemas.Collections.TrustedIssuer] = []string{trustedIssuerIndex1, trustedIssuerIndex2}
 
+	// SAMLServiceProvider indexes
+	samlServiceProviderIndex1 := fmt.Sprintf("CREATE INDEX SAMLServiceProviderOrgIdEntityIdIndex ON %s.%s(org_id, entity_id)", scopeName, schemas.Collections.SAMLServiceProvider)
+	indices[schemas.Collections.SAMLServiceProvider] = []string{samlServiceProviderIndex1}
+
+	// SAMLIDPKey indexes
+	samlIDPKeyIndex1 := fmt.Sprintf("CREATE INDEX SAMLIDPKeyOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.SAMLIDPKey)
+	indices[schemas.Collections.SAMLIDPKey] = []string{samlIDPKeyIndex1}
+
 	// WebauthnCredential indexes
 	webauthnCredentialIndex1 := fmt.Sprintf("CREATE INDEX WebauthnCredentialCredentialIdIndex ON %s.%s(credential_id)", scopeName, schemas.Collections.WebauthnCredential)
 	webauthnCredentialIndex2 := fmt.Sprintf("CREATE INDEX WebauthnCredentialUserIdIndex ON %s.%s(user_id)", scopeName, schemas.Collections.WebauthnCredential)

--- a/internal/storage/db/couchbase/saml_idp.go
+++ b/internal/storage/db/couchbase/saml_idp.go
@@ -1,0 +1,301 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const samlServiceProviderColumns = "_id, org_id, name, entity_id, acs_url, sp_cert_pem, name_id_format, mapped_attributes, allow_idp_initiated, is_active, created_at, updated_at"
+
+const samlIDPKeyColumns = "_id, org_id, cert_pem, private_key_enc, algorithm, status, created_at, updated_at"
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(sp)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.SAMLServiceProvider).Insert(sp.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider writes back a fully-loaded record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	spMap, err := structToDocument(sp)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(spMap)
+	params["_id"] = sp.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.SAMLServiceProvider, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.SAMLServiceProvider).Remove(sp.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	params := make(map[string]interface{}, 1)
+	params["_id"] = id
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, samlServiceProviderColumns, p.scopeName, schemas.Collections.SAMLServiceProvider)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	sp := &schemas.SAMLServiceProvider{}
+	if err := decodeDocument(raw, sp); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	params := make(map[string]interface{}, 2)
+	params["org_id"] = orgID
+	params["entity_id"] = entityID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND entity_id=$entity_id LIMIT 1`, samlServiceProviderColumns, p.scopeName, schemas.Collections.SAMLServiceProvider)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	sp := &schemas.SAMLServiceProvider{}
+	if err := decodeDocument(raw, sp); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	sps := []*schemas.SAMLServiceProvider{}
+	paginationClone := pagination
+	table := fmt.Sprintf("%s.%s", p.scopeName, schemas.Collections.SAMLServiceProvider)
+
+	params := make(map[string]interface{}, 3)
+	params["offset"] = paginationClone.Offset
+	params["limit"] = paginationClone.Limit
+	params["org_id"] = orgID
+
+	countParams := make(map[string]interface{}, 1)
+	countParams["org_id"] = orgID
+	total := TotalDocs{}
+	countQuery := fmt.Sprintf("SELECT COUNT(*) as Total FROM %s WHERE org_id=$org_id", table)
+	countRes, err := p.db.Query(countQuery, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: countParams,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = countRes.One(&total)
+	paginationClone.Total = total.Total
+
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id=$org_id ORDER BY created_at DESC OFFSET $offset LIMIT $limit", samlServiceProviderColumns, table)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, nil, err
+		}
+		sp := &schemas.SAMLServiceProvider{}
+		if err := decodeDocument(raw, sp); err != nil {
+			return nil, nil, err
+		}
+		sps = append(sps, sp)
+	}
+	if err := queryResult.Err(); err != nil {
+		return nil, nil, err
+	}
+	return sps, paginationClone, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(key)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.SAMLIDPKey).Insert(key.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// UpdateSAMLIDPKey writes back a fully-loaded record (used to flip status).
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	keyMap, err := structToDocument(key)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(keyMap)
+	params["_id"] = key.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.SAMLIDPKey, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.SAMLIDPKey).Remove(key.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	params := make(map[string]interface{}, 1)
+	params["_id"] = id
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, samlIDPKeyColumns, p.scopeName, schemas.Collections.SAMLIDPKey)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	key := &schemas.SAMLIDPKey{}
+	if err := decodeDocument(raw, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org (newest first).
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	keys := []*schemas.SAMLIDPKey{}
+	params := make(map[string]interface{}, 1)
+	params["org_id"] = orgID
+	query := fmt.Sprintf("SELECT %s FROM %s.%s WHERE org_id=$org_id ORDER BY created_at DESC", samlIDPKeyColumns, p.scopeName, schemas.Collections.SAMLIDPKey)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, err
+		}
+		key := &schemas.SAMLIDPKey{}
+		if err := decodeDocument(raw, key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if err := queryResult.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}

--- a/internal/storage/db/dynamodb/saml_idp.go
+++ b/internal/storage/db/dynamodb/saml_idp.go
@@ -1,0 +1,185 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	if err := p.putItem(ctx, schemas.Collections.SAMLServiceProvider, sp); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider writes back a fully-loaded record. UpdateItem applies
+// a partial SET/REMOVE merge, so callers MUST load the record and mutate it
+// before calling — a partial struct blanks untouched columns to zero values.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.SAMLServiceProvider, "id", sp.ID, sp); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	if sp == nil {
+		return nil
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.SAMLServiceProvider, "id", sp.ID)
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	var sp schemas.SAMLServiceProvider
+	err := p.getItemByHash(ctx, schemas.Collections.SAMLServiceProvider, "id", id, &sp)
+	if err != nil {
+		return nil, err
+	}
+	if sp.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding. Query
+// the org_id GSI then filter entity_id in Go.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	f := expression.Name("entity_id").Equal(expression.Value(entityID))
+	items, err := p.queryEq(ctx, schemas.Collections.SAMLServiceProvider, "org_id", "org_id", orgID, &f)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.New("no document found")
+	}
+	var sp schemas.SAMLServiceProvider
+	if err := unmarshalItem(items[0], &sp); err != nil {
+		return nil, err
+	}
+	return &sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	paginationClone := pagination
+	items, err := p.queryEq(ctx, schemas.Collections.SAMLServiceProvider, "org_id", "org_id", orgID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var sps []*schemas.SAMLServiceProvider
+	for _, it := range items {
+		var sp schemas.SAMLServiceProvider
+		if err := unmarshalItem(it, &sp); err != nil {
+			return nil, nil, err
+		}
+		sps = append(sps, &sp)
+	}
+
+	sort.Slice(sps, func(i, j int) bool { return sps[i].CreatedAt > sps[j].CreatedAt })
+	paginationClone.Total = int64(len(sps))
+
+	start := int(pagination.Offset)
+	if start >= len(sps) {
+		return []*schemas.SAMLServiceProvider{}, paginationClone, nil
+	}
+	end := start + int(pagination.Limit)
+	if end > len(sps) {
+		end = len(sps)
+	}
+	return sps[start:end], paginationClone, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	if err := p.putItem(ctx, schemas.Collections.SAMLIDPKey, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// UpdateSAMLIDPKey writes back a fully-loaded record (used to flip status).
+// Callers MUST load the record and mutate it before calling.
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.SAMLIDPKey, "id", key.ID, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	if key == nil {
+		return nil
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.SAMLIDPKey, "id", key.ID)
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	var key schemas.SAMLIDPKey
+	err := p.getItemByHash(ctx, schemas.Collections.SAMLIDPKey, "id", id, &key)
+	if err != nil {
+		return nil, err
+	}
+	if key.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org (newest first).
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	items, err := p.queryEq(ctx, schemas.Collections.SAMLIDPKey, "org_id", "org_id", orgID, nil)
+	if err != nil {
+		return nil, err
+	}
+	var keys []*schemas.SAMLIDPKey
+	for _, it := range items {
+		var key schemas.SAMLIDPKey
+		if err := unmarshalItem(it, &key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, &key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].CreatedAt > keys[j].CreatedAt })
+	return keys, nil
+}

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -267,6 +267,24 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			},
 			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
 		},
+		{
+			name: schemas.Collections.SAMLServiceProvider,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
+		},
+		{
+			name: schemas.Collections.SAMLIDPKey,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
+		},
 	}
 
 	for _, t := range tables {

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -319,6 +319,28 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// SAMLServiceProvider collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.SAMLServiceProvider, options.CreateCollection())
+	samlServiceProviderCollection := mongodb.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	_, _ = samlServiceProviderCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.M{"org_id": 1},
+		},
+		{
+			Keys:    bson.D{{Key: "org_id", Value: 1}, {Key: "entity_id", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	}, options.CreateIndexes())
+
+	// SAMLIDPKey collection and indexes
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.SAMLIDPKey, options.CreateCollection())
+	samlIDPKeyCollection := mongodb.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	_, _ = samlIDPKeyCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.M{"org_id": 1},
+		},
+	}, options.CreateIndexes())
+
 	return &provider{
 		config:       config,
 		dependencies: deps,

--- a/internal/storage/db/mongodb/saml_idp.go
+++ b/internal/storage/db/mongodb/saml_idp.go
@@ -1,0 +1,191 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	_, err := spCollection.InsertOne(ctx, sp)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider writes back a fully-loaded record. The $set write
+// replaces every column, so callers MUST load the record and mutate it before
+// calling — a partial struct will blank zero-value fields.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	_, err := spCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": sp.ID}}, bson.M{"$set": sp}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	_, err := spCollection.DeleteOne(ctx, bson.M{"_id": sp.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	var sp *schemas.SAMLServiceProvider
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	err := spCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&sp)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	var sp *schemas.SAMLServiceProvider
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	err := spCollection.FindOne(ctx, bson.M{"org_id": orgID, "entity_id": entityID}).Decode(&sp)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	sps := []*schemas.SAMLServiceProvider{}
+	filter := bson.M{"org_id": orgID}
+	opts := options.Find()
+	opts.SetLimit(pagination.Limit)
+	opts.SetSkip(pagination.Offset)
+	opts.SetSort(bson.M{"created_at": -1})
+	paginationClone := pagination
+	spCollection := p.db.Collection(schemas.Collections.SAMLServiceProvider, options.Collection())
+	count, err := spCollection.CountDocuments(ctx, filter, options.Count())
+	if err != nil {
+		return nil, nil, err
+	}
+	paginationClone.Total = count
+	cursor, err := spCollection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	for cursor.Next(ctx) {
+		var sp *schemas.SAMLServiceProvider
+		err := cursor.Decode(&sp)
+		if err != nil {
+			return nil, nil, err
+		}
+		sps = append(sps, sp)
+	}
+	return sps, paginationClone, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	keyCollection := p.db.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	_, err := keyCollection.InsertOne(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// UpdateSAMLIDPKey writes back a fully-loaded record (used to flip status). The
+// $set write replaces every column, so callers MUST load the record and mutate
+// it before calling — a partial struct will blank zero-value fields.
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	keyCollection := p.db.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	_, err := keyCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": key.ID}}, bson.M{"$set": key}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	keyCollection := p.db.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	_, err := keyCollection.DeleteOne(ctx, bson.M{"_id": key.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	var key *schemas.SAMLIDPKey
+	keyCollection := p.db.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	err := keyCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org (newest first).
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	keys := []*schemas.SAMLIDPKey{}
+	keyCollection := p.db.Collection(schemas.Collections.SAMLIDPKey, options.Collection())
+	opts := options.Find()
+	opts.SetSort(bson.M{"created_at": -1})
+	cursor, err := keyCollection.Find(ctx, bson.M{"org_id": orgID}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	for cursor.Next(ctx) {
+		var key *schemas.SAMLIDPKey
+		err := cursor.Decode(&key)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{}, &schemas.WebauthnCredential{}, &schemas.OrgDomain{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{}, &schemas.WebauthnCredential{}, &schemas.OrgDomain{}, &schemas.SAMLServiceProvider{}, &schemas.SAMLIDPKey{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/sql/saml_idp.go
+++ b/internal/storage/db/sql/saml_idp.go
@@ -1,0 +1,145 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// --- SAMLServiceProvider (registered downstream SPs; Authorizer as IdP) ---
+
+// AddSAMLServiceProvider registers a new downstream SP.
+func (p *provider) AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.ID == "" {
+		sp.ID = uuid.New().String()
+	}
+	sp.Key = sp.ID
+	now := time.Now().Unix()
+	sp.CreatedAt = now
+	sp.UpdatedAt = now
+	res := p.db.Create(sp)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return sp, nil
+}
+
+// UpdateSAMLServiceProvider writes back a fully-loaded record. Save writes every
+// column, so callers MUST load the record and mutate it before calling.
+func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error) {
+	if sp.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLServiceProvider: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	sp.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(sp)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return sp, nil
+}
+
+// DeleteSAMLServiceProvider removes a registered SP.
+func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error {
+	return p.db.Delete(sp).Error
+}
+
+// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+func (p *provider) GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error) {
+	var sp schemas.SAMLServiceProvider
+	res := p.db.Where("id = ?", id).First(&sp)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &sp, nil
+}
+
+// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for an
+// (orgID, entityID) pair — the AuthnRequest-Issuer → trusted-ACS binding.
+func (p *provider) GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error) {
+	var sp schemas.SAMLServiceProvider
+	res := p.db.Where("org_id = ? AND entity_id = ?", orgID, entityID).First(&sp)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &sp, nil
+}
+
+// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+func (p *provider) ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error) {
+	var sps []*schemas.SAMLServiceProvider
+	res := p.db.Where("org_id = ?", orgID).Limit(int(pagination.Limit)).Offset(int(pagination.Offset)).Order("created_at DESC").Find(&sps)
+	if res.Error != nil {
+		return nil, nil, res.Error
+	}
+	var total int64
+	if err := p.db.Model(&schemas.SAMLServiceProvider{}).Where("org_id = ?", orgID).Count(&total).Error; err != nil {
+		return nil, nil, err
+	}
+	return sps, &model.Pagination{
+		Limit:  pagination.Limit,
+		Page:   pagination.Page,
+		Offset: pagination.Offset,
+		Total:  total,
+	}, nil
+}
+
+// --- SAMLIDPKey (per-org signing keypairs with rotation) ---
+
+// AddSAMLIDPKey persists a newly-generated signing keypair.
+func (p *provider) AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.ID == "" {
+		key.ID = uuid.New().String()
+	}
+	key.Key = key.ID
+	now := time.Now().Unix()
+	key.CreatedAt = now
+	key.UpdatedAt = now
+	res := p.db.Create(key)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return key, nil
+}
+
+// UpdateSAMLIDPKey writes back a fully-loaded record (used to flip status).
+func (p *provider) UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error) {
+	if key.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateSAMLIDPKey: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	key.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(key)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return key, nil
+}
+
+// DeleteSAMLIDPKey removes a signing key.
+func (p *provider) DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error {
+	return p.db.Delete(key).Error
+}
+
+// GetSAMLIDPKeyByID fetches a signing key by primary key.
+func (p *provider) GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error) {
+	var key schemas.SAMLIDPKey
+	res := p.db.Where("id = ?", id).First(&key)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &key, nil
+}
+
+// ListSAMLIDPKeys returns every signing key for an org (newest first).
+func (p *provider) ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error) {
+	var keys []*schemas.SAMLIDPKey
+	res := p.db.Where("org_id = ?", orgID).Order("created_at DESC").Find(&keys)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return keys, nil
+}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -238,6 +238,41 @@ type Provider interface {
 	// Pass an empty serviceAccountID to list all issuers.
 	ListTrustedIssuers(ctx context.Context, serviceAccountID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error)
 
+	// SAMLServiceProvider methods (downstream SPs Authorizer issues assertions to,
+	// acting as the SAML IdP). Scoped per Organization.
+
+	// AddSAMLServiceProvider registers a new downstream SP.
+	AddSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error)
+	// UpdateSAMLServiceProvider writes back a fully-loaded record. Callers MUST
+	// load the existing record and mutate it before calling (Save semantics).
+	UpdateSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) (*schemas.SAMLServiceProvider, error)
+	// DeleteSAMLServiceProvider removes a registered SP.
+	DeleteSAMLServiceProvider(ctx context.Context, sp *schemas.SAMLServiceProvider) error
+	// GetSAMLServiceProviderByID fetches a registered SP by primary key.
+	GetSAMLServiceProviderByID(ctx context.Context, id string) (*schemas.SAMLServiceProvider, error)
+	// GetSAMLServiceProviderByOrgAndEntityID resolves the single registered SP for
+	// an (orgID, entityID) pair — the lookup that binds an incoming AuthnRequest's
+	// Issuer to a trusted ACS URL. Returns an error when no matching row exists.
+	GetSAMLServiceProviderByOrgAndEntityID(ctx context.Context, orgID, entityID string) (*schemas.SAMLServiceProvider, error)
+	// ListSAMLServiceProviders returns the registered SPs for an org (paginated).
+	ListSAMLServiceProviders(ctx context.Context, orgID string, pagination *model.Pagination) ([]*schemas.SAMLServiceProvider, *model.Pagination, error)
+
+	// SAMLIDPKey methods (per-org SAML IdP signing keypairs with rotation).
+
+	// AddSAMLIDPKey persists a newly-generated signing keypair.
+	AddSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error)
+	// UpdateSAMLIDPKey writes back a fully-loaded record (used to flip rotation
+	// status). Callers MUST load the existing record before calling.
+	UpdateSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) (*schemas.SAMLIDPKey, error)
+	// DeleteSAMLIDPKey removes a signing key.
+	DeleteSAMLIDPKey(ctx context.Context, key *schemas.SAMLIDPKey) error
+	// GetSAMLIDPKeyByID fetches a signing key by primary key.
+	GetSAMLIDPKeyByID(ctx context.Context, id string) (*schemas.SAMLIDPKey, error)
+	// ListSAMLIDPKeys returns every signing key for an org (typically 1–3). The
+	// caller filters by Status: "current" is the signing key, "current"+"active"
+	// are published in metadata.
+	ListSAMLIDPKeys(ctx context.Context, orgID string) ([]*schemas.SAMLIDPKey, error)
+
 	// WebauthnCredential methods (per-user passkey credentials).
 
 	// AddWebauthnCredential persists a newly registered passkey.

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -208,6 +208,10 @@ func TestStorageProvider(t *testing.T) {
 				testOrgSAMLOperations(t, ctx, provider, dbType)
 			})
 
+			t.Run("SAML IdP Storage Operations", func(t *testing.T) {
+				testSAMLIDPStorageOperations(t, ctx, provider)
+			})
+
 			t.Run("SCIM Endpoint Operations", func(t *testing.T) {
 				testScimEndpointOperations(t, ctx, provider)
 			})

--- a/internal/storage/saml_idp_test.go
+++ b/internal/storage/saml_idp_test.go
@@ -1,0 +1,96 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// testSAMLIDPStorageOperations exercises the SAMLServiceProvider and SAMLIDPKey
+// CRUD across every configured DB provider (the multi-DB parity guard).
+func testSAMLIDPStorageOperations(t *testing.T, ctx context.Context, p Provider) {
+	orgID := "org-" + uuid.New().String()
+	entityID := "https://sp-" + uuid.New().String() + ".example.com/metadata"
+
+	// --- SAMLServiceProvider ---
+	sp, err := p.AddSAMLServiceProvider(ctx, &schemas.SAMLServiceProvider{
+		OrgID:             orgID,
+		Name:              "Zendesk",
+		EntityID:          entityID,
+		ACSURL:            "https://sp.example.com/acs",
+		NameIDFormat:      "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+		MappedAttributes:  refs.NewStringRef(`{"email":"email"}`),
+		AllowIDPInitiated: true,
+		IsActive:          true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, sp.ID)
+
+	byID, err := p.GetSAMLServiceProviderByID(ctx, sp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Zendesk", byID.Name)
+	assert.Equal(t, entityID, byID.EntityID)
+	assert.True(t, byID.AllowIDPInitiated)
+
+	byEntity, err := p.GetSAMLServiceProviderByOrgAndEntityID(ctx, orgID, entityID)
+	require.NoError(t, err)
+	assert.Equal(t, sp.ID, byEntity.ID)
+
+	// Wrong org must not resolve the record.
+	_, err = p.GetSAMLServiceProviderByOrgAndEntityID(ctx, "org-other", entityID)
+	assert.Error(t, err, "SP lookup must be org-scoped")
+
+	byEntity.Name = "Zendesk Prod"
+	byEntity.IsActive = false
+	updated, err := p.UpdateSAMLServiceProvider(ctx, byEntity)
+	require.NoError(t, err)
+	assert.Equal(t, "Zendesk Prod", updated.Name)
+	assert.False(t, updated.IsActive)
+
+	list, page, err := p.ListSAMLServiceProviders(ctx, orgID, &model.Pagination{Limit: 10, Offset: 0, Page: 1})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(list), 1)
+	assert.GreaterOrEqual(t, page.Total, int64(1))
+
+	require.NoError(t, p.DeleteSAMLServiceProvider(ctx, updated))
+	_, err = p.GetSAMLServiceProviderByID(ctx, sp.ID)
+	assert.Error(t, err, "deleted SP must not be retrievable")
+
+	// --- SAMLIDPKey ---
+	keyOrg := "keyorg-" + uuid.New().String()
+	key, err := p.AddSAMLIDPKey(ctx, &schemas.SAMLIDPKey{
+		OrgID:         keyOrg,
+		CertPEM:       "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+		PrivateKeyEnc: "encrypted-blob",
+		Algorithm:     "RS256",
+		Status:        schemas.SAMLIDPKeyStatusCurrent,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, key.ID)
+
+	gotKey, err := p.GetSAMLIDPKeyByID(ctx, key.ID)
+	require.NoError(t, err)
+	assert.Equal(t, schemas.SAMLIDPKeyStatusCurrent, gotKey.Status)
+	assert.Equal(t, "encrypted-blob", gotKey.PrivateKeyEnc, "encrypted private key must round-trip")
+
+	gotKey.Status = schemas.SAMLIDPKeyStatusActive
+	_, err = p.UpdateSAMLIDPKey(ctx, gotKey)
+	require.NoError(t, err)
+
+	keys, err := p.ListSAMLIDPKeys(ctx, keyOrg)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, schemas.SAMLIDPKeyStatusActive, keys[0].Status)
+
+	require.NoError(t, p.DeleteSAMLIDPKey(ctx, keys[0]))
+	remaining, err := p.ListSAMLIDPKeys(ctx, keyOrg)
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+}

--- a/internal/storage/saml_idp_test.go
+++ b/internal/storage/saml_idp_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -32,8 +33,11 @@ func testSAMLIDPStorageOperations(t *testing.T, ctx context.Context, p Provider)
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, sp.ID)
+	// The public/API id (arangodb's Add returns the "collection/key" handle;
+	// the service layer always looks records up by the stripped API id).
+	spAPIID := sp.AsAPISAMLServiceProvider().ID
 
-	byID, err := p.GetSAMLServiceProviderByID(ctx, sp.ID)
+	byID, err := p.GetSAMLServiceProviderByID(ctx, spAPIID)
 	require.NoError(t, err)
 	assert.Equal(t, "Zendesk", byID.Name)
 	assert.Equal(t, entityID, byID.EntityID)
@@ -60,7 +64,7 @@ func testSAMLIDPStorageOperations(t *testing.T, ctx context.Context, p Provider)
 	assert.GreaterOrEqual(t, page.Total, int64(1))
 
 	require.NoError(t, p.DeleteSAMLServiceProvider(ctx, updated))
-	_, err = p.GetSAMLServiceProviderByID(ctx, sp.ID)
+	_, err = p.GetSAMLServiceProviderByID(ctx, spAPIID)
 	assert.Error(t, err, "deleted SP must not be retrievable")
 
 	// --- SAMLIDPKey ---
@@ -74,8 +78,9 @@ func testSAMLIDPStorageOperations(t *testing.T, ctx context.Context, p Provider)
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, key.ID)
+	keyAPIID := strings.TrimPrefix(key.ID, schemas.Collections.SAMLIDPKey+"/")
 
-	gotKey, err := p.GetSAMLIDPKeyByID(ctx, key.ID)
+	gotKey, err := p.GetSAMLIDPKeyByID(ctx, keyAPIID)
 	require.NoError(t, err)
 	assert.Equal(t, schemas.SAMLIDPKeyStatusCurrent, gotKey.Status)
 	assert.Equal(t, "encrypted-blob", gotKey.PrivateKeyEnc, "encrypted private key must round-trip")

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -24,6 +24,8 @@ type CollectionList struct {
 	ScimEndpoint           string
 	WebauthnCredential     string
 	OrgDomain              string
+	SAMLServiceProvider    string
+	SAMLIDPKey             string
 }
 
 var (
@@ -53,5 +55,7 @@ var (
 		ScimEndpoint:           Prefix + "scim_endpoints",
 		WebauthnCredential:     Prefix + "webauthn_credentials",
 		OrgDomain:              Prefix + "org_domains",
+		SAMLServiceProvider:    Prefix + "saml_service_providers",
+		SAMLIDPKey:             Prefix + "saml_idp_keys",
 	}
 )

--- a/internal/storage/schemas/saml_idp_key.go
+++ b/internal/storage/schemas/saml_idp_key.go
@@ -1,0 +1,58 @@
+package schemas
+
+// SAMLIDPKey is a per-organization SAML IdP signing keypair: an RSA private key
+// and its self-signed X.509 certificate. Authorizer signs the SAML assertions it
+// issues (as an IdP) with this key; downstream SPs pin the certificate.
+//
+// The JWT signing key (Config.JWTPrivateKey) is deliberately NOT reused: SAML
+// XML-DSIG requires an X.509 certificate wrapper, which the raw-PEM JWT key does
+// not carry, and SAML key rotation is independent of JWT key rotation.
+//
+// ROTATION (Status field):
+//   - "current" — the single active key NEW assertions are signed with. There is
+//     at most one "current" key per org.
+//   - "active"  — a formerly-current key that is STILL published in IdP metadata
+//     so that SPs which have not refreshed their cached metadata continue to
+//     accept assertions. It is never used to sign new assertions.
+//   - "retired" — explicitly retired by an admin; no longer published, no longer
+//     usable. Retirement is an explicit admin action, never time-based.
+//
+// Metadata publishes every "current" + "active" key as separate <KeyDescriptor>
+// signing entries. Signing always uses the "current" key only.
+//
+// Note: any field addition must also be reflected in the cassandradb provider.
+type SAMLIDPKey struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID scopes this signing key to one Organization. Immutable.
+	OrgID string `json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" gorm:"index" index:"org_id,hash"`
+
+	// CertPEM is the self-signed X.509 certificate (PEM) wrapping the public key.
+	// Published in IdP metadata; safe to expose.
+	CertPEM string `json:"cert_pem" bson:"cert_pem" cql:"cert_pem" dynamo:"cert_pem"`
+
+	// PrivateKeyEnc is the RSA private key (PEM), AES-encrypted at rest with
+	// crypto.EncryptAES keyed on Config.ClientSecret — reversible because the raw
+	// key must be reconstructed to sign. json:"-" so it NEVER serializes into an
+	// API/webhook/log projection.
+	PrivateKeyEnc string `json:"-" bson:"private_key_enc" cql:"private_key_enc" dynamo:"private_key_enc"`
+
+	// Algorithm is the JWS-style signing algorithm identifier (e.g. "RS256"),
+	// mapped to the XML-DSIG signature method at signing time.
+	Algorithm string `json:"algorithm" bson:"algorithm" cql:"algorithm" dynamo:"algorithm"`
+
+	// Status is one of "current", "active", "retired" (see type docs).
+	Status string `json:"status" bson:"status" cql:"status" dynamo:"status" gorm:"default:'current'"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// SAML IdP key rotation statuses.
+const (
+	SAMLIDPKeyStatusCurrent = "current"
+	SAMLIDPKeyStatusActive  = "active"
+	SAMLIDPKeyStatusRetired = "retired"
+)

--- a/internal/storage/schemas/saml_service_provider.go
+++ b/internal/storage/schemas/saml_service_provider.go
@@ -1,0 +1,101 @@
+package schemas
+
+import (
+	"strings"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// SAMLServiceProvider registers a downstream SAML 2.0 Service Provider (SP) that
+// an Organization's users authenticate INTO, with Authorizer acting as the SAML
+// Identity Provider (IdP). This is the architectural inverse of the sso_saml
+// TrustedIssuer row (which registers an UPSTREAM IdP that Authorizer, as an SP,
+// consumes). Do NOT conflate the two: a TrustedIssuer means "an issuer we trust";
+// a SAMLServiceProvider means "an SP we issue signed assertions to".
+//
+// SECURITY INVARIANTS (enforced by the IdP handlers, not here):
+//
+//	I1 — EntityID and ACSURL are the ONLY trusted values. An incoming
+//	     AuthnRequest's Issuer selects this record by (OrgID, EntityID); the
+//	     assertion's Audience is set to this EntityID and the Recipient/Destination
+//	     to this ACSURL. A request-supplied AssertionConsumerServiceURL that does
+//	     not match this ACSURL is rejected (crewjam getACSEndpoint), which is the
+//	     open-redirect / assertion-exfiltration guard.
+//	I2 — An assertion minted for SP-A (Audience = A's EntityID) cannot validate at
+//	     SP-B, because the Audience is bound to this record's EntityID.
+//	I3 — IdP-initiated SSO is refused unless AllowIDPInitiated is true.
+//
+// Note: any field addition must also be reflected in the cassandradb provider,
+// whose struct tags are authoritative for that driver.
+type SAMLServiceProvider struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID scopes this registered SP to one Organization. Every IdP endpoint is
+	// resolved per org_slug, so an SP registered for Org A is never reachable when
+	// issuing for Org B. Immutable after creation.
+	OrgID string `json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" gorm:"index" index:"org_id,hash"`
+
+	// Name is a human-readable label (e.g. "Zendesk prod").
+	Name string `json:"name" bson:"name" cql:"name" dynamo:"name"`
+
+	// EntityID is the SP's SAML entity ID (the AuthnRequest Issuer value and the
+	// assertion Audience). Unique within an org — the (org_id, entity_id) pair is
+	// the lookup that resolves an incoming AuthnRequest to this record.
+	EntityID string `json:"entity_id" bson:"entity_id" cql:"entity_id" dynamo:"entity_id"`
+
+	// ACSURL is the SP's Assertion Consumer Service URL — the sole location a
+	// signed assertion is POSTed to. NEVER taken from the request (I1).
+	ACSURL string `json:"acs_url" bson:"acs_url" cql:"acs_url" dynamo:"acs_url"`
+
+	// SPCertPEM is the SP's optional X.509 signing certificate (PEM). When present
+	// it is used to encrypt-to the SP and (future) to validate signed
+	// AuthnRequests. Optional — most SPs do not sign their AuthnRequests.
+	SPCertPEM *string `json:"sp_cert_pem" bson:"sp_cert_pem" cql:"sp_cert_pem" dynamo:"sp_cert_pem"`
+
+	// NameIDFormat is the SAML NameID format emitted in the Subject. Defaults to
+	// urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress when empty.
+	NameIDFormat string `json:"name_id_format" bson:"name_id_format" cql:"name_id_format" dynamo:"name_id_format"`
+
+	// MappedAttributes is a JSON object mapping Authorizer profile fields to the
+	// SAML attribute names this SP expects, e.g.
+	// {"email":"email","given_name":"firstName","family_name":"lastName"}. This is
+	// the inverse of the SP-side SAMLAttributeMapping: here the map's VALUES are
+	// the emitted SAML attribute Names. Empty means "use default names".
+	MappedAttributes *string `json:"mapped_attributes" bson:"mapped_attributes" cql:"mapped_attributes" dynamo:"mapped_attributes"`
+
+	// AllowIDPInitiated permits unsolicited (IdP-initiated) SSO to this SP's ACS.
+	// DEFAULT FALSE — SP-initiated only, which binds InResponseTo to a pending
+	// AuthnRequest. Enable only when the SP supports unsolicited assertions.
+	AllowIDPInitiated bool `json:"allow_idp_initiated" bson:"allow_idp_initiated" cql:"allow_idp_initiated" dynamo:"allow_idp_initiated"`
+
+	// IsActive controls whether Authorizer will issue assertions to this SP.
+	IsActive bool `json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active" gorm:"default:true"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPISAMLServiceProvider converts the storage record into the GraphQL model.
+func (s *SAMLServiceProvider) AsAPISAMLServiceProvider() *model.SAMLServiceProvider {
+	id := s.ID
+	if strings.Contains(id, Collections.SAMLServiceProvider+"/") {
+		id = strings.TrimPrefix(id, Collections.SAMLServiceProvider+"/")
+	}
+	return &model.SAMLServiceProvider{
+		ID:                id,
+		OrgID:             s.OrgID,
+		Name:              s.Name,
+		EntityID:          s.EntityID,
+		AcsURL:            s.ACSURL,
+		SpCertPem:         s.SPCertPEM,
+		NameIDFormat:      refs.NewStringRef(s.NameIDFormat),
+		MappedAttributes:  s.MappedAttributes,
+		AllowIdpInitiated: s.AllowIDPInitiated,
+		IsActive:          s.IsActive,
+		CreatedAt:         refs.NewInt64Ref(s.CreatedAt),
+		UpdatedAt:         refs.NewInt64Ref(s.UpdatedAt),
+	}
+}

--- a/proto/authorizer/v1/admin.proto
+++ b/proto/authorizer/v1/admin.proto
@@ -421,6 +421,92 @@ service AuthorizerAdminService {
       body: "*"
     };
   }
+
+  // === SAML IdP: downstream service providers ===
+
+  // CreateSamlServiceProvider registers a downstream SAML 2.0 SP that Authorizer
+  // (acting as the IdP) issues signed assertions to. Requires super-admin auth.
+  rpc CreateSamlServiceProvider(CreateSamlServiceProviderRequest) returns (CreateSamlServiceProviderResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/create_saml_service_provider"
+      body: "*"
+    };
+  }
+
+  // UpdateSamlServiceProvider updates a downstream SP's name, endpoints,
+  // certificate, attribute mapping, or active state. Requires super-admin auth.
+  rpc UpdateSamlServiceProvider(UpdateSamlServiceProviderRequest) returns (UpdateSamlServiceProviderResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/update_saml_service_provider"
+      body: "*"
+    };
+  }
+
+  // DeleteSamlServiceProvider deletes a downstream SP by id. Requires
+  // super-admin auth.
+  rpc DeleteSamlServiceProvider(DeleteSamlServiceProviderRequest) returns (DeleteSamlServiceProviderResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/delete_saml_service_provider"
+      body: "*"
+    };
+  }
+
+  // GetSamlServiceProvider returns a single downstream SP by id. Requires
+  // super-admin auth.
+  rpc GetSamlServiceProvider(GetSamlServiceProviderRequest) returns (GetSamlServiceProviderResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/saml_service_provider"
+      body: "*"
+    };
+  }
+
+  // ListSamlServiceProviders returns a paginated list of downstream SPs for an
+  // org. Requires super-admin auth.
+  rpc ListSamlServiceProviders(ListSamlServiceProvidersRequest) returns (ListSamlServiceProvidersResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/saml_service_providers"
+      body: "*"
+    };
+  }
+
+  // === SAML IdP: signing key rotation & SP-metadata import ===
+
+  // RotateSamlIdpCert generates a new current signing keypair for an org's SAML
+  // IdP, demoting the previous current key. Requires super-admin auth.
+  rpc RotateSamlIdpCert(RotateSamlIdpCertRequest) returns (RotateSamlIdpCertResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/rotate_saml_idp_cert"
+      body: "*"
+    };
+  }
+
+  // RetireSamlIdpKey retires a published-but-not-signing SAML IdP key by id.
+  // Requires super-admin auth.
+  rpc RetireSamlIdpKey(RetireSamlIdpKeyRequest) returns (RetireSamlIdpKeyResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/retire_saml_idp_key"
+      body: "*"
+    };
+  }
+
+  // ListSamlIdpKeys returns all SAML IdP signing keys for an org. Requires
+  // super-admin auth.
+  rpc ListSamlIdpKeys(ListSamlIdpKeysRequest) returns (ListSamlIdpKeysResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/saml_idp_keys"
+      body: "*"
+    };
+  }
+
+  // ImportSamlSpMetadata parses pasted SP metadata XML and returns the fields to
+  // prefill a create call. It does NOT create a record and performs no remote
+  // fetch. Requires super-admin auth.
+  rpc ImportSamlSpMetadata(ImportSamlSpMetadataRequest) returns (ImportSamlSpMetadataResponse) {
+    option (google.api.http) = {
+      post: "/v1/admin/import_saml_sp_metadata"
+      body: "*"
+    };
+  }
 }
 
 // ============================================================================
@@ -1048,4 +1134,155 @@ message TrustedIssuersRequest {
 message TrustedIssuersResponse {
   repeated TrustedIssuer trusted_issuers = 1;
   Pagination pagination = 2;
+}
+
+// === SAML IdP ===
+
+// SamlServiceProvider mirrors model.SAMLServiceProvider field-for-field. It is a
+// downstream SAML 2.0 SP that Authorizer (acting as the IdP) issues signed
+// assertions to. Optional pointer fields collapse to zero values on the wire.
+message SamlServiceProvider {
+  string id = 1;
+  string org_id = 2;
+  string name = 3;
+  // entity_id: the SP entity ID (the AuthnRequest Issuer and assertion Audience).
+  string entity_id = 4;
+  // acs_url: the SP Assertion Consumer Service URL — the only place assertions
+  // are POSTed.
+  string acs_url = 5;
+  // sp_cert_pem: the SP's optional X.509 signing certificate (PEM).
+  string sp_cert_pem = 6;
+  // name_id_format: SAML NameID format for the Subject (default emailAddress).
+  string name_id_format = 7;
+  // mapped_attributes: JSON mapping profile fields to emitted SAML attribute names.
+  string mapped_attributes = 8;
+  // allow_idp_initiated: whether unsolicited IdP-initiated SSO is permitted.
+  bool allow_idp_initiated = 9;
+  bool is_active = 10;
+  int64 created_at = 11;
+  int64 updated_at = 12;
+}
+
+// SamlIdpKey mirrors model.SAMLIDPKey. The private key is NEVER projected — only
+// the certificate and rotation status.
+message SamlIdpKey {
+  string id = 1;
+  string org_id = 2;
+  // cert_pem: the self-signed X.509 signing certificate (PEM), pinned by SPs.
+  string cert_pem = 3;
+  string algorithm = 4;
+  // status: "current" (signs new assertions), "active" (published in metadata,
+  // not signing), or "retired" (neither).
+  string status = 5;
+  int64 created_at = 6;
+  int64 updated_at = 7;
+}
+
+// SamlSpMetadataParseResult mirrors model.SAMLSPMetadataParseResult. It does NOT
+// create a record — it returns fields to prefill a create call.
+message SamlSpMetadataParseResult {
+  string entity_id = 1;
+  string acs_url = 2;
+  string certificate = 3;
+}
+
+// CreateSamlServiceProviderRequest mirrors model.CreateSAMLServiceProviderRequest.
+// sp_cert_pem, name_id_format, mapped_attributes, and allow_idp_initiated are
+// optional.
+message CreateSamlServiceProviderRequest {
+  string org_id = 1 [(buf.validate.field).string.min_len = 1];
+  string name = 2 [(buf.validate.field).string.min_len = 1];
+  string entity_id = 3 [(buf.validate.field).string.min_len = 1];
+  string acs_url = 4 [(buf.validate.field).string.min_len = 1];
+  optional string sp_cert_pem = 5;
+  // name_id_format: default urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress.
+  optional string name_id_format = 6;
+  // mapped_attributes: JSON, e.g. {"email":"email","given_name":"firstName"}.
+  optional string mapped_attributes = 7;
+  // allow_idp_initiated: default false (SP-initiated only).
+  optional bool allow_idp_initiated = 8;
+}
+message CreateSamlServiceProviderResponse {
+  SamlServiceProvider saml_service_provider = 1;
+}
+
+// UpdateSamlServiceProviderRequest mirrors model.UpdateSAMLServiceProviderRequest.
+// Nullable GraphQL inputs use proto3 `optional` so an unset field is
+// distinguishable from an empty value.
+message UpdateSamlServiceProviderRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+  optional string name = 2;
+  optional string entity_id = 3;
+  optional string acs_url = 4;
+  optional string sp_cert_pem = 5;
+  optional string name_id_format = 6;
+  optional string mapped_attributes = 7;
+  optional bool allow_idp_initiated = 8;
+  optional bool is_active = 9;
+}
+message UpdateSamlServiceProviderResponse {
+  SamlServiceProvider saml_service_provider = 1;
+}
+
+// DeleteSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a
+// single SP id). Kept distinct from GetSamlServiceProviderRequest per buf's
+// one-message-per-RPC rule.
+message DeleteSamlServiceProviderRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+}
+message DeleteSamlServiceProviderResponse {
+  string message = 1;
+}
+
+// GetSamlServiceProviderRequest mirrors model.SAMLServiceProviderRequest (a
+// single SP id). Kept distinct from DeleteSamlServiceProviderRequest per buf's
+// one-message-per-RPC rule.
+message GetSamlServiceProviderRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+}
+message GetSamlServiceProviderResponse {
+  SamlServiceProvider saml_service_provider = 1;
+}
+
+// ListSamlServiceProvidersRequest mirrors model.ListSAMLServiceProvidersRequest.
+message ListSamlServiceProvidersRequest {
+  string org_id = 1 [(buf.validate.field).string.min_len = 1];
+  PaginationRequest pagination = 2;
+}
+message ListSamlServiceProvidersResponse {
+  repeated SamlServiceProvider saml_service_providers = 1;
+  Pagination pagination = 2;
+}
+
+// RotateSamlIdpCertRequest mirrors model.RotateSAMLIDPCertRequest.
+message RotateSamlIdpCertRequest {
+  string org_id = 1 [(buf.validate.field).string.min_len = 1];
+}
+message RotateSamlIdpCertResponse {
+  SamlIdpKey saml_idp_key = 1;
+}
+
+// RetireSamlIdpKeyRequest mirrors model.RetireSAMLIDPKeyRequest (a single key id).
+message RetireSamlIdpKeyRequest {
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+}
+message RetireSamlIdpKeyResponse {
+  string message = 1;
+}
+
+// ListSamlIdpKeysRequest mirrors model.ListSAMLIDPKeysRequest.
+message ListSamlIdpKeysRequest {
+  string org_id = 1 [(buf.validate.field).string.min_len = 1];
+}
+message ListSamlIdpKeysResponse {
+  repeated SamlIdpKey saml_idp_keys = 1;
+}
+
+// ImportSamlSpMetadataRequest mirrors model.ImportSAMLSPMetadataRequest. The
+// metadata is pasted XML — NOT a URL; no remote fetch is performed.
+message ImportSamlSpMetadataRequest {
+  string metadata_xml = 1 [(buf.validate.field).string.min_len = 1];
+}
+message ImportSamlSpMetadataResponse {
+  SamlSpMetadataParseResult result = 1;
 }

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -27,8 +27,7 @@ export default function App() {
 		scope,
 	};
 
-	const redirectURL =
-		getParam('redirect_uri') || getParam('redirectURL');
+	const redirectURL = getParam('redirect_uri') || getParam('redirectURL');
 	if (redirectURL) {
 		urlProps.redirectURL = redirectURL;
 	} else {

--- a/web/app/src/Root.tsx
+++ b/web/app/src/Root.tsx
@@ -1,6 +1,10 @@
 import { useEffect, lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { AuthorizerMFASetup, AuthorizerVerifyOtp, useAuthorizer } from '@authorizerdev/authorizer-react';
+import {
+	AuthorizerMFASetup,
+	AuthorizerVerifyOtp,
+	useAuthorizer,
+} from '@authorizerdev/authorizer-react';
 import { parseMfaRedirectParams } from '@authorizerdev/authorizer-js';
 import SetupPassword from './pages/setup-password';
 import { hasWindow, createRandomString } from './utils/common';

--- a/web/app/src/pages/login.tsx
+++ b/web/app/src/pages/login.tsx
@@ -244,7 +244,11 @@ export default function Login({ urlProps }: { urlProps: Record<string, any> }) {
 				!config.is_magic_link_login_enabled &&
 				config.is_sign_up_enabled && (
 					<FooterContent>
-						Don't have an account? &nbsp; <Link to={{ pathname: '/app/signup', search: location.search }}> Sign Up</Link>
+						Don't have an account? &nbsp;{' '}
+						<Link to={{ pathname: '/app/signup', search: location.search }}>
+							{' '}
+							Sign Up
+						</Link>
 					</FooterContent>
 				)}
 		</Fragment>

--- a/web/dashboard/src/components/FgaNotEnabled.test.tsx
+++ b/web/dashboard/src/components/FgaNotEnabled.test.tsx
@@ -20,9 +20,9 @@ describe('FgaNotEnabled', () => {
 		render(<FgaNotEnabled />);
 		// The command renders in more than one place (code block + copy
 		// affordance) — all occurrences must carry both flags.
-		expect(
-			screen.getAllByText(/--fga-store=postgres/).length,
-		).toBeGreaterThan(0);
+		expect(screen.getAllByText(/--fga-store=postgres/).length).toBeGreaterThan(
+			0,
+		);
 		expect(screen.getAllByText(/--fga-store-url=/).length).toBeGreaterThan(0);
 	});
 });

--- a/web/dashboard/src/components/FgaNotEnabled.tsx
+++ b/web/dashboard/src/components/FgaNotEnabled.tsx
@@ -6,7 +6,8 @@ import { ShieldCheck, Copy, Check, ExternalLink, Database } from 'lucide-react';
 // automatically when it is SQLite/Postgres/MySQL; this screen typically means
 // the main database is not OpenFGA-compatible (e.g. MongoDB, DynamoDB), so a
 // SQL store must be pointed to explicitly via --fga-store.
-const ENABLE_CMD = '--fga-store=postgres --fga-store-url=postgres://user:pass@host:5432/db';
+const ENABLE_CMD =
+	'--fga-store=postgres --fga-store-url=postgres://user:pass@host:5432/db';
 
 const StoreChip = ({ label }: { label: string }) => (
 	<code className="rounded bg-gray-200/70 px-1 py-0.5 text-[11px] font-medium text-gray-700">
@@ -39,7 +40,9 @@ const FgaNotEnabled = () => {
 				</h2>
 				<p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-gray-500">
 					FGA turns on automatically when Authorizer runs on{' '}
-					<span className="font-medium text-gray-700">SQLite, Postgres or MySQL</span>{' '}
+					<span className="font-medium text-gray-700">
+						SQLite, Postgres or MySQL
+					</span>{' '}
 					&mdash; it reuses your database. Your current database isn&rsquo;t
 					supported by OpenFGA, so point FGA at a SQL store to enable it.
 				</p>
@@ -61,7 +64,10 @@ const FgaNotEnabled = () => {
 						>
 							{copied ? (
 								<>
-									<Check className="h-3.5 w-3.5 text-green-400" aria-hidden="true" />
+									<Check
+										className="h-3.5 w-3.5 text-green-400"
+										aria-hidden="true"
+									/>
 									Copied
 								</>
 							) : (

--- a/web/dashboard/src/components/SAMLServiceProviders.tsx
+++ b/web/dashboard/src/components/SAMLServiceProviders.tsx
@@ -1,0 +1,511 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { Plus, RefreshCw, Upload } from 'lucide-react';
+import dayjs from 'dayjs';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import {
+	ListSAMLServiceProvidersQuery,
+	ListSAMLIDPKeysQuery,
+} from '../graphql/queries';
+import {
+	DeleteSAMLServiceProvider,
+	RotateSAMLIDPCert,
+	RetireSAMLIDPKey,
+	ImportSAMLSPMetadata,
+} from '../graphql/mutation';
+import type {
+	SAMLServiceProvider,
+	SAMLIDPKey,
+	SAMLSPMetadataParseResult,
+} from '../types';
+import UpdateSAMLServiceProviderModal from './UpdateSAMLServiceProviderModal';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { Textarea } from './ui/textarea';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from './ui/card';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from './ui/dialog';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from './ui/table';
+
+interface SAMLServiceProvidersProps {
+	orgId: string;
+	// orgSlug is the URL-safe org name used in the IdP metadata URL.
+	orgSlug: string;
+}
+
+const keyStatusVariant = (status: string) => {
+	if (status === 'current') return 'success';
+	if (status === 'active') return 'default';
+	return 'secondary';
+};
+
+const SAMLServiceProviders = ({
+	orgId,
+	orgSlug,
+}: SAMLServiceProvidersProps) => {
+	const client = useClient();
+
+	const [providers, setProviders] = useState<SAMLServiceProvider[]>([]);
+	const [keys, setKeys] = useState<SAMLIDPKey[]>([]);
+
+	// Create/edit modal.
+	const [modalOpen, setModalOpen] = useState(false);
+	const [editingProvider, setEditingProvider] =
+		useState<SAMLServiceProvider | null>(null);
+	const [prefill, setPrefill] = useState<SAMLSPMetadataParseResult | null>(
+		null,
+	);
+
+	// Import SP metadata sheet.
+	const [importOpen, setImportOpen] = useState(false);
+	const [metadataXml, setMetadataXml] = useState('');
+	const [importing, setImporting] = useState(false);
+
+	// Confirm dialogs.
+	const [providerToDelete, setProviderToDelete] =
+		useState<SAMLServiceProvider | null>(null);
+	const [keyToRetire, setKeyToRetire] = useState<SAMLIDPKey | null>(null);
+	const [rotateOpen, setRotateOpen] = useState(false);
+
+	const fetchProviders = async () => {
+		if (!orgId) return;
+		const res = await client
+			.query<{
+				_list_saml_service_providers: {
+					saml_service_providers: SAMLServiceProvider[];
+				};
+			}>(ListSAMLServiceProvidersQuery, { params: { org_id: orgId } })
+			.toPromise();
+		setProviders(
+			res.data?._list_saml_service_providers?.saml_service_providers || [],
+		);
+	};
+
+	const fetchKeys = async () => {
+		if (!orgId) return;
+		const res = await client
+			.query<{ _list_saml_idp_keys: SAMLIDPKey[] }>(ListSAMLIDPKeysQuery, {
+				params: { org_id: orgId },
+			})
+			.toPromise();
+		setKeys(res.data?._list_saml_idp_keys || []);
+	};
+
+	useEffect(() => {
+		fetchProviders();
+		fetchKeys();
+	}, [orgId]);
+
+	const openCreate = () => {
+		setEditingProvider(null);
+		setPrefill(null);
+		setModalOpen(true);
+	};
+
+	const openEdit = (provider: SAMLServiceProvider) => {
+		setEditingProvider(provider);
+		setPrefill(null);
+		setModalOpen(true);
+	};
+
+	const importMetadata = async () => {
+		if (!metadataXml.trim()) return;
+		setImporting(true);
+		const res = await client
+			.mutation<{
+				_import_saml_sp_metadata: SAMLSPMetadataParseResult;
+			}>(ImportSAMLSPMetadata, { params: { metadata_xml: metadataXml.trim() } })
+			.toPromise();
+		setImporting(false);
+		if (res.error || !res.data?._import_saml_sp_metadata) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to parse SP metadata'),
+				),
+			);
+			return;
+		}
+		// Prefill the create form with the parsed values.
+		setEditingProvider(null);
+		setPrefill(res.data._import_saml_sp_metadata);
+		setImportOpen(false);
+		setMetadataXml('');
+		setModalOpen(true);
+	};
+
+	const deleteProviderHandler = async () => {
+		if (!providerToDelete) return;
+		const res = await client
+			.mutation(DeleteSAMLServiceProvider, {
+				params: { id: providerToDelete.id },
+			})
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						'Failed to delete SAML service provider',
+					),
+				),
+			);
+			return;
+		}
+		toast.success('SAML service provider deleted');
+		setProviderToDelete(null);
+		fetchProviders();
+	};
+
+	const rotateCertHandler = async () => {
+		const res = await client
+			.mutation(RotateSAMLIDPCert, { params: { org_id: orgId } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						'Failed to rotate signing certificate',
+					),
+				),
+			);
+			return;
+		}
+		toast.success('Signing certificate rotated');
+		setRotateOpen(false);
+		fetchKeys();
+	};
+
+	const retireKeyHandler = async () => {
+		if (!keyToRetire) return;
+		const res = await client
+			.mutation(RetireSAMLIDPKey, { params: { id: keyToRetire.id } })
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to retire signing key'),
+				),
+			);
+			return;
+		}
+		toast.success('Signing key retired');
+		setKeyToRetire(null);
+		fetchKeys();
+	};
+
+	const metadataUrl = `${window.location.origin}/saml/idp/${orgSlug}/metadata`;
+
+	return (
+		<>
+			{/* SAML IdP: registered service providers */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>SAML IdP — Service Providers</CardTitle>
+							<CardDescription>
+								Downstream SAML 2.0 Service Providers this organization issues
+								signed assertions to. Authorizer acts as the Identity Provider.
+							</CardDescription>
+						</div>
+						<div className="flex gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => setImportOpen(true)}
+							>
+								<Upload className="mr-2 h-4 w-4" />
+								Import SP Metadata
+							</Button>
+							<Button size="sm" onClick={openCreate}>
+								<Plus className="mr-2 h-4 w-4" />
+								Register Service Provider
+							</Button>
+						</div>
+					</div>
+				</CardHeader>
+				<CardContent>
+					{providers.length > 0 ? (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead>Entity ID</TableHead>
+									<TableHead>ACS URL</TableHead>
+									<TableHead>IdP Initiated</TableHead>
+									<TableHead>Active</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{providers.map((sp) => (
+									<TableRow key={sp.id}>
+										<TableCell>{sp.name}</TableCell>
+										<TableCell className="font-mono text-xs">
+											{sp.entity_id}
+										</TableCell>
+										<TableCell className="font-mono text-xs">
+											{sp.acs_url}
+										</TableCell>
+										<TableCell>
+											{sp.allow_idp_initiated ? 'Allowed' : 'Disabled'}
+										</TableCell>
+										<TableCell>
+											<Badge variant={sp.is_active ? 'success' : 'warning'}>
+												{sp.is_active.toString()}
+											</Badge>
+										</TableCell>
+										<TableCell className="text-right">
+											<div className="flex justify-end gap-2">
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => openEdit(sp)}
+												>
+													Edit
+												</Button>
+												<Button
+													variant="destructive"
+													size="sm"
+													onClick={() => setProviderToDelete(sp)}
+												>
+													Delete
+												</Button>
+											</div>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					) : (
+						<p className="text-sm text-gray-400">
+							No SAML service providers registered.
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* SAML IdP: signing keys */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>SAML IdP — Signing Keys</CardTitle>
+							<CardDescription>
+								Signing keypairs published in this organization's IdP metadata.
+								Rotating generates a new "current" key; the previous one stays
+								"active" until retired.
+							</CardDescription>
+						</div>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setRotateOpen(true)}
+						>
+							<RefreshCw className="mr-2 h-4 w-4" />
+							Rotate Certificate
+						</Button>
+					</div>
+				</CardHeader>
+				<CardContent>
+					<p className="mb-4 text-sm text-gray-500">
+						IdP metadata URL:{' '}
+						<span className="font-mono text-xs text-gray-700">
+							{metadataUrl}
+						</span>
+					</p>
+					{keys.length > 0 ? (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Status</TableHead>
+									<TableHead>Algorithm</TableHead>
+									<TableHead>Created</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{keys.map((key) => (
+									<TableRow key={key.id}>
+										<TableCell>
+											<Badge variant={keyStatusVariant(key.status)}>
+												{key.status}
+											</Badge>
+										</TableCell>
+										<TableCell className="font-mono text-xs">
+											{key.algorithm}
+										</TableCell>
+										<TableCell>
+											{key.created_at
+												? dayjs.unix(key.created_at).format('MMM D, YYYY')
+												: '—'}
+										</TableCell>
+										<TableCell className="text-right">
+											{key.status !== 'current' && key.status !== 'retired' ? (
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => setKeyToRetire(key)}
+												>
+													Retire
+												</Button>
+											) : null}
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					) : (
+						<p className="text-sm text-gray-400">No signing keys yet.</p>
+					)}
+				</CardContent>
+			</Card>
+
+			<UpdateSAMLServiceProviderModal
+				open={modalOpen}
+				onOpenChange={setModalOpen}
+				orgId={orgId}
+				selectedProvider={editingProvider}
+				prefill={prefill}
+				onSaved={fetchProviders}
+			/>
+
+			{/* Import SP metadata */}
+			<Sheet open={importOpen} onOpenChange={setImportOpen}>
+				<SheetContent className="overflow-y-auto sm:max-w-2xl">
+					<SheetHeader>
+						<SheetTitle>Import SP Metadata</SheetTitle>
+						<SheetDescription>
+							Paste the Service Provider's SAML metadata XML. Parsed values
+							prefill the registration form — no record is created until you
+							save.
+						</SheetDescription>
+					</SheetHeader>
+					<div className="mt-6">
+						<Textarea
+							rows={16}
+							className="font-mono text-xs"
+							placeholder="<md:EntityDescriptor ...>"
+							value={metadataXml}
+							onChange={(e) => setMetadataXml(e.currentTarget.value)}
+						/>
+					</div>
+					<SheetFooter className="mt-6">
+						<Button
+							onClick={importMetadata}
+							isLoading={importing}
+							disabled={importing || metadataXml.trim().length === 0}
+						>
+							Parse & Continue
+						</Button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+
+			{/* Confirm: delete provider */}
+			<Dialog
+				open={!!providerToDelete}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) setProviderToDelete(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete SAML Service Provider</DialogTitle>
+						<DialogDescription>Are you sure?</DialogDescription>
+					</DialogHeader>
+					<div className="rounded-md border border-red-300 bg-red-50 p-4">
+						<p className="text-sm">
+							Service provider <strong>{providerToDelete?.name}</strong> will be
+							deleted permanently! SSO into it will stop working.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button variant="destructive" onClick={deleteProviderHandler}>
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Confirm: rotate certificate */}
+			<Dialog open={rotateOpen} onOpenChange={setRotateOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Rotate Signing Certificate</DialogTitle>
+						<DialogDescription>Are you sure?</DialogDescription>
+					</DialogHeader>
+					<div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+						<p className="text-sm">
+							A new signing keypair becomes "current". The previous key stays
+							published as "active" until you retire it.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button onClick={rotateCertHandler}>
+							<RefreshCw className="mr-2 h-4 w-4" />
+							Rotate
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Confirm: retire key */}
+			<Dialog
+				open={!!keyToRetire}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) setKeyToRetire(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Retire Signing Key</DialogTitle>
+						<DialogDescription>Are you sure?</DialogDescription>
+					</DialogHeader>
+					<div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+						<p className="text-sm">
+							This key will be dropped from the published IdP metadata. SPs
+							still pinning it will fail to verify assertions.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button variant="destructive" onClick={retireKeyHandler}>
+							Retire
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+};
+
+export default SAMLServiceProviders;

--- a/web/dashboard/src/components/UpdateSAMLServiceProviderModal.tsx
+++ b/web/dashboard/src/components/UpdateSAMLServiceProviderModal.tsx
@@ -1,0 +1,300 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
+import {
+	CreateSAMLServiceProvider,
+	UpdateSAMLServiceProvider,
+} from '../graphql/mutation';
+import type { SAMLServiceProvider, SAMLSPMetadataParseResult } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import { Textarea } from './ui/textarea';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetDescription,
+	SheetFooter,
+} from './ui/sheet';
+
+interface UpdateSAMLServiceProviderModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	orgId: string;
+	// selectedProvider present => edit; absent => create.
+	selectedProvider?: SAMLServiceProvider | null;
+	// prefill seeds the create form (e.g. from imported SP metadata).
+	prefill?: SAMLSPMetadataParseResult | null;
+	onSaved: () => void;
+}
+
+interface SPFormData {
+	name: string;
+	entityId: string;
+	acsUrl: string;
+	spCertPem: string;
+	nameIdFormat: string;
+	mappedAttributes: string;
+	allowIdpInitiated: boolean;
+	isActive: boolean;
+}
+
+const initFormData: SPFormData = {
+	name: '',
+	entityId: '',
+	acsUrl: '',
+	spCertPem: '',
+	nameIdFormat: '',
+	mappedAttributes: '',
+	allowIdpInitiated: false,
+	isActive: true,
+};
+
+const UpdateSAMLServiceProviderModal = ({
+	open,
+	onOpenChange,
+	orgId,
+	selectedProvider,
+	prefill,
+	onSaved,
+}: UpdateSAMLServiceProviderModalProps) => {
+	const client = useClient();
+	const [loading, setLoading] = useState(false);
+	const [formData, setFormData] = useState<SPFormData>({ ...initFormData });
+
+	const isEdit = !!selectedProvider;
+
+	useEffect(() => {
+		if (!open) return;
+		if (selectedProvider) {
+			setFormData({
+				name: selectedProvider.name,
+				entityId: selectedProvider.entity_id,
+				acsUrl: selectedProvider.acs_url,
+				spCertPem: selectedProvider.sp_cert_pem || '',
+				nameIdFormat: selectedProvider.name_id_format || '',
+				mappedAttributes: selectedProvider.mapped_attributes || '',
+				allowIdpInitiated: selectedProvider.allow_idp_initiated,
+				isActive: selectedProvider.is_active,
+			});
+		} else {
+			setFormData({
+				...initFormData,
+				entityId: prefill?.entity_id || '',
+				acsUrl: prefill?.acs_url || '',
+				spCertPem: prefill?.certificate || '',
+			});
+		}
+	}, [open]);
+
+	const setField = (field: keyof SPFormData, value: string | boolean) =>
+		setFormData({ ...formData, [field]: value });
+
+	const validateData = () => {
+		if (loading) return false;
+		return (
+			formData.name.trim().length > 0 &&
+			formData.entityId.trim().length > 0 &&
+			formData.acsUrl.trim().length > 0
+		);
+	};
+
+	const saveData = async () => {
+		if (!validateData()) return;
+		setLoading(true);
+		let res: { error?: unknown };
+		if (isEdit && selectedProvider?.id) {
+			res = await client
+				.mutation(UpdateSAMLServiceProvider, {
+					params: {
+						id: selectedProvider.id,
+						name: formData.name.trim(),
+						entity_id: formData.entityId.trim(),
+						acs_url: formData.acsUrl.trim(),
+						sp_cert_pem: formData.spCertPem.trim() || undefined,
+						name_id_format: formData.nameIdFormat.trim() || undefined,
+						mapped_attributes: formData.mappedAttributes.trim() || undefined,
+						allow_idp_initiated: formData.allowIdpInitiated,
+						is_active: formData.isActive,
+					},
+				})
+				.toPromise();
+		} else {
+			res = await client
+				.mutation(CreateSAMLServiceProvider, {
+					params: {
+						org_id: orgId,
+						name: formData.name.trim(),
+						entity_id: formData.entityId.trim(),
+						acs_url: formData.acsUrl.trim(),
+						sp_cert_pem: formData.spCertPem.trim() || undefined,
+						name_id_format: formData.nameIdFormat.trim() || undefined,
+						mapped_attributes: formData.mappedAttributes.trim() || undefined,
+						allow_idp_initiated: formData.allowIdpInitiated,
+					},
+				})
+				.toPromise();
+		}
+		setLoading(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						isEdit
+							? 'Failed to update SAML service provider'
+							: 'Failed to create SAML service provider',
+					),
+				),
+			);
+			return;
+		}
+		toast.success(
+			isEdit
+				? 'SAML service provider updated'
+				: 'SAML service provider created',
+		);
+		onOpenChange(false);
+		onSaved();
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent className="overflow-y-auto sm:max-w-2xl">
+				<SheetHeader>
+					<SheetTitle>
+						{isEdit
+							? 'Edit SAML Service Provider'
+							: 'Register SAML Service Provider'}
+					</SheetTitle>
+					<SheetDescription>
+						A downstream SAML 2.0 Service Provider that Authorizer (acting as
+						the IdP) issues signed assertions to.
+					</SheetDescription>
+				</SheetHeader>
+
+				<div className="mt-6 space-y-5 rounded-md border border-gray-200 p-5">
+					<div className="flex items-center gap-4">
+						<label className="w-32 text-sm font-medium shrink-0">Name</label>
+						<Input
+							placeholder="acme-app"
+							value={formData.name}
+							isInvalid={formData.name.trim().length === 0}
+							onChange={(e) => setField('name', e.currentTarget.value)}
+						/>
+					</div>
+
+					<div className="flex items-center gap-4">
+						<label className="w-32 text-sm font-medium shrink-0">
+							Entity ID
+						</label>
+						<Input
+							placeholder="https://sp.example.com/saml/metadata"
+							value={formData.entityId}
+							isInvalid={formData.entityId.trim().length === 0}
+							onChange={(e) => setField('entityId', e.currentTarget.value)}
+						/>
+					</div>
+
+					<div className="flex items-center gap-4">
+						<label className="w-32 text-sm font-medium shrink-0">ACS URL</label>
+						<Input
+							placeholder="https://sp.example.com/saml/acs"
+							value={formData.acsUrl}
+							isInvalid={formData.acsUrl.trim().length === 0}
+							onChange={(e) => setField('acsUrl', e.currentTarget.value)}
+						/>
+					</div>
+
+					<div className="flex items-start gap-4">
+						<label className="w-32 text-sm font-medium shrink-0 pt-2">
+							SP Certificate
+						</label>
+						<Textarea
+							rows={5}
+							className="font-mono text-xs"
+							placeholder="-----BEGIN CERTIFICATE----- (PEM, optional)"
+							value={formData.spCertPem}
+							onChange={(e) => setField('spCertPem', e.currentTarget.value)}
+						/>
+					</div>
+
+					<div className="flex items-center gap-4">
+						<label className="w-32 text-sm font-medium shrink-0">
+							NameID Format
+						</label>
+						<Input
+							placeholder="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+							value={formData.nameIdFormat}
+							onChange={(e) => setField('nameIdFormat', e.currentTarget.value)}
+						/>
+					</div>
+
+					<div className="flex items-start gap-4">
+						<label className="w-32 text-sm font-medium shrink-0 pt-2">
+							Mapped Attributes
+						</label>
+						<Textarea
+							rows={3}
+							className="font-mono text-xs"
+							placeholder='{"email":"email","given_name":"firstName"}'
+							value={formData.mappedAttributes}
+							onChange={(e) =>
+								setField('mappedAttributes', e.currentTarget.value)
+							}
+						/>
+					</div>
+
+					<div className="flex items-center gap-4">
+						<label className="w-32 text-sm font-medium shrink-0">
+							Allow IdP Initiated
+						</label>
+						<div className="flex items-center gap-2">
+							<span className="text-sm font-medium">Off</span>
+							<Switch
+								checked={formData.allowIdpInitiated}
+								onCheckedChange={(checked: boolean) =>
+									setField('allowIdpInitiated', checked)
+								}
+							/>
+							<span className="text-sm font-medium">On</span>
+						</div>
+					</div>
+
+					{isEdit && (
+						<div className="flex items-center gap-4">
+							<label className="w-32 text-sm font-medium shrink-0">
+								Active
+							</label>
+							<div className="flex items-center gap-2">
+								<span className="text-sm font-medium">Off</span>
+								<Switch
+									checked={formData.isActive}
+									onCheckedChange={(checked: boolean) =>
+										setField('isActive', checked)
+									}
+								/>
+								<span className="text-sm font-medium">On</span>
+							</div>
+						</div>
+					)}
+				</div>
+
+				<SheetFooter className="mt-6">
+					<Button
+						onClick={saveData}
+						isLoading={loading}
+						disabled={!validateData()}
+					>
+						Save
+					</Button>
+				</SheetFooter>
+			</SheetContent>
+		</Sheet>
+	);
+};
+
+export default UpdateSAMLServiceProviderModal;

--- a/web/dashboard/src/components/ui/table.tsx
+++ b/web/dashboard/src/components/ui/table.tsx
@@ -19,7 +19,11 @@ const TableHeader = React.forwardRef<
 	HTMLTableSectionElement,
 	React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-	<thead ref={ref} className={cn('[&_tr]:border-b [&_tr]:border-gray-100', className)} {...props} />
+	<thead
+		ref={ref}
+		className={cn('[&_tr]:border-b [&_tr]:border-gray-100', className)}
+		{...props}
+	/>
 ));
 TableHeader.displayName = 'TableHeader';
 

--- a/web/dashboard/src/graphql/mutation/index.ts
+++ b/web/dashboard/src/graphql/mutation/index.ts
@@ -357,3 +357,56 @@ export const DeleteScimEndpoint = `
     }
   }
 `;
+
+export const CreateSAMLServiceProvider = `
+  mutation createSAMLServiceProvider($params: CreateSAMLServiceProviderRequest!) {
+    _create_saml_service_provider(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const UpdateSAMLServiceProvider = `
+  mutation updateSAMLServiceProvider($params: UpdateSAMLServiceProviderRequest!) {
+    _update_saml_service_provider(params: $params) {
+      id
+      name
+    }
+  }
+`;
+
+export const DeleteSAMLServiceProvider = `
+  mutation deleteSAMLServiceProvider($params: SAMLServiceProviderRequest!) {
+    _delete_saml_service_provider(params: $params) {
+      message
+    }
+  }
+`;
+
+export const RotateSAMLIDPCert = `
+  mutation rotateSAMLIDPCert($params: RotateSAMLIDPCertRequest!) {
+    _rotate_saml_idp_cert(params: $params) {
+      id
+      status
+    }
+  }
+`;
+
+export const RetireSAMLIDPKey = `
+  mutation retireSAMLIDPKey($params: RetireSAMLIDPKeyRequest!) {
+    _retire_saml_idp_key(params: $params) {
+      message
+    }
+  }
+`;
+
+export const ImportSAMLSPMetadata = `
+  mutation importSAMLSPMetadata($params: ImportSAMLSPMetadataRequest!) {
+    _import_saml_sp_metadata(params: $params) {
+      entity_id
+      acs_url
+      certificate
+    }
+  }
+`;

--- a/web/dashboard/src/graphql/queries/index.ts
+++ b/web/dashboard/src/graphql/queries/index.ts
@@ -366,3 +366,41 @@ export const ScimEndpointQuery = `
     }
   }
 `;
+
+export const ListSAMLServiceProvidersQuery = `
+  query listSAMLServiceProviders($params: ListSAMLServiceProvidersRequest!) {
+    _list_saml_service_providers(params: $params) {
+      pagination {
+        total
+      }
+      saml_service_providers {
+        id
+        org_id
+        name
+        entity_id
+        acs_url
+        sp_cert_pem
+        name_id_format
+        mapped_attributes
+        allow_idp_initiated
+        is_active
+        created_at
+        updated_at
+      }
+    }
+  }
+`;
+
+export const ListSAMLIDPKeysQuery = `
+  query listSAMLIDPKeys($params: ListSAMLIDPKeysRequest!) {
+    _list_saml_idp_keys(params: $params) {
+      id
+      org_id
+      cert_pem
+      algorithm
+      status
+      created_at
+      updated_at
+    }
+  }
+`;

--- a/web/dashboard/src/pages/OrganizationDetail.tsx
+++ b/web/dashboard/src/pages/OrganizationDetail.tsx
@@ -13,6 +13,7 @@ import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import UpdateOrgOIDCConnectionModal from '../components/UpdateOrgOIDCConnectionModal';
 import UpdateOrgSAMLConnectionModal from '../components/UpdateOrgSAMLConnectionModal';
+import SAMLServiceProviders from '../components/SAMLServiceProviders';
 import ClientSecretDialog from '../components/ClientSecretDialog';
 import { UpdateModalViews } from '../constants';
 import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
@@ -735,6 +736,9 @@ const OrganizationDetail = () => {
 					)}
 				</CardContent>
 			</Card>
+
+			{/* SAML IdP: downstream service providers + signing keys */}
+			<SAMLServiceProviders orgId={orgId} orgSlug={org?.name || ''} />
 
 			{/* SCIM */}
 			<Card>

--- a/web/dashboard/src/pages/authorization/DocsLinks.tsx
+++ b/web/dashboard/src/pages/authorization/DocsLinks.tsx
@@ -6,9 +6,18 @@ import { BookOpen, ExternalLink } from 'lucide-react';
 const LINKS = [
 	{ label: 'What is FGA / ReBAC', href: 'https://openfga.dev/docs/fga' },
 	{ label: 'Concepts', href: 'https://openfga.dev/docs/concepts' },
-	{ label: 'Modeling guide', href: 'https://openfga.dev/docs/modeling/getting-started' },
-	{ label: 'Model DSL', href: 'https://openfga.dev/docs/configuration-language' },
-	{ label: 'Relationship tuples', href: 'https://openfga.dev/docs/concepts#what-is-a-relationship-tuple' },
+	{
+		label: 'Modeling guide',
+		href: 'https://openfga.dev/docs/modeling/getting-started',
+	},
+	{
+		label: 'Model DSL',
+		href: 'https://openfga.dev/docs/configuration-language',
+	},
+	{
+		label: 'Relationship tuples',
+		href: 'https://openfga.dev/docs/concepts#what-is-a-relationship-tuple',
+	},
 ];
 
 const DocsLinks = () => (

--- a/web/dashboard/src/pages/authorization/Tuples.test.tsx
+++ b/web/dashboard/src/pages/authorization/Tuples.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import {
+	render,
+	screen,
+	fireEvent,
+	waitFor,
+	cleanup,
+} from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Tuples from './Tuples';
 import { FgaGetModelQuery, FgaReadTuplesQuery } from '../../graphql/queries';
@@ -50,9 +56,12 @@ afterEach(cleanup);
 
 beforeEach(() => {
 	mockClient = {
-		query: vi.fn(() => ({ toPromise: () => Promise.resolve(emptyTuplesResponse) })),
+		query: vi.fn(() => ({
+			toPromise: () => Promise.resolve(emptyTuplesResponse),
+		})),
 		mutation: vi.fn(() => ({
-			toPromise: () => Promise.resolve({ data: { _fga_write_tuples: { message: 'ok' } } }),
+			toPromise: () =>
+				Promise.resolve({ data: { _fga_write_tuples: { message: 'ok' } } }),
 		})),
 	};
 });
@@ -63,7 +72,8 @@ beforeEach(() => {
 // the same render, so call count/order isn't deterministic across components.
 function mockQueries(tuplesResponse: unknown) {
 	mockClient.query.mockImplementation((doc: unknown) => {
-		const response = doc === FgaReadTuplesQuery ? tuplesResponse : modelExistsResponse;
+		const response =
+			doc === FgaReadTuplesQuery ? tuplesResponse : modelExistsResponse;
 		return { toPromise: () => Promise.resolve(response) };
 	});
 }

--- a/web/dashboard/src/pages/authorization/Tuples.tsx
+++ b/web/dashboard/src/pages/authorization/Tuples.tsx
@@ -214,7 +214,8 @@ const Tuples = () => {
 	// grants the relation to literally everyone — the broadest possible tuple.
 	// It gets an extra warning in the confirm dialog rather than silently
 	// going through the same one-click path as a scoped grant.
-	const isWildcardGrant = (user: string): boolean => /^user:\*/.test(user.trim());
+	const isWildcardGrant = (user: string): boolean =>
+		/^user:\*/.test(user.trim());
 
 	const handleAddSubmit = (e: React.FormEvent) => {
 		e.preventDefault();

--- a/web/dashboard/src/types.ts
+++ b/web/dashboard/src/types.ts
@@ -322,6 +322,43 @@ export interface ScimEndpoint {
 	updated_at?: number | null;
 }
 
+// SAMLServiceProvider is a downstream SP that Authorizer (as IdP) issues
+// signed assertions to. Inverse of OrgSAMLConnection.
+export interface SAMLServiceProvider {
+	id: string;
+	org_id: string;
+	name: string;
+	entity_id: string;
+	acs_url: string;
+	sp_cert_pem?: string | null;
+	name_id_format?: string | null;
+	mapped_attributes?: string | null;
+	allow_idp_initiated: boolean;
+	is_active: boolean;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+// SAMLIDPKey is a per-org SAML IdP signing keypair. The private key is never
+// projected — only the certificate and rotation status.
+export interface SAMLIDPKey {
+	id: string;
+	org_id: string;
+	cert_pem: string;
+	algorithm: string;
+	// "current" (signs new assertions), "active" (published, not signing) or
+	// "retired" (neither).
+	status: string;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+export interface SAMLSPMetadataParseResult {
+	entity_id: string;
+	acs_url: string;
+	certificate?: string | null;
+}
+
 export interface CreateScimEndpointResponse {
 	scim_endpoint: ScimEndpoint;
 	// Returned exactly once at creation/rotation; never retrievable again.


### PR DESCRIPTION
## Summary

Adds the SAML 2.0 **Identity Provider** role to Authorizer. Until now Authorizer could only act as a SAML *Service Provider* (consuming an org's upstream Okta/Entra). It can now also **be** the IdP — issuing signed SAML assertions so downstream SaaS SPs (Zendesk, Notion, Tableau, …) can federate against Authorizer. Architecturally the inverse of the existing SP role in `saml_sp.go`.

Built on the lower-level `crewjam/saml` `IdentityProvider` primitives (not the opinionated `samlidp` subpackage), so it composes with Authorizer's existing user/session/admin layers.

## Changes

**Storage (all 6 DB providers)**
- New entities `SAMLServiceProvider` (registered downstream SP) and `SAMLIDPKey` (per-org signing keypair with rotation status). Implemented across sql, mongodb, arangodb, cassandradb, dynamodb, couchbase + provider interface + collection/table/GSI registration.
- `SAMLIDPKey.PrivateKeyEnc` is AES-encrypted at rest (keyed on `Config.ClientSecret`), `json:"-"`.

**Crypto**
- `NewSAMLSigningKeypair` generates a self-signed X.509 cert wrapping an RSA-2048 key (SAML XML-DSIG needs the cert wrapper the raw JWT key lacks). `ParseCertificateFromPemStr` helper.

**HTTP endpoints** (`internal/http_handlers/saml_idp.go`)
- `GET /saml/idp/:org_slug/metadata` — IdP EntityDescriptor; publishes **all** currently-active signing certs as separate `<KeyDescriptor>`s.
- `GET|POST /saml/idp/:org_slug/sso` — SP-initiated SSO (redirect + POST bindings) with a login bounce/resume for unauthenticated users.
- `GET /saml/idp/:org_slug/sso/:sp_id` — IdP-initiated SSO, gated by the SP's `allow_idp_initiated` flag.
- Assertions signed **RSA-SHA256** (stronger than crewjam's SHA-1 default); attributes mapped from the Authorizer profile per the SP's config.

**Admin API**
- GraphQL: `_create/_update/_delete/_saml_service_provider`, `_list_saml_service_providers`, `_rotate_saml_idp_cert`, `_retire_saml_idp_key`, `_list_saml_idp_keys`, `_import_saml_sp_metadata`. Business logic in `internal/service/admin_saml_idp.go`, gated by super-admin / org-admin.
- gRPC/proto parity for the same admin surface (`AuthorizerAdminService`).
- Dashboard UI: SP registration list/create/edit/delete, metadata-import, and signing-key rotation/retire panel.

## Key-rotation operator workflow

Signing keys carry a status: `current` → `active` → `retired`.
1. A first key is generated lazily (`current`) on first metadata/SSO hit — no manual init needed.
2. **Rotate** (`_rotate_saml_idp_cert`): generates a new `current` key; the previously-current key becomes `active` — still published in IdP metadata (so SPs with cached metadata keep validating), but no longer used to sign. New assertions are signed with `current` only.
3. Operator gives downstream SPs time to refresh IdP metadata (they now trust both certs).
4. **Retire** (`_retire_saml_idp_key`): once SPs have picked up the new cert, explicitly retire the old `active` key — it drops out of metadata and can no longer be used. Retirement is an explicit admin action; there is **no time-based auto-expiry**. The `current` key cannot be retired (rotate first).

This overlap-window model **exceeds Auth0**, which supports only a single SAML signing cert with a disruptive, no-overlap manual rotation.

## IdP-initiated replay-guard decision

The IdP-initiated path issues an **unsolicited** assertion (no `InResponseTo` to bind to). I deliberately added **no issuance-side replay guard**, because:
- Assertion replay is defended on the **consuming SP's** side (single-use `AssertionID`), and here Authorizer is the *issuer*, not the consumer. An issuance-side dedupe would not protect any SP that doesn't itself dedupe, and would add shared-store state for no security gain on the issuer side.
- Instead the assertion carries a tight `NotBefore`/`NotOnOrAfter` window (crewjam `MaxClockSkew`/`MaxIssueDelay`), bounding any replay to that window regardless of SP behavior.
- The unsolicited path is off by default and must be explicitly enabled per SP (`allow_idp_initiated`), mirroring the SP-side IdP-initiated gate and the Auth0 Login-CSRF guidance.

## Security review

Second-pass by the security-engineer agent. Key guarantees, verified by tests:
- **ACS/entity-ID strict binding**: the ACS URL comes only from the registered `SAMLServiceProvider` record via `samlSPRegistry.GetServiceProvider`; crewjam `Validate` rejects any request-supplied ACS that doesn't match — no open-redirect / assertion-exfiltration.
- **Audience isolation**: an assertion for SP-A (Audience = A's entity ID) does not validate at SP-B (test `TestSAMLIDPAudienceIsolation`).
- **No unauthenticated issuance** (SP-initiated): an assertion is only emitted after a valid Authorizer session; otherwise the flow bounces through the normal login UI and resumes via an opaque single-use memory-store key (never a request-supplied redirect target).
- **XML import**: `ImportSAMLSPMetadata` parses via crewjam `samlsp.ParseMetadata` over Go `encoding/xml`, which ignores DTDs and never resolves external entities — no XXE.
- **Rotation**: a retired key is neither published nor usable for signing; the current key cannot be retired.

**Findings from the review pass and their resolution:**
- **C1 (Critical) — fixed**: issuance resolved the browser user from the session cookie but never checked org membership, so any authenticated user could get an assertion signed by *another* org's key for that org's SP (cross-tenant identity). Now every emit path gates on `GetOrgMembership(org, user)` (mirroring the SP-side model), and refuses to assert an **unverified** email as the NameID.
- **M1 (Medium) — fixed**: the "current" signing key could become ambiguous (rotation inserted-then-demoted with a non-fatal demote; concurrent first-access). Rotation now demotes-then-inserts with a fatal demote (never >1 current); key selection is deterministic (newest wins).
- **L3 (Low) — fixed**: the generated signing cert was marked `IsCA`/`certSign`; now a least-privilege leaf (`digitalSignature` only), which strict SP validators prefer.
- **L1 (Low) — fixed**: IdP-initiated `RelayState` length is now bounded.
- **M2 / L2 / L4 — documented, not changed**: the login-bounce/metadata host derivation uses `parsers.GetHost` (the same request-host pattern used pervasively across the codebase, incl. the SP side); lazy first-key generation is reachable pre-auth (bounded, idempotent); and SAML private keys are encrypted under `Config.ClientSecret` (rotating it requires re-rotating SAML keys). These match existing conventions; hardening them is a follow-up.

The reviewer confirmed **What's Good**: ACS/entity-ID strict binding, audience isolation, mapped attributes inside the signature, key-status gating, AES-256-GCM at-rest key protection, no-XXE metadata import, and complete IDOR-safe admin authorization.

**Final pre-merge audit** (second security pass): **no merge-blocking issues**; C1 confirmed closed end-to-end (no bypass path — both emit functions gate on `authorizeSAMLIssuance`; fail-closed on all 6 providers' `GetOrgMembership` not-found; e2e test proves member→signed-assertion, non-member→403-style deny through the real handler + real storage). One residual of the same spoofing class was then closed: `buildMappedAttributes` no longer emits the `email` **attribute** for an unverified address (previously only the NameID was guarded), so an unverified email is now asserted nowhere.

## Testing

- `internal/http_handlers/saml_idp_test.go` — assertion round-trip proving emitted assertions pass a real crewjam `ServiceProvider.ParseXMLResponse` (signature + audience + recipient + InResponseTo), audience isolation, unknown-SP rejection, attribute mapping, NameID derivation, published-key filtering.
- `internal/crypto/saml_x509_test.go` — keypair/cert round-trip.
- `internal/storage/saml_idp_test.go` — `SAMLServiceProvider` + `SAMLIDPKey` CRUD across all DB providers (`TEST_DBS`).
- Touched packages (`crypto`, `http_handlers`, `storage`, `service`, `grpcsrv/...`) and the integration suite green on SQLite; `golangci-lint` clean on the changed packages.
- Dashboard: `tsc --noEmit` + `vite build` + prettier clean.
- `make test-all-db` should be run in CI before merge for full cross-DB validation of the two new entities.

## Not in this PR / follow-ups
- `make proto-gen` requires a valid `buf.build` token for its BSR remote plugins; `gen/` here was regenerated with the exact pinned local plugin versions (byte-identical headers). CI with a token will reproduce it.
- M2/L2/L4 security hardening (host-derivation source, pre-auth lazy keygen, dedicated SAML-key secret) — documented above, consistent with existing conventions.

## Deployment note

The SP-initiated login bounce returns the browser to the IdP SSO endpoint on Authorizer's own host. Under the default wildcard `allowed_origins` this is permitted automatically; deployments that pin `allowed_origins` should include the Authorizer host so the post-login resume validates.
