### PR TITLE
feat(scim,fga,saml): SCIM group provisioning → OpenFGA roles → SAML group assertions (#692, closes #512's pending piece)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -625,6 +625,7 @@ func runRoot(c *cobra.Command, args []string) {
 		Log:                 &log,
 		StorageProvider:     storageProvider,
 		MemoryStoreProvider: memoryStoreProvider,
+		AuthzEngine:         authzEngine,
 	})
 	scimHandler := scimhttp.New(&scimhttp.Dependencies{
 		Log:     &log,

--- a/internal/http_handlers/oauth_sso.go
+++ b/internal/http_handlers/oauth_sso.go
@@ -634,7 +634,10 @@ func (h *httpProvider) jitProvisionFederatedUser(ctx context.Context, orgID, iss
 // records the session, and redirects to the app's redirect_uri.
 func (h *httpProvider) issueSSOSession(c *gin.Context, flow *ssoFlowState, user *schemas.User, isSignUp bool) error {
 	hostname := parsers.GetHost(c)
-	roles := splitRoles(user.Roles)
+	// Org-scoped mint point: augment the user's roles with any role granted in
+	// THIS org through SCIM group membership (issue #692). Additive and
+	// org-namespaced — see orgGroupDerivedRoles.
+	roles := unionRoles(splitRoles(user.Roles), h.orgGroupDerivedRoles(c.Request.Context(), flow.OrgID, user, h.Log))
 	authToken, err := h.TokenProvider.CreateAuthToken(c, &token.AuthTokenConfig{
 		User:        user,
 		Roles:       roles,

--- a/internal/http_handlers/org_group_roles.go
+++ b/internal/http_handlers/org_group_roles.go
@@ -1,0 +1,91 @@
+package http_handlers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// orgGroupDerivedRoles resolves the role names a user holds in orgID through the
+// FGA graph — roles granted transitively via group membership
+// (role:<orgID>/<name>#assignee@group:<orgID>/<gid>#member) or granted to the
+// user directly (role:<orgID>/<name>#assignee@user:<uid>). It is the JWT-claim
+// twin of assertedGroupsForOrg (saml_idp.go): the SCIM/SSO group→role projection
+// deferred by issue #692. Callers union the result onto the roles they already
+// mint, so it only ever ADDS roles for the org being authenticated into.
+//
+// CROSS-TENANT CONTAINMENT (security-critical): a user may legitimately hold
+// roles in several orgs. A token minted for orgID must NEVER carry a role
+// belonging to another org — an org-B "admin" role must not leak into an org-A
+// token. Containment is enforced by the org-namespace of the role object,
+// mirroring assertedGroupsForOrg's two gates:
+//
+//	Gate 1 (namespace): the FGA object id must start with "role:<orgID>/".
+//	                    Role objects are always org-namespaced and orgID is a
+//	                    slash-free UUID, so a foreign org's role cannot match.
+//	Gate 2 (shape, defense in depth): the stripped remainder must be a bare role
+//	                    name — non-empty and containing no "/". Roles have no DB
+//	                    row to verify against (unlike groups' ScimGroup row), so
+//	                    the structural check is the row-of-record analog: it
+//	                    rejects any object id that slipped past Gate 1 malformed.
+//
+// Fail-closed: no engine, or any lookup error, yields NO derived roles (never a
+// partial or unscoped set). Because callers union onto their existing roles, a
+// failure only ever falls back to today's behaviour — never fewer roles, never a
+// blocked login.
+func (h *httpProvider) orgGroupDerivedRoles(ctx context.Context, orgID string, user *schemas.User, log *zerolog.Logger) []string {
+	if h.AuthzEngine == nil {
+		return nil
+	}
+	l := log.With().Str("func", "orgGroupDerivedRoles").Logger()
+	objects, err := h.AuthzEngine.ListObjects(ctx, "user:"+user.ID, "assignee", "role")
+	if err != nil {
+		// No model, no role type/relation, engine down — derive nothing.
+		l.Debug().Err(err).Msg("role lookup failed, deriving no roles")
+		return nil
+	}
+	prefix := "role:" + orgID + "/"
+	seen := map[string]bool{}
+	var names []string
+	for _, obj := range objects {
+		name, ok := strings.CutPrefix(obj, prefix) // Gate 1: namespace.
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || strings.Contains(name, "/") { // Gate 2: bare name.
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// unionRoles returns base with every role in extra not already present appended,
+// preserving base's order. The result is always a superset of base — the
+// additive, never-fewer-roles guarantee the org role projection relies on.
+func unionRoles(base, extra []string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[string]bool, len(base))
+	for _, r := range base {
+		seen[r] = true
+	}
+	out := base
+	for _, r := range extra {
+		if r == "" || seen[r] {
+			continue
+		}
+		seen[r] = true
+		out = append(out, r)
+	}
+	return out
+}

--- a/internal/http_handlers/org_group_roles_test.go
+++ b/internal/http_handlers/org_group_roles_test.go
@@ -1,0 +1,182 @@
+package http_handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	fgaengine "github.com/authorizerdev/authorizer/internal/authorization/engine/openfga"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// newRoleTestEngine spins up an in-memory FGA engine loaded with groupTestModel
+// (defined in saml_idp_groups_test.go), whose `role` type already accepts both
+// direct user assignees and nested group#member usersets.
+func newRoleTestEngine(t *testing.T, storeName string) engine.AuthorizationEngine {
+	t.Helper()
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	eng, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: storeName},
+		&fgaengine.Dependencies{Log: &logger},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := eng.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	_, err = eng.WriteModel(context.Background(), groupTestModel)
+	require.NoError(t, err)
+	return eng
+}
+
+// finalClaimRoles reproduces exactly what the org-scoped mint points
+// (issueSSOSession / issueSAMLSession) put into AuthTokenConfig.Roles:
+// splitRoles(user.Roles) unioned with the org's FGA-derived roles.
+func finalClaimRoles(h *httpProvider, orgID string, user *schemas.User, log *zerolog.Logger) []string {
+	return unionRoles(splitRoles(user.Roles), h.orgGroupDerivedRoles(context.Background(), orgID, user, log))
+}
+
+// TestOrgGroupDerivedRolesHappyPath: a user who is a member of a group bound to
+// role "admin" in Org A gets "admin" in the roles claim minted for Org A —
+// through both the transitive group→role path and a direct user→role grant.
+func TestOrgGroupDerivedRolesHappyPath(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+	eng := newRoleTestEngine(t, "authorizer-org-roles-happy")
+
+	const (
+		orgA    = "org-a"
+		userID  = "user-1"
+		groupID = "gid-a"
+	)
+	// user -> group (SCIM membership), group -> role:admin (admin-written binding).
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{
+		{User: "user:" + userID, Relation: "member", Object: "group:" + orgA + "/" + groupID},
+		{User: "group:" + orgA + "/" + groupID + "#member", Relation: "assignee", Object: "role:" + orgA + "/admin"},
+		// A direct user->role grant in the same org must also project.
+		{User: "user:" + userID, Relation: "assignee", Object: "role:" + orgA + "/editor"},
+	}))
+
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, AuthzEngine: eng}}
+	user := &schemas.User{ID: userID, Roles: "user"} // global default role
+
+	derived := h.orgGroupDerivedRoles(ctx, orgA, user, &logger)
+	assert.ElementsMatch(t, []string{"admin", "editor"}, derived)
+
+	// The role lands in the JWT claim, and the pre-existing global role survives.
+	claim := finalClaimRoles(h, orgA, user, &logger)
+	assert.Equal(t, "user", claim[0], "existing role must stay first / never be dropped")
+	assert.ElementsMatch(t, []string{"user", "admin", "editor"}, claim)
+}
+
+// TestOrgGroupDerivedRolesCrossTenantContainment is the security-critical proof:
+// a user who legitimately holds the "admin" role in Org B must NEVER have that
+// role appear in a token minted for Org A.
+func TestOrgGroupDerivedRolesCrossTenantContainment(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+	eng := newRoleTestEngine(t, "authorizer-org-roles-xtenant")
+
+	const (
+		orgA   = "org-a"
+		orgB   = "org-b"
+		userID = "user-shared" // member of a group in BOTH orgs
+	)
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{
+		// Org A: viewer role via group.
+		{User: "user:" + userID, Relation: "member", Object: "group:" + orgA + "/ga"},
+		{User: "group:" + orgA + "/ga#member", Relation: "assignee", Object: "role:" + orgA + "/viewer"},
+		// Org B: admin role via group (the dangerous one).
+		{User: "user:" + userID, Relation: "member", Object: "group:" + orgB + "/gb"},
+		{User: "group:" + orgB + "/gb#member", Relation: "assignee", Object: "role:" + orgB + "/admin"},
+	}))
+
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, AuthzEngine: eng}}
+	user := &schemas.User{ID: userID, Roles: "user"}
+
+	// Token for Org A carries ONLY org-A's viewer, NEVER org-B's admin.
+	claimA := finalClaimRoles(h, orgA, user, &logger)
+	assert.ElementsMatch(t, []string{"user", "viewer"}, claimA)
+	assert.NotContains(t, claimA, "admin", "cross-tenant leak: org-B role surfaced in an org-A token")
+
+	// Symmetric: token for Org B carries ONLY org-B's admin.
+	claimB := finalClaimRoles(h, orgB, user, &logger)
+	assert.ElementsMatch(t, []string{"user", "admin"}, claimB)
+	assert.NotContains(t, claimB, "viewer")
+}
+
+// TestOrgGroupDerivedRolesGate2RejectsSlash: an object id that slips the Gate 1
+// prefix but is not a bare role name (contains a further "/") is rejected by the
+// shape gate — never emitted as a role.
+func TestOrgGroupDerivedRolesGate2RejectsSlash(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+	eng := newRoleTestEngine(t, "authorizer-org-roles-gate2")
+
+	const orgA = "org-a"
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{
+		{User: "user:u", Relation: "assignee", Object: "role:" + orgA + "/nested/evil"},
+	}))
+
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, AuthzEngine: eng}}
+	got := h.orgGroupDerivedRoles(ctx, orgA, &schemas.User{ID: "u"}, &logger)
+	assert.Empty(t, got, "gate 2 must reject a non-bare role name")
+}
+
+// TestOrgGroupDerivedRolesRegression proves the non-FGA-group case is unchanged:
+// a user with no role bindings derives nothing, so the claim is exactly what it
+// was before this change (splitRoles(user.Roles)).
+func TestOrgGroupDerivedRolesRegression(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+	eng := newRoleTestEngine(t, "authorizer-org-roles-regression")
+
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, AuthzEngine: eng}}
+	user := &schemas.User{ID: "lonely", Roles: "user,cashier"}
+
+	assert.Empty(t, h.orgGroupDerivedRoles(ctx, "org-a", user, &logger))
+	// Claim is byte-for-byte the pre-change behaviour.
+	assert.Equal(t, splitRoles(user.Roles), finalClaimRoles(h, "org-a", user, &logger))
+}
+
+// TestOrgGroupDerivedRolesFailClosed: with no engine configured, and on any
+// lookup error, no roles are derived — never an error, never a partial set.
+func TestOrgGroupDerivedRolesFailClosed(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	// No engine at all.
+	hNoEngine := &httpProvider{Dependencies: Dependencies{Log: &logger}}
+	assert.Nil(t, hNoEngine.orgGroupDerivedRoles(ctx, "org-a", &schemas.User{ID: "u"}, &logger))
+
+	// Engine present but no model written yet → ListObjects errors → fail-closed.
+	logger2 := zerolog.New(zerolog.NewTestWriter(t))
+	engNoModel, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: "authorizer-org-roles-nomodel"},
+		&fgaengine.Dependencies{Log: &logger2},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := engNoModel.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	hNoModel := &httpProvider{Dependencies: Dependencies{Log: &logger, AuthzEngine: engNoModel}}
+	assert.Nil(t, hNoModel.orgGroupDerivedRoles(ctx, "org-a", &schemas.User{ID: "u"}, &logger))
+}
+
+// TestUnionRoles covers the additive union helper: dedup, order preservation,
+// and the never-fewer-than-base guarantee.
+func TestUnionRoles(t *testing.T) {
+	assert.Equal(t, []string{"a", "b"}, unionRoles([]string{"a", "b"}, nil))
+	assert.Equal(t, []string{"a", "b", "c"}, unionRoles([]string{"a", "b"}, []string{"c"}))
+	// Duplicates in extra are dropped; base order preserved; base is a prefix.
+	assert.Equal(t, []string{"a", "b", "c"}, unionRoles([]string{"a", "b"}, []string{"a", "c", "b"}))
+	// Empty strings in extra are ignored.
+	assert.Equal(t, []string{"a"}, unionRoles([]string{"a"}, []string{"", "a"}))
+}

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -293,7 +294,8 @@ func (h *httpProvider) emitSAMLAssertion(c *gin.Context, idp *saml.IdentityProvi
 		return
 	}
 	session := buildSAMLSession(user, sp)
-	maker := mappedAssertionMaker{attributes: buildMappedAttributes(user, sp)}
+	attrs, groups := h.mappedAttributesWithGroups(ctx, orgID, user, sp, log)
+	maker := mappedAssertionMaker{attributes: attrs}
 	if err := maker.MakeAssertion(req, session); err != nil {
 		log.Debug().Err(err).Msg("failed to build assertion")
 		h.samlIDPFail(c, log, slug, "assertion_error", "could not build assertion")
@@ -304,13 +306,14 @@ func (h *httpProvider) emitSAMLAssertion(c *gin.Context, idp *saml.IdentityProvi
 		h.samlIDPFail(c, log, slug, "assertion_error", "could not deliver assertion")
 		return
 	}
-	h.auditSAMLIDPIssued(c, slug, sp, user)
+	h.auditSAMLIDPIssued(c, slug, sp, user, groups)
 }
 
 // emitIDPInitiatedAssertion produces an unsolicited assertion and POSTs it to the
 // SP's ACS. Mirrors crewjam ServeIDPInitiated, but with our session + mapped
 // attributes. No InResponseTo (there is no request to bind to).
 func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.IdentityProvider, sp *schemas.SAMLServiceProvider, orgID, slug, relayState string, user *schemas.User, log *zerolog.Logger) {
+	ctx := c.Request.Context()
 	if !h.authorizeSAMLIssuance(c, orgID, slug, sp, user, log) {
 		return
 	}
@@ -325,7 +328,8 @@ func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.Ident
 		Now:                     saml.TimeNow(),
 	}
 	session := buildSAMLSession(user, sp)
-	maker := mappedAssertionMaker{attributes: buildMappedAttributes(user, sp)}
+	attrs, groups := h.mappedAttributesWithGroups(ctx, orgID, user, sp, log)
+	maker := mappedAssertionMaker{attributes: attrs}
 	if err := maker.MakeAssertion(req, session); err != nil {
 		log.Debug().Err(err).Msg("failed to build idp-initiated assertion")
 		h.samlIDPFail(c, log, slug, "assertion_error", "could not build assertion")
@@ -336,7 +340,7 @@ func (h *httpProvider) emitIDPInitiatedAssertion(c *gin.Context, idp *saml.Ident
 		h.samlIDPFail(c, log, slug, "assertion_error", "could not deliver assertion")
 		return
 	}
-	h.auditSAMLIDPIssued(c, slug, sp, user)
+	h.auditSAMLIDPIssued(c, slug, sp, user, groups)
 }
 
 // authorizeSAMLIssuance is the single chokepoint that decides whether an
@@ -479,6 +483,106 @@ func buildMappedAttributes(user *schemas.User, sp *schemas.SAMLServiceProvider) 
 	add("nickname", refs.StringValue(user.Nickname))
 	add("picture", refs.StringValue(user.Picture))
 	return attrs
+}
+
+// samlDefaultGroupsAttribute is the SAML attribute name a group set is emitted
+// under when the SP configures no override. "groups" and "memberOf" are the two
+// real-world conventions; "groups" is the default.
+const samlDefaultGroupsAttribute = "groups"
+
+// mappedAttributesWithGroups builds the SP's profile attributes and appends the
+// user's group set as a single multi-valued attribute. It MUST be called only
+// after authorizeSAMLIssuance has passed — the group set is scoped to the issuing
+// org inside assertedGroupsForOrg, which is the cross-tenant containment gate.
+// Returns the attributes plus the asserted group names (for the audit event).
+func (h *httpProvider) mappedAttributesWithGroups(ctx context.Context, orgID string, user *schemas.User, sp *schemas.SAMLServiceProvider, log *zerolog.Logger) ([]saml.Attribute, []string) {
+	attrs := buildMappedAttributes(user, sp)
+	groups := h.assertedGroupsForOrg(ctx, orgID, user, log)
+	if len(groups) > 0 {
+		attrs = append(attrs, buildMultiValuedAttribute(samlGroupsAttributeName(sp), groups))
+	}
+	return attrs, groups
+}
+
+// assertedGroupsForOrg resolves the group displayNames to emit for `user` in an
+// assertion issued for `orgID`, sourced ONLY from that org's namespace.
+//
+// CROSS-TENANT CONTAINMENT (the security-critical invariant): a user may
+// legitimately be a member of groups in several orgs. An assertion issued for
+// org A must NEVER carry a group that belongs to org B — a bare-name SP that
+// grants on "admins" would otherwise let an org-B "admins" membership grant org-A
+// admin. Two independent gates enforce this, both of which must pass:
+//
+//	Gate 1 (namespace): the FGA object id must start with "group:<orgID>/".
+//	                    Group objects are always org-namespaced, so a foreign
+//	                    group cannot match this prefix.
+//	Gate 2 (row of record, defense in depth): the stored ScimGroup row's OrgID
+//	                    must equal orgID. Even if a malformed id slipped past
+//	                    Gate 1, the authoritative row rejects it.
+//
+// Fail-closed: any engine/model/lookup error yields NO groups (never a partial or
+// unscoped set) — omitting groups only ever narrows the SP's view, never widens it.
+func (h *httpProvider) assertedGroupsForOrg(ctx context.Context, orgID string, user *schemas.User, log *zerolog.Logger) []string {
+	if h.AuthzEngine == nil {
+		return nil
+	}
+	objects, err := h.AuthzEngine.ListObjects(ctx, "user:"+user.ID, "member", "group")
+	if err != nil {
+		// No model yet, engine down, etc. — emit no groups (fail-closed).
+		log.Debug().Err(err).Msg("saml idp: group lookup failed, emitting no groups")
+		return nil
+	}
+	prefix := "group:" + orgID + "/"
+	seen := map[string]bool{}
+	var names []string
+	for _, obj := range objects {
+		groupID, ok := strings.CutPrefix(obj, prefix) // Gate 1: namespace.
+		if !ok {
+			continue
+		}
+		group, err := h.StorageProvider.GetScimGroupByID(ctx, groupID)
+		if err != nil || group == nil || group.OrgID != orgID { // Gate 2: row of record.
+			continue
+		}
+		name := strings.TrimSpace(group.DisplayName)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// samlGroupsAttributeName returns the SAML attribute name the SP expects its
+// group set under, read from the SP's MappedAttributes "groups" key, defaulting
+// to "groups".
+func samlGroupsAttributeName(sp *schemas.SAMLServiceProvider) string {
+	if sp.MappedAttributes != nil && strings.TrimSpace(*sp.MappedAttributes) != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(*sp.MappedAttributes), &m); err == nil {
+			if name := strings.TrimSpace(m["groups"]); name != "" {
+				return name
+			}
+		}
+	}
+	return samlDefaultGroupsAttribute
+}
+
+// buildMultiValuedAttribute encodes a slice of values as ONE SAML <Attribute>
+// carrying multiple <AttributeValue> children — the correct encoding for a
+// multi-valued attribute (not several <Attribute> elements, not a delimited
+// string).
+func buildMultiValuedAttribute(name string, values []string) saml.Attribute {
+	vals := make([]saml.AttributeValue, 0, len(values))
+	for _, v := range values {
+		vals = append(vals, saml.AttributeValue{Type: "xs:string", Value: v})
+	}
+	return saml.Attribute{
+		Name:       name,
+		NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+		Values:     vals,
+	}
 }
 
 // samlSPRegistry implements crewjam's ServiceProviderProvider against the org's
@@ -740,8 +844,15 @@ func (h *httpProvider) samlIDPFail(c *gin.Context, log *zerolog.Logger, slug, co
 	c.JSON(http.StatusBadRequest, gin.H{"error": code, "error_description": desc})
 }
 
-func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User) {
+func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User, groups []string) {
 	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusSuccess)
+	// Record the asserted group set so a later "why did this SP grant admin?"
+	// question is answerable. Count goes in the durable audit metadata; the full
+	// (org-scoped) set is logged at debug for forensics.
+	if len(groups) > 0 {
+		h.Log.Debug().Str("org", slug).Str("sp", sp.EntityID).Str("user_id", user.ID).
+			Strs("asserted_groups", groups).Msg("saml idp: asserted group set")
+	}
 	h.AuditProvider.LogEvent(audit.Event{
 		Action:       constants.AuditSAMLIDPAssertionIssuedEvent,
 		ActorID:      user.ID,
@@ -749,7 +860,7 @@ func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schem
 		ActorEmail:   refs.StringValue(user.Email),
 		ResourceType: constants.AuditResourceTypeSession,
 		ResourceID:   sp.ID,
-		Metadata:     slug + ":" + sp.EntityID,
+		Metadata:     slug + ":" + sp.EntityID + ":groups=" + strconv.Itoa(len(groups)),
 		IPAddress:    utils.GetIP(c.Request),
 		UserAgent:    utils.GetUserAgent(c.Request),
 	})

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -40,7 +40,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -846,9 +845,10 @@ func (h *httpProvider) samlIDPFail(c *gin.Context, log *zerolog.Logger, slug, co
 
 func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schemas.SAMLServiceProvider, user *schemas.User, groups []string) {
 	metrics.RecordAuthEvent(metrics.EventOAuthCallback, metrics.StatusSuccess)
-	// Record the asserted group set so a later "why did this SP grant admin?"
-	// question is answerable. Count goes in the durable audit metadata; the full
-	// (org-scoped) set is logged at debug for forensics.
+	// Record the actual asserted group set (not just its count) in the durable
+	// audit metadata so a later "why did this SP grant admin?" question is
+	// answerable from the audit trail alone — the debug log is typically off in
+	// production. The set is already org-scoped by assertedGroupsForOrg.
 	if len(groups) > 0 {
 		h.Log.Debug().Str("org", slug).Str("sp", sp.EntityID).Str("user_id", user.ID).
 			Strs("asserted_groups", groups).Msg("saml idp: asserted group set")
@@ -860,7 +860,7 @@ func (h *httpProvider) auditSAMLIDPIssued(c *gin.Context, slug string, sp *schem
 		ActorEmail:   refs.StringValue(user.Email),
 		ResourceType: constants.AuditResourceTypeSession,
 		ResourceID:   sp.ID,
-		Metadata:     slug + ":" + sp.EntityID + ":groups=" + strconv.Itoa(len(groups)),
+		Metadata:     slug + ":" + sp.EntityID + ":groups=[" + strings.Join(groups, ",") + "]",
 		IPAddress:    utils.GetIP(c.Request),
 		UserAgent:    utils.GetUserAgent(c.Request),
 	})

--- a/internal/http_handlers/saml_idp_groups_test.go
+++ b/internal/http_handlers/saml_idp_groups_test.go
@@ -1,0 +1,141 @@
+package http_handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	fgaengine "github.com/authorizerdev/authorizer/internal/authorization/engine/openfga"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// groupTestModel is the minimal ReBAC model the SCIM-group SAML projection needs:
+// a group's members and a role's assignees may both be users or nested-group
+// usersets (group#member).
+const groupTestModel = `model
+  schema 1.1
+type user
+type group
+  relations
+    define member: [user, group#member]
+type role
+  relations
+    define assignee: [user, group#member]
+`
+
+// groupOnlyStore is a storage.Provider that answers only GetScimGroupByID (the
+// one method assertedGroupsForOrg calls). Embedding the interface satisfies the
+// full contract; any other call panics, which is the point — the test must not
+// reach for anything else.
+type groupOnlyStore struct {
+	storage.Provider
+	groups map[string]*schemas.ScimGroup
+}
+
+func (s groupOnlyStore) GetScimGroupByID(_ context.Context, id string) (*schemas.ScimGroup, error) {
+	if g, ok := s.groups[id]; ok {
+		return g, nil
+	}
+	return nil, assert.AnError
+}
+
+// TestAssertedGroupsCrossTenantContainment is the security-critical proof for
+// this feature: a user who is (legitimately) a member of a group in Org B must
+// NEVER have that group's name appear in an assertion issued for Org A.
+func TestAssertedGroupsCrossTenantContainment(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	eng, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: "authorizer-groups-test"},
+		&fgaengine.Dependencies{Log: &logger},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := eng.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	_, err = eng.WriteModel(ctx, groupTestModel)
+	require.NoError(t, err)
+
+	const (
+		orgA   = "org-a"
+		orgB   = "org-b"
+		userID = "user-shared" // a real member of BOTH orgs
+	)
+	// Org A: "viewers". Org B: "admins" (the dangerous one).
+	groupA := &schemas.ScimGroup{ID: "gid-a", OrgID: orgA, DisplayName: "viewers"}
+	groupB := &schemas.ScimGroup{ID: "gid-b", OrgID: orgB, DisplayName: "admins"}
+	store := groupOnlyStore{groups: map[string]*schemas.ScimGroup{
+		groupA.ID: groupA,
+		groupB.ID: groupB,
+	}}
+
+	// The user is a genuine member of a group in EACH org.
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{
+		{User: "user:" + userID, Relation: "member", Object: "group:" + orgA + "/" + groupA.ID},
+		{User: "user:" + userID, Relation: "member", Object: "group:" + orgB + "/" + groupB.ID},
+	}))
+
+	h := &httpProvider{Dependencies: Dependencies{
+		Log:             &logger,
+		StorageProvider: store,
+		AuthzEngine:     eng,
+	}}
+	user := &schemas.User{ID: userID}
+
+	// Assertion for Org A: only Org A's group name, NEVER Org B's "admins".
+	groupsForA := h.assertedGroupsForOrg(ctx, orgA, user, &logger)
+	assert.Equal(t, []string{"viewers"}, groupsForA)
+	assert.NotContains(t, groupsForA, "admins", "cross-tenant leak: org-B group surfaced in an org-A assertion")
+
+	// Assertion for Org B: only Org B's group name, NEVER Org A's "viewers".
+	groupsForB := h.assertedGroupsForOrg(ctx, orgB, user, &logger)
+	assert.Equal(t, []string{"admins"}, groupsForB)
+	assert.NotContains(t, groupsForB, "viewers")
+
+	// A user with no memberships in an org gets an empty set (fail-closed).
+	groupsForStranger := h.assertedGroupsForOrg(ctx, orgA, &schemas.User{ID: "nobody"}, &logger)
+	assert.Empty(t, groupsForStranger)
+}
+
+// TestAssertedGroupsGate2RejectsForgedNamespace proves the second, authoritative
+// gate: even if a tuple's object id somehow carried this org's prefix but the
+// stored row belongs to another org, the row-of-record check rejects it.
+func TestAssertedGroupsGate2RejectsForgedNamespace(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	eng, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: "authorizer-groups-gate2"},
+		&fgaengine.Dependencies{Log: &logger},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := eng.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	require.NoError(t, func() error { _, e := eng.WriteModel(ctx, groupTestModel); return e }())
+
+	const orgA = "org-a"
+	// The stored group row for "gid-x" actually belongs to org-b, but a tuple
+	// places it under the org-a prefix (a forged/mismatched id).
+	store := groupOnlyStore{groups: map[string]*schemas.ScimGroup{
+		"gid-x": {ID: "gid-x", OrgID: "org-b", DisplayName: "admins"},
+	}}
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{
+		{User: "user:u", Relation: "member", Object: "group:" + orgA + "/gid-x"},
+	}))
+
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, StorageProvider: store, AuthzEngine: eng}}
+	// Gate 1 (prefix) passes, but Gate 2 (row.OrgID == orgA) rejects it → no groups.
+	got := h.assertedGroupsForOrg(ctx, orgA, &schemas.User{ID: "u"}, &logger)
+	assert.Empty(t, got, "gate 2 must reject a group whose stored OrgID != issuing org")
+}

--- a/internal/http_handlers/saml_idp_groups_test.go
+++ b/internal/http_handlers/saml_idp_groups_test.go
@@ -139,3 +139,45 @@ func TestAssertedGroupsGate2RejectsForgedNamespace(t *testing.T) {
 	got := h.assertedGroupsForOrg(ctx, orgA, &schemas.User{ID: "u"}, &logger)
 	assert.Empty(t, got, "gate 2 must reject a group whose stored OrgID != issuing org")
 }
+
+// TestAssertedGroupsFollowMembershipRemoval is the SAML/JWT half of the SCIM
+// clear-members fix (the HIGH bug): a group is asserted only while the member
+// tuple exists. Once membership is cleared — exactly what SCIM clear-members
+// does (replaceMembers with an empty set → engine.DeleteTuples) — a
+// subsequently-issued assertion no longer carries the group, so any SP attribute
+// or group-derived JWT role is dropped. (The SCIM-HTTP → tuple-removed half is
+// proven end-to-end in integration_tests/scim_groups_test.go.)
+func TestAssertedGroupsFollowMembershipRemoval(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	eng, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: "authorizer-groups-removal"},
+		&fgaengine.Dependencies{Log: &logger},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := eng.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	_, err = eng.WriteModel(ctx, groupTestModel)
+	require.NoError(t, err)
+
+	const org = "org-a"
+	const userID = "user-1"
+	group := &schemas.ScimGroup{ID: "gid-1", OrgID: org, DisplayName: "admins"}
+	store := groupOnlyStore{groups: map[string]*schemas.ScimGroup{group.ID: group}}
+	h := &httpProvider{Dependencies: Dependencies{Log: &logger, StorageProvider: store, AuthzEngine: eng}}
+	user := &schemas.User{ID: userID}
+	memberTuple := engine.TupleKey{User: "user:" + userID, Relation: "member", Object: "group:" + org + "/" + group.ID}
+
+	// Member present → the group is asserted.
+	require.NoError(t, eng.WriteTuples(ctx, []engine.TupleKey{memberTuple}))
+	assert.Equal(t, []string{"admins"}, h.assertedGroupsForOrg(ctx, org, user, &logger))
+
+	// Membership cleared → the group is no longer asserted.
+	require.NoError(t, eng.DeleteTuples(ctx, []engine.TupleKey{memberTuple}))
+	assert.Empty(t, h.assertedGroupsForOrg(ctx, org, user, &logger),
+		"a cleared group member must not appear in a subsequently-issued SAML assertion")
+}

--- a/internal/http_handlers/saml_sp.go
+++ b/internal/http_handlers/saml_sp.go
@@ -293,7 +293,7 @@ func (h *httpProvider) SAMLACSHandler() gin.HandlerFunc {
 			return
 		}
 
-		if err := h.issueSAMLSession(c, slug, appRedirect, appState, user, isSignUp); err != nil {
+		if err := h.issueSAMLSession(c, slug, conn.OrgID, appRedirect, appState, user, isSignUp); err != nil {
 			log.Debug().Err(err).Msg("failed to issue session")
 			h.samlFail(c, &log, slug, "saml_session_failed", "could not establish session")
 			return
@@ -515,9 +515,12 @@ func samlAttr(assertion *saml.Assertion, name string) string {
 // issueSAMLSession mints the Authorizer session/tokens, sets the session cookie,
 // records the session, and redirects to the app's redirect_uri. Mirrors
 // issueSSOSession but with SAML audit semantics and no upstream nonce.
-func (h *httpProvider) issueSAMLSession(c *gin.Context, slug, appRedirect, appState string, user *schemas.User, isSignUp bool) error {
+func (h *httpProvider) issueSAMLSession(c *gin.Context, slug, orgID, appRedirect, appState string, user *schemas.User, isSignUp bool) error {
 	hostname := parsers.GetHost(c)
-	roles := splitRoles(user.Roles)
+	// Org-scoped mint point: augment the user's roles with any role granted in
+	// THIS org through SCIM group membership (issue #692). Additive and
+	// org-namespaced — see orgGroupDerivedRoles.
+	roles := unionRoles(splitRoles(user.Roles), h.orgGroupDerivedRoles(c.Request.Context(), orgID, user, h.Log))
 	authToken, err := h.TokenProvider.CreateAuthToken(c, &token.AuthTokenConfig{
 		User:        user,
 		Roles:       roles,

--- a/internal/http_handlers/scim/discovery.go
+++ b/internal/http_handlers/scim/discovery.go
@@ -73,6 +73,13 @@ func (h *Handler) schemas(c *gin.Context) {
 			"returned": "default", "uniqueness": "none",
 		}
 	}
+	immutableAttr := func(name, typ string) gin.H {
+		return gin.H{
+			"name": name, "type": typ, "required": false,
+			"multiValued": false, "mutability": "immutable",
+			"returned": "default", "uniqueness": "none",
+		}
+	}
 	userSchema := gin.H{
 		"schemas":     []string{schemaSchema},
 		"id":          schemaUser,
@@ -115,11 +122,12 @@ func (h *Handler) schemas(c *gin.Context) {
 				"name": "members", "type": "complex", "required": false,
 				"multiValued": true, "mutability": "readWrite",
 				"returned": "default", "uniqueness": "none",
+				// RFC 7643 §4.2: the members sub-attributes are immutable.
 				"subAttributes": []gin.H{
-					attr("value", "string", false),
-					attr("$ref", "reference", false),
-					attr("type", "string", false),
-					attr("display", "string", false),
+					immutableAttr("value", "string"),
+					immutableAttr("$ref", "reference"),
+					immutableAttr("type", "string"),
+					immutableAttr("display", "string"),
 				},
 			},
 		},

--- a/internal/http_handlers/scim/discovery.go
+++ b/internal/http_handlers/scim/discovery.go
@@ -31,8 +31,8 @@ func (h *Handler) serviceProviderConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, cfg)
 }
 
-// resourceTypes lists the provisionable resource types. Only User is supported;
-// Group is deferred (org-namespaced FGA roles, design §4.4 CR2).
+// resourceTypes lists the provisionable resource types: User and Group. Group
+// membership is stored as org-namespaced FGA tuples (RFC 7643 §4.1.2).
 func (h *Handler) resourceTypes(c *gin.Context) {
 	user := gin.H{
 		"schemas":     []string{schemaRestype},
@@ -43,12 +43,21 @@ func (h *Handler) resourceTypes(c *gin.Context) {
 		"schema":      schemaUser,
 		"meta":        gin.H{"resourceType": "ResourceType"},
 	}
+	group := gin.H{
+		"schemas":     []string{schemaRestype},
+		"id":          "Group",
+		"name":        "Group",
+		"endpoint":    "/Groups",
+		"description": "Group",
+		"schema":      schemaGroup,
+		"meta":        gin.H{"resourceType": "ResourceType"},
+	}
 	resp := gin.H{
 		"schemas":      []string{schemaListResp},
-		"totalResults": 1,
+		"totalResults": 2,
 		"startIndex":   1,
-		"itemsPerPage": 1,
-		"Resources":    []gin.H{user},
+		"itemsPerPage": 2,
+		"Resources":    []gin.H{user, group},
 	}
 	c.Header("Content-Type", contentType)
 	c.JSON(http.StatusOK, resp)
@@ -94,12 +103,34 @@ func (h *Handler) schemas(c *gin.Context) {
 		},
 		"meta": gin.H{"resourceType": "Schema"},
 	}
+	groupSchema := gin.H{
+		"schemas":     []string{schemaSchema},
+		"id":          schemaGroup,
+		"name":        "Group",
+		"description": "Group",
+		"attributes": []gin.H{
+			attr("displayName", "string", true),
+			attr("externalId", "string", false),
+			{
+				"name": "members", "type": "complex", "required": false,
+				"multiValued": true, "mutability": "readWrite",
+				"returned": "default", "uniqueness": "none",
+				"subAttributes": []gin.H{
+					attr("value", "string", false),
+					attr("$ref", "reference", false),
+					attr("type", "string", false),
+					attr("display", "string", false),
+				},
+			},
+		},
+		"meta": gin.H{"resourceType": "Schema"},
+	}
 	resp := gin.H{
 		"schemas":      []string{schemaListResp},
-		"totalResults": 1,
+		"totalResults": 2,
 		"startIndex":   1,
-		"itemsPerPage": 1,
-		"Resources":    []gin.H{userSchema},
+		"itemsPerPage": 2,
+		"Resources":    []gin.H{userSchema, groupSchema},
 	}
 	c.Header("Content-Type", contentType)
 	c.JSON(http.StatusOK, resp)

--- a/internal/http_handlers/scim/groups.go
+++ b/internal/http_handlers/scim/groups.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 
@@ -139,7 +140,7 @@ func (h *Handler) replaceGroup(c *gin.Context) {
 }
 
 func (h *Handler) patchGroup(c *gin.Context) {
-	displayName, ops, ok := parseGroupPatch(c)
+	displayName, ops, ok := parseGroupPatch(c.Request.Body)
 	if !ok {
 		writeError(c, http.StatusBadRequest, "invalidValue", "invalid PatchOp body")
 		return
@@ -193,7 +194,7 @@ func parseDisplayNameEq(filter string) (string, bool) {
 //     the member is encoded in the filtered path.
 //   - no-path form: {"op":"add","value":{"members":[{"value":"x"}]}} / displayName.
 //   - member values may be [{"value":"x"}] objects or bare ["x"] strings.
-func parseGroupPatch(c *gin.Context) (displayName *string, ops []MemberOpJSON, ok bool) {
+func parseGroupPatch(r io.Reader) (displayName *string, ops []MemberOpJSON, ok bool) {
 	body := struct {
 		Operations []struct {
 			Op    string          `json:"op"`
@@ -201,7 +202,7 @@ func parseGroupPatch(c *gin.Context) (displayName *string, ops []MemberOpJSON, o
 			Value json.RawMessage `json:"value"`
 		} `json:"Operations"`
 	}{}
-	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
 		return nil, nil, false
 	}
 	for _, raw := range body.Operations {

--- a/internal/http_handlers/scim/groups.go
+++ b/internal/http_handlers/scim/groups.go
@@ -1,0 +1,327 @@
+package scim
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/authorizerdev/authorizer/internal/refs"
+	svcscim "github.com/authorizerdev/authorizer/internal/service/scim"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// scimGroupMember is one entry of the multi-valued "members" attribute
+// (RFC 7643 §4.2). value is the member's Authorizer user id.
+type scimGroupMember struct {
+	Value   string `json:"value"`
+	Ref     string `json:"$ref,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Display string `json:"display,omitempty"`
+}
+
+// scimGroupResource is the wire representation of a SCIM Group (request + response).
+type scimGroupResource struct {
+	Schemas     []string          `json:"schemas"`
+	ID          string            `json:"id,omitempty"`
+	ExternalID  string            `json:"externalId,omitempty"`
+	DisplayName string            `json:"displayName"`
+	Members     []scimGroupMember `json:"members"`
+	Meta        scimMeta          `json:"meta"`
+}
+
+// scimGroupListResponse is the RFC 7644 §3.4.2 list envelope for groups.
+type scimGroupListResponse struct {
+	Schemas      []string            `json:"schemas"`
+	TotalResults int                 `json:"totalResults"`
+	StartIndex   int                 `json:"startIndex"`
+	ItemsPerPage int                 `json:"itemsPerPage"`
+	Resources    []scimGroupResource `json:"Resources"`
+}
+
+// toGroupResource maps a stored group + its member ids to the SCIM wire form.
+// externalId is de-namespaced back to the raw IdP value (stored "<orgID>:<raw>").
+func toGroupResource(orgID string, g *schemas.ScimGroup, memberIDs []string) scimGroupResource {
+	res := scimGroupResource{
+		Schemas:     []string{schemaGroup},
+		ID:          g.ID,
+		DisplayName: g.DisplayName,
+		Members:     []scimGroupMember{},
+		Meta:        scimMeta{ResourceType: "Group"},
+	}
+	if g.ExternalID != nil {
+		res.ExternalID = strings.TrimPrefix(refs.StringValue(g.ExternalID), orgID+":")
+	}
+	for _, uid := range memberIDs {
+		res.Members = append(res.Members, scimGroupMember{Value: uid, Ref: "../Users/" + uid, Type: "User"})
+	}
+	return res
+}
+
+// parseGroup decodes a SCIM Group create/replace body into the service input.
+func parseGroup(c *gin.Context) (svcscim.Group, bool) {
+	body := struct {
+		ExternalID  string          `json:"externalId"`
+		DisplayName string          `json:"displayName"`
+		Members     json.RawMessage `json:"members"`
+	}{}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		return svcscim.Group{}, false
+	}
+	return svcscim.Group{
+		ExternalID:  strings.TrimSpace(body.ExternalID),
+		DisplayName: strings.TrimSpace(body.DisplayName),
+		Members:     parseMemberValues(body.Members),
+	}, true
+}
+
+func (h *Handler) createGroup(c *gin.Context) {
+	in, ok := parseGroup(c)
+	if !ok || in.DisplayName == "" {
+		writeError(c, http.StatusBadRequest, "invalidValue", "displayName is required")
+		return
+	}
+	group, existed, err := h.Service.CreateGroup(c.Request.Context(), h.orgID(c), in)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	status := http.StatusCreated
+	if existed {
+		status = http.StatusOK
+	}
+	h.writeGroup(c, status, h.orgID(c), group)
+}
+
+func (h *Handler) getGroup(c *gin.Context) {
+	group, err := h.Service.GetGroup(c.Request.Context(), h.orgID(c), c.Param("id"))
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	h.writeGroup(c, http.StatusOK, h.orgID(c), group)
+}
+
+// listGroups supports only the `displayName eq "..."` filter (the IdP dedup
+// probe), mirroring listUsers. An unfiltered list returns an empty set.
+func (h *Handler) listGroups(c *gin.Context) {
+	orgID := h.orgID(c)
+	resp := scimGroupListResponse{
+		Schemas:    []string{schemaListResp},
+		StartIndex: 1,
+		Resources:  []scimGroupResource{},
+	}
+	if displayName, ok := parseDisplayNameEq(c.Query("filter")); ok {
+		if group, err := h.Service.FindGroupByDisplayName(c.Request.Context(), orgID, displayName); err == nil && group != nil {
+			members, _ := h.Service.GroupMembers(c.Request.Context(), orgID, group.ID)
+			resp.Resources = append(resp.Resources, toGroupResource(orgID, group, members))
+		}
+	}
+	resp.TotalResults = len(resp.Resources)
+	resp.ItemsPerPage = len(resp.Resources)
+	c.Header("Content-Type", contentType)
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) replaceGroup(c *gin.Context) {
+	in, ok := parseGroup(c)
+	if !ok {
+		writeError(c, http.StatusBadRequest, "invalidValue", "invalid body")
+		return
+	}
+	group, err := h.Service.ReplaceGroup(c.Request.Context(), h.orgID(c), c.Param("id"), in)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	h.writeGroup(c, http.StatusOK, h.orgID(c), group)
+}
+
+func (h *Handler) patchGroup(c *gin.Context) {
+	displayName, ops, ok := parseGroupPatch(c)
+	if !ok {
+		writeError(c, http.StatusBadRequest, "invalidValue", "invalid PatchOp body")
+		return
+	}
+	group, err := h.Service.PatchGroup(c.Request.Context(), h.orgID(c), c.Param("id"), displayName, ops)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	h.writeGroup(c, http.StatusOK, h.orgID(c), group)
+}
+
+func (h *Handler) deleteGroup(c *gin.Context) {
+	if err := h.Service.DeleteGroup(c.Request.Context(), h.orgID(c), c.Param("id")); err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) writeGroup(c *gin.Context, status int, orgID string, group *schemas.ScimGroup) {
+	members, _ := h.Service.GroupMembers(c.Request.Context(), orgID, group.ID)
+	c.Header("Content-Type", contentType)
+	c.JSON(status, toGroupResource(orgID, group, members))
+}
+
+// parseDisplayNameEq extracts X from `displayName eq "X"` (case-insensitive op).
+func parseDisplayNameEq(filter string) (string, bool) {
+	f := strings.TrimSpace(filter)
+	lower := strings.ToLower(f)
+	const prefix = "displayname eq "
+	if !strings.HasPrefix(lower, prefix) {
+		return "", false
+	}
+	val := strings.Trim(strings.TrimSpace(f[len(prefix):]), `"`)
+	if val == "" {
+		return "", false
+	}
+	return val, true
+}
+
+// parseGroupPatch parses a SCIM Group PatchOp (RFC 7644 §3.5.2) into an optional
+// displayName change plus member add/remove/replace ops. It is written for the
+// real world, not just the RFC — it accepts every shape Okta and Entra send:
+//
+//   - op case is normalised (Entra sends "Add"/"Replace"/"Remove").
+//   - members add/replace:  {"op":"add","path":"members","value":[{"value":"x"}]}
+//   - members remove (Entra, NON-RFC): {"op":"remove","path":"members","value":[{"value":"x"}]}
+//     — the member is in `value`, not the path.
+//   - members remove (RFC/Okta): {"op":"remove","path":"members[value eq \"x\"]"} —
+//     the member is encoded in the filtered path.
+//   - no-path form: {"op":"add","value":{"members":[{"value":"x"}]}} / displayName.
+//   - member values may be [{"value":"x"}] objects or bare ["x"] strings.
+func parseGroupPatch(c *gin.Context) (displayName *string, ops []MemberOpJSON, ok bool) {
+	body := struct {
+		Operations []struct {
+			Op    string          `json:"op"`
+			Path  string          `json:"path"`
+			Value json.RawMessage `json:"value"`
+		} `json:"Operations"`
+	}{}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		return nil, nil, false
+	}
+	for _, raw := range body.Operations {
+		op := strings.ToLower(strings.TrimSpace(raw.Op))
+		if op != "add" && op != "remove" && op != "replace" {
+			continue
+		}
+		path := strings.TrimSpace(raw.Path)
+		lpath := strings.ToLower(path)
+		switch {
+		case strings.HasPrefix(lpath, "members["):
+			// RFC/Okta filtered path: the member id is inside [value eq "x"].
+			if val := extractFilterValue(path); val != "" {
+				ops = append(ops, MemberOpJSON{Op: op, Members: []string{val}})
+			}
+		case lpath == "members":
+			// Entra remove (member in value) and add/replace all land here.
+			if members := parseMemberValues(raw.Value); len(members) > 0 {
+				ops = append(ops, MemberOpJSON{Op: op, Members: members})
+			}
+		case lpath == "displayname":
+			if dn, dok := parseStringValue(raw.Value); dok {
+				displayName = &dn
+			}
+		case lpath == "":
+			// No path: value is an attribute map, e.g.
+			// {"members":[...], "displayName":"..."}.
+			m := map[string]json.RawMessage{}
+			if err := json.Unmarshal(raw.Value, &m); err != nil {
+				continue
+			}
+			for k, v := range m {
+				switch strings.ToLower(strings.TrimSpace(k)) {
+				case "members":
+					if members := parseMemberValues(v); len(members) > 0 {
+						ops = append(ops, MemberOpJSON{Op: op, Members: members})
+					}
+				case "displayname":
+					if dn, dok := parseStringValue(v); dok {
+						displayName = &dn
+					}
+				}
+			}
+		}
+	}
+	return displayName, ops, true
+}
+
+// MemberOpJSON is the transport twin of svcscim.MemberOp. Kept in the handler so
+// the parser stays transport-side; converted to the service type by the handler.
+type MemberOpJSON = svcscim.MemberOp
+
+// parseMemberValues extracts member ids from a SCIM `members` value, tolerating
+// both [{"value":"x"}] complex entries and bare ["x"] strings, plus a single
+// {"value":"x"} object.
+func parseMemberValues(raw json.RawMessage) []string {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return nil
+	}
+	var objs []struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &objs); err == nil {
+		out := make([]string, 0, len(objs))
+		for _, o := range objs {
+			if v := strings.TrimSpace(o.Value); v != "" {
+				out = append(out, v)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	var strs []string
+	if err := json.Unmarshal(raw, &strs); err == nil {
+		out := make([]string, 0, len(strs))
+		for _, s := range strs {
+			if v := strings.TrimSpace(s); v != "" {
+				out = append(out, v)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	var one struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &one); err == nil {
+		if v := strings.TrimSpace(one.Value); v != "" {
+			return []string{v}
+		}
+	}
+	return nil
+}
+
+// parseStringValue reads a SCIM value that should be a plain string (displayName).
+func parseStringValue(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// extractFilterValue pulls X out of a `members[value eq "X"]` filtered path.
+func extractFilterValue(path string) string {
+	open := strings.Index(path, "[")
+	closeIdx := strings.LastIndex(path, "]")
+	if open < 0 || closeIdx < 0 || closeIdx <= open {
+		return ""
+	}
+	inner := path[open+1 : closeIdx]
+	q1 := strings.Index(inner, `"`)
+	q2 := strings.LastIndex(inner, `"`)
+	if q1 < 0 || q2 <= q1 {
+		return ""
+	}
+	return inner[q1+1 : q2]
+}

--- a/internal/http_handlers/scim/groups.go
+++ b/internal/http_handlers/scim/groups.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -51,6 +52,15 @@ func toGroupResource(orgID string, g *schemas.ScimGroup, memberIDs []string) sci
 		Members:     []scimGroupMember{},
 		Meta:        scimMeta{ResourceType: "Group"},
 	}
+	// created/lastModified are RFC 7643 §3.1 returned:"default" attributes and are
+	// carried on the stored row — surface them (location is set by the caller,
+	// which holds the request context).
+	if g.CreatedAt > 0 {
+		res.Meta.Created = time.Unix(g.CreatedAt, 0).UTC().Format(time.RFC3339)
+	}
+	if g.UpdatedAt > 0 {
+		res.Meta.LastModified = time.Unix(g.UpdatedAt, 0).UTC().Format(time.RFC3339)
+	}
 	if g.ExternalID != nil {
 		res.ExternalID = strings.TrimPrefix(refs.StringValue(g.ExternalID), orgID+":")
 	}
@@ -58,6 +68,21 @@ func toGroupResource(orgID string, g *schemas.ScimGroup, memberIDs []string) sci
 		res.Members = append(res.Members, scimGroupMember{Value: uid, Ref: "../Users/" + uid, Type: "User"})
 	}
 	return res
+}
+
+// groupLocation builds the absolute SCIM location URI for a group, best-effort
+// from the request (scheme+host, /scim/v2 mount). Returns "" when the host is
+// unknown, in which case meta.location is omitted.
+func groupLocation(c *gin.Context, id string) string {
+	host := c.Request.Host
+	if host == "" {
+		return ""
+	}
+	scheme := "http"
+	if c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	return scheme + "://" + host + "/scim/v2/Groups/" + id
 }
 
 // parseGroup decodes a SCIM Group create/replace body into the service input.
@@ -105,7 +130,9 @@ func (h *Handler) getGroup(c *gin.Context) {
 }
 
 // listGroups supports only the `displayName eq "..."` filter (the IdP dedup
-// probe), mirroring listUsers. An unfiltered list returns an empty set.
+// probe), mirroring listUsers. An unfiltered list returns an empty set; a filter
+// the parser does not recognize is a 400 invalidFilter (never an empty 200,
+// which a connector reads as "no such group" and then duplicates).
 func (h *Handler) listGroups(c *gin.Context) {
 	orgID := h.orgID(c)
 	resp := scimGroupListResponse{
@@ -113,10 +140,17 @@ func (h *Handler) listGroups(c *gin.Context) {
 		StartIndex: 1,
 		Resources:  []scimGroupResource{},
 	}
-	if displayName, ok := parseDisplayNameEq(c.Query("filter")); ok {
+	if filter := strings.TrimSpace(c.Query("filter")); filter != "" {
+		displayName, ok := parseDisplayNameEq(filter)
+		if !ok {
+			writeError(c, http.StatusBadRequest, "invalidFilter", "unsupported filter; only displayName eq is supported")
+			return
+		}
 		if group, err := h.Service.FindGroupByDisplayName(c.Request.Context(), orgID, displayName); err == nil && group != nil {
 			members, _ := h.Service.GroupMembers(c.Request.Context(), orgID, group.ID)
-			resp.Resources = append(resp.Resources, toGroupResource(orgID, group, members))
+			res := toGroupResource(orgID, group, members)
+			res.Meta.Location = groupLocation(c, group.ID)
+			resp.Resources = append(resp.Resources, res)
 		}
 	}
 	resp.TotalResults = len(resp.Resources)
@@ -140,12 +174,18 @@ func (h *Handler) replaceGroup(c *gin.Context) {
 }
 
 func (h *Handler) patchGroup(c *gin.Context) {
-	displayName, ops, ok := parseGroupPatch(c.Request.Body)
+	patch, ok := parseGroupPatch(c.Request.Body)
 	if !ok {
-		writeError(c, http.StatusBadRequest, "invalidValue", "invalid PatchOp body")
+		writeError(c, http.StatusBadRequest, "invalidSyntax", "invalid PatchOp body")
 		return
 	}
-	group, err := h.Service.PatchGroup(c.Request.Context(), h.orgID(c), c.Param("id"), displayName, ops)
+	if patch.InvalidPath {
+		// RFC 7644 §3.5.2: an op targeting an unsupported path is a 400/invalidPath,
+		// not a silent no-op 200.
+		writeError(c, http.StatusBadRequest, "invalidPath", "unsupported PATCH path")
+		return
+	}
+	group, err := h.Service.PatchGroup(c.Request.Context(), h.orgID(c), c.Param("id"), patch.DisplayName, patch.ExternalID, patch.Ops)
 	if err != nil {
 		mapServiceError(c, err)
 		return
@@ -163,8 +203,10 @@ func (h *Handler) deleteGroup(c *gin.Context) {
 
 func (h *Handler) writeGroup(c *gin.Context, status int, orgID string, group *schemas.ScimGroup) {
 	members, _ := h.Service.GroupMembers(c.Request.Context(), orgID, group.ID)
+	res := toGroupResource(orgID, group, members)
+	res.Meta.Location = groupLocation(c, group.ID)
 	c.Header("Content-Type", contentType)
-	c.JSON(status, toGroupResource(orgID, group, members))
+	c.JSON(status, res)
 }
 
 // parseDisplayNameEq extracts X from `displayName eq "X"` (case-insensitive op).
@@ -175,11 +217,33 @@ func parseDisplayNameEq(filter string) (string, bool) {
 	if !strings.HasPrefix(lower, prefix) {
 		return "", false
 	}
-	val := strings.Trim(strings.TrimSpace(f[len(prefix):]), `"`)
+	val := unquoteFilterValue(f[len(prefix):])
 	if val == "" {
 		return "", false
 	}
 	return val, true
+}
+
+// unquoteFilterValue strips exactly ONE enclosing pair of double quotes from a
+// SCIM filter comparison value and unescapes \" and \\ inside it (RFC 7644
+// §3.4.2.2 values are JSON strings). Unlike strings.Trim(v, `"`) it does not
+// strip repeated quotes, and it honours an escaped quote within the value. A
+// value with no enclosing quote pair is returned trimmed, as-is.
+func unquoteFilterValue(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return s
+	}
+	inner := s[1 : len(s)-1]
+	var b strings.Builder
+	b.Grow(len(inner))
+	for i := 0; i < len(inner); i++ {
+		if inner[i] == '\\' && i+1 < len(inner) {
+			i++
+		}
+		b.WriteByte(inner[i])
+	}
+	return b.String()
 }
 
 // parseGroupPatch parses a SCIM Group PatchOp (RFC 7644 §3.5.2) into an optional
@@ -194,7 +258,7 @@ func parseDisplayNameEq(filter string) (string, bool) {
 //     the member is encoded in the filtered path.
 //   - no-path form: {"op":"add","value":{"members":[{"value":"x"}]}} / displayName.
 //   - member values may be [{"value":"x"}] objects or bare ["x"] strings.
-func parseGroupPatch(r io.Reader) (displayName *string, ops []MemberOpJSON, ok bool) {
+func parseGroupPatch(r io.Reader) (groupPatch, bool) {
 	body := struct {
 		Operations []struct {
 			Op    string          `json:"op"`
@@ -203,8 +267,9 @@ func parseGroupPatch(r io.Reader) (displayName *string, ops []MemberOpJSON, ok b
 		} `json:"Operations"`
 	}{}
 	if err := json.NewDecoder(r).Decode(&body); err != nil {
-		return nil, nil, false
+		return groupPatch{}, false
 	}
+	var out groupPatch
 	for _, raw := range body.Operations {
 		op := strings.ToLower(strings.TrimSpace(raw.Op))
 		if op != "add" && op != "remove" && op != "replace" {
@@ -216,20 +281,29 @@ func parseGroupPatch(r io.Reader) (displayName *string, ops []MemberOpJSON, ok b
 		case strings.HasPrefix(lpath, "members["):
 			// RFC/Okta filtered path: the member id is inside [value eq "x"].
 			if val := extractFilterValue(path); val != "" {
-				ops = append(ops, MemberOpJSON{Op: op, Members: []string{val}})
+				out.Ops = append(out.Ops, MemberOpJSON{Op: op, Members: []string{val}})
 			}
 		case lpath == "members":
 			// Entra remove (member in value) and add/replace all land here.
 			if members := parseMemberValues(raw.Value); len(members) > 0 {
-				ops = append(ops, MemberOpJSON{Op: op, Members: members})
+				out.Ops = append(out.Ops, MemberOpJSON{Op: op, Members: members})
+			} else if op == "remove" || op == "replace" {
+				// "members" present with an empty/absent value is a full clear
+				// (RFC 7644 §3.5.2 — the deprovisioning shape). Distinct from
+				// "members" simply not appearing in the patch (nothing emitted).
+				out.Ops = append(out.Ops, MemberOpJSON{Op: op, ClearAll: true})
 			}
 		case lpath == "displayname":
 			if dn, dok := parseStringValue(raw.Value); dok {
-				displayName = &dn
+				out.DisplayName = &dn
+			}
+		case lpath == "externalid":
+			if ext, eok := parseStringValue(raw.Value); eok {
+				out.ExternalID = &ext
 			}
 		case lpath == "":
 			// No path: value is an attribute map, e.g.
-			// {"members":[...], "displayName":"..."}.
+			// {"members":[...], "displayName":"...", "externalId":"..."}.
 			m := map[string]json.RawMessage{}
 			if err := json.Unmarshal(raw.Value, &m); err != nil {
 				continue
@@ -238,17 +312,37 @@ func parseGroupPatch(r io.Reader) (displayName *string, ops []MemberOpJSON, ok b
 				switch strings.ToLower(strings.TrimSpace(k)) {
 				case "members":
 					if members := parseMemberValues(v); len(members) > 0 {
-						ops = append(ops, MemberOpJSON{Op: op, Members: members})
+						out.Ops = append(out.Ops, MemberOpJSON{Op: op, Members: members})
+					} else if op == "remove" || op == "replace" {
+						out.Ops = append(out.Ops, MemberOpJSON{Op: op, ClearAll: true})
 					}
 				case "displayname":
 					if dn, dok := parseStringValue(v); dok {
-						displayName = &dn
+						out.DisplayName = &dn
+					}
+				case "externalid":
+					if ext, eok := parseStringValue(v); eok {
+						out.ExternalID = &ext
 					}
 				}
 			}
+		default:
+			// A recognized op targeting a path this server does not support
+			// (e.g. "emails", "name.givenName") → RFC 7644 §3.5.2 invalidPath.
+			out.InvalidPath = true
 		}
 	}
-	return displayName, ops, true
+	return out, true
+}
+
+// groupPatch is the parsed result of a SCIM Group PatchOp body: optional
+// displayName / externalId changes plus the member ops. InvalidPath flags an op
+// that targeted an unsupported path so the handler can return 400/invalidPath.
+type groupPatch struct {
+	DisplayName *string
+	ExternalID  *string
+	Ops         []MemberOpJSON
+	InvalidPath bool
 }
 
 // MemberOpJSON is the transport twin of svcscim.MemberOp. Kept in the handler so

--- a/internal/http_handlers/scim/groups_patch_test.go
+++ b/internal/http_handlers/scim/groups_patch_test.go
@@ -14,11 +14,13 @@ import (
 // and Entra only ever write membership via PATCH on the group's `members`.
 func TestParseGroupPatch(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
-		wantDisplay  *string
-		wantOps      []MemberOpJSON
-		wantParsedOK bool
+		name            string
+		body            string
+		wantDisplay     *string
+		wantExternalID  *string
+		wantOps         []MemberOpJSON
+		wantInvalidPath bool
+		wantParsedOK    bool
 	}{
 		{
 			name:         "RFC/Okta add — path members, value [{value}]",
@@ -87,6 +89,34 @@ func TestParseGroupPatch(t *testing.T) {
 			wantParsedOK: true,
 		},
 		{
+			// The exact deprovisioning op an IdP sends to empty a group: replace
+			// members with an empty array. Must become an explicit clear, not a
+			// silent no-op (the HIGH bug).
+			name:         "clear members — replace with empty array",
+			body:         `{"Operations":[{"op":"replace","path":"members","value":[]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "replace", ClearAll: true}},
+			wantParsedOK: true,
+		},
+		{
+			// The other RFC-valid full clear: remove members with no filter/value.
+			name:         "clear members — remove with no filter",
+			body:         `{"Operations":[{"op":"remove","path":"members"}]}`,
+			wantOps:      []MemberOpJSON{{Op: "remove", ClearAll: true}},
+			wantParsedOK: true,
+		},
+		{
+			name:           "externalId replace with path",
+			body:           `{"Operations":[{"op":"replace","path":"externalId","value":"ext-9"}]}`,
+			wantExternalID: strptr("ext-9"),
+			wantParsedOK:   true,
+		},
+		{
+			name:            "unsupported path -> invalidPath",
+			body:            `{"Operations":[{"op":"replace","path":"emails","value":"x@y.com"}]}`,
+			wantInvalidPath: true,
+			wantParsedOK:    true,
+		},
+		{
 			name:         "malformed JSON fails to parse",
 			body:         `{not json`,
 			wantParsedOK: false,
@@ -95,18 +125,25 @@ func TestParseGroupPatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			display, ops, ok := parseGroupPatch(strings.NewReader(tt.body))
+			patch, ok := parseGroupPatch(strings.NewReader(tt.body))
 			require.Equal(t, tt.wantParsedOK, ok)
 			if !tt.wantParsedOK {
 				return
 			}
 			if tt.wantDisplay == nil {
-				assert.Nil(t, display)
+				assert.Nil(t, patch.DisplayName)
 			} else {
-				require.NotNil(t, display)
-				assert.Equal(t, *tt.wantDisplay, *display)
+				require.NotNil(t, patch.DisplayName)
+				assert.Equal(t, *tt.wantDisplay, *patch.DisplayName)
 			}
-			assert.Equal(t, tt.wantOps, ops)
+			if tt.wantExternalID == nil {
+				assert.Nil(t, patch.ExternalID)
+			} else {
+				require.NotNil(t, patch.ExternalID)
+				assert.Equal(t, *tt.wantExternalID, *patch.ExternalID)
+			}
+			assert.Equal(t, tt.wantInvalidPath, patch.InvalidPath)
+			assert.Equal(t, tt.wantOps, patch.Ops)
 		})
 	}
 }

--- a/internal/http_handlers/scim/groups_patch_test.go
+++ b/internal/http_handlers/scim/groups_patch_test.go
@@ -1,0 +1,119 @@
+package scim
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseGroupPatch exercises the SCIM Group PATCH member parser against the
+// RFC 7644 §3.5.2 shapes AND the two confirmed real-world Entra deviations, plus
+// Okta's filtered-path remove. These are the load-bearing interop fixtures: Okta
+// and Entra only ever write membership via PATCH on the group's `members`.
+func TestParseGroupPatch(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantDisplay  *string
+		wantOps      []MemberOpJSON
+		wantParsedOK bool
+	}{
+		{
+			name:         "RFC/Okta add — path members, value [{value}]",
+			body:         `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"add","path":"members","value":[{"value":"u1"},{"value":"u2"}]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "add", Members: []string{"u1", "u2"}}},
+			wantParsedOK: true,
+		},
+		{
+			name: "Entra add — capitalized Op",
+			// Entra sends "Add"/"Replace"/"Remove". RFC says op is case-insensitive;
+			// we MUST lower-case before matching or Entra silently fails.
+			body:         `{"Operations":[{"op":"Add","path":"members","value":[{"value":"u1"}]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "add", Members: []string{"u1"}}},
+			wantParsedOK: true,
+		},
+		{
+			name: "Entra remove — NON-RFC: member in value, path is bare members",
+			// Entra does NOT send a filtered path for remove; the member to drop is
+			// in the value array. Parser must accept this.
+			body:         `{"Operations":[{"op":"Remove","path":"members","value":[{"value":"u1"}]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "remove", Members: []string{"u1"}}},
+			wantParsedOK: true,
+		},
+		{
+			name: "Okta/RFC remove — filtered path members[value eq \"x\"]",
+			body: `{"Operations":[{"op":"remove","path":"members[value eq \"u1\"]"}]}`,
+
+			wantOps:      []MemberOpJSON{{Op: "remove", Members: []string{"u1"}}},
+			wantParsedOK: true,
+		},
+		{
+			name:         "replace whole members set",
+			body:         `{"Operations":[{"op":"replace","path":"members","value":[{"value":"u1"},{"value":"u2"}]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "replace", Members: []string{"u1", "u2"}}},
+			wantParsedOK: true,
+		},
+		{
+			name:         "bare string member values [\"u1\"]",
+			body:         `{"Operations":[{"op":"add","path":"members","value":["u1","u2"]}]}`,
+			wantOps:      []MemberOpJSON{{Op: "add", Members: []string{"u1", "u2"}}},
+			wantParsedOK: true,
+		},
+		{
+			name:         "displayName replace with path",
+			body:         `{"Operations":[{"op":"replace","path":"displayName","value":"Engineers"}]}`,
+			wantDisplay:  strptr("Engineers"),
+			wantParsedOK: true,
+		},
+		{
+			name:         "Entra no-path form — value is attribute map",
+			body:         `{"Operations":[{"op":"Replace","value":{"displayName":"Engineers","members":[{"value":"u1"}]}}]}`,
+			wantDisplay:  strptr("Engineers"),
+			wantOps:      []MemberOpJSON{{Op: "replace", Members: []string{"u1"}}},
+			wantParsedOK: true,
+		},
+		{
+			name:         "multiple ops in one PatchOp (add then remove)",
+			body:         `{"Operations":[{"op":"add","path":"members","value":[{"value":"u1"}]},{"op":"remove","path":"members[value eq \"u2\"]"}]}`,
+			wantOps:      []MemberOpJSON{{Op: "add", Members: []string{"u1"}}, {Op: "remove", Members: []string{"u2"}}},
+			wantParsedOK: true,
+		},
+		{
+			name:         "unknown op is ignored, not fatal",
+			body:         `{"Operations":[{"op":"noop","path":"members","value":[{"value":"u1"}]}]}`,
+			wantOps:      nil,
+			wantParsedOK: true,
+		},
+		{
+			name:         "malformed JSON fails to parse",
+			body:         `{not json`,
+			wantParsedOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			display, ops, ok := parseGroupPatch(strings.NewReader(tt.body))
+			require.Equal(t, tt.wantParsedOK, ok)
+			if !tt.wantParsedOK {
+				return
+			}
+			if tt.wantDisplay == nil {
+				assert.Nil(t, display)
+			} else {
+				require.NotNil(t, display)
+				assert.Equal(t, *tt.wantDisplay, *display)
+			}
+			assert.Equal(t, tt.wantOps, ops)
+		})
+	}
+}
+
+func TestExtractFilterValue(t *testing.T) {
+	assert.Equal(t, "u1", extractFilterValue(`members[value eq "u1"]`))
+	assert.Equal(t, "user@x.com", extractFilterValue(`members[value eq "user@x.com"]`))
+	assert.Equal(t, "", extractFilterValue(`members`))
+	assert.Equal(t, "", extractFilterValue(`members[value eq u1]`))
+}

--- a/internal/http_handlers/scim/scim.go
+++ b/internal/http_handlers/scim/scim.go
@@ -21,6 +21,7 @@ const (
 	contentType = "application/scim+json"
 
 	schemaUser     = "urn:ietf:params:scim:schemas:core:2.0:User"
+	schemaGroup    = "urn:ietf:params:scim:schemas:core:2.0:Group"
 	schemaError    = "urn:ietf:params:scim:api:messages:2.0:Error"
 	schemaListResp = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
 	schemaSPConfig = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
@@ -59,6 +60,13 @@ func (h *Handler) Register(rg *gin.RouterGroup) {
 	rg.PUT("/Users/:id", h.replaceUser)
 	rg.PATCH("/Users/:id", h.patchUser)
 	rg.DELETE("/Users/:id", h.deleteUser)
+
+	rg.POST("/Groups", h.createGroup)
+	rg.GET("/Groups", h.listGroups)
+	rg.GET("/Groups/:id", h.getGroup)
+	rg.PUT("/Groups/:id", h.replaceGroup)
+	rg.PATCH("/Groups/:id", h.patchGroup)
+	rg.DELETE("/Groups/:id", h.deleteGroup)
 
 	rg.GET("/ServiceProviderConfig", h.serviceProviderConfig)
 	rg.GET("/ResourceTypes", h.resourceTypes)
@@ -123,6 +131,8 @@ func mapServiceError(c *gin.Context, err error) {
 		writeError(c, http.StatusBadRequest, "invalidValue", "invalid request")
 	case errors.Is(err, svcscim.ErrUnauthorized):
 		writeError(c, http.StatusUnauthorized, "", "authentication failed")
+	case errors.Is(err, svcscim.ErrGroupsUnavailable):
+		writeError(c, http.StatusNotImplemented, "", "group provisioning is not enabled on this server")
 	default:
 		writeError(c, http.StatusInternalServerError, "", "internal error")
 	}

--- a/internal/http_handlers/scim/scim.go
+++ b/internal/http_handlers/scim/scim.go
@@ -127,6 +127,8 @@ func mapServiceError(c *gin.Context, err error) {
 		writeError(c, http.StatusNotFound, "", "resource not found")
 	case errors.Is(err, svcscim.ErrConflict):
 		writeError(c, http.StatusConflict, "uniqueness", "userName already exists")
+	case errors.Is(err, svcscim.ErrGroupConflict):
+		writeError(c, http.StatusConflict, "uniqueness", "a group with this displayName already exists")
 	case errors.Is(err, svcscim.ErrInvalid):
 		writeError(c, http.StatusBadRequest, "invalidValue", "invalid request")
 	case errors.Is(err, svcscim.ErrUnauthorized):

--- a/internal/http_handlers/scim/scim_test.go
+++ b/internal/http_handlers/scim/scim_test.go
@@ -27,6 +27,11 @@ type fakeService struct {
 	setErr   error
 	lastOrg  string
 	lastUser string
+
+	createdGroup *schemas.ScimGroup
+	groupErr     error
+	groupMembers []string
+	lastGroup    string
 }
 
 func (f *fakeService) Authenticate(_ context.Context, bearer string) (string, error) {
@@ -60,6 +65,37 @@ func (f *fakeService) SetActive(_ context.Context, orgID, userID string, _ bool)
 		return nil, f.setErr
 	}
 	return f.created, nil
+}
+
+// Group stubs — the handler-level Group tests drive the parser directly
+// (parseGroupPatch); these satisfy the Provider interface for the User tests.
+func (f *fakeService) CreateGroup(_ context.Context, orgID string, _ svcscim.Group) (*schemas.ScimGroup, bool, error) {
+	f.lastOrg = orgID
+	return f.createdGroup, f.existed, f.groupErr
+}
+func (f *fakeService) GetGroup(_ context.Context, orgID, groupID string) (*schemas.ScimGroup, error) {
+	f.lastOrg, f.lastGroup = orgID, groupID
+	return f.createdGroup, f.groupErr
+}
+func (f *fakeService) FindGroupByDisplayName(_ context.Context, orgID, _ string) (*schemas.ScimGroup, error) {
+	f.lastOrg = orgID
+	return f.createdGroup, f.groupErr
+}
+func (f *fakeService) ReplaceGroup(_ context.Context, orgID, groupID string, _ svcscim.Group) (*schemas.ScimGroup, error) {
+	f.lastOrg, f.lastGroup = orgID, groupID
+	return f.createdGroup, f.groupErr
+}
+func (f *fakeService) PatchGroup(_ context.Context, orgID, groupID string, _ *string, _ []svcscim.MemberOp) (*schemas.ScimGroup, error) {
+	f.lastOrg, f.lastGroup = orgID, groupID
+	return f.createdGroup, f.groupErr
+}
+func (f *fakeService) DeleteGroup(_ context.Context, orgID, groupID string) error {
+	f.lastOrg, f.lastGroup = orgID, groupID
+	return f.groupErr
+}
+func (f *fakeService) GroupMembers(_ context.Context, orgID, groupID string) ([]string, error) {
+	f.lastOrg, f.lastGroup = orgID, groupID
+	return f.groupMembers, nil
 }
 
 func newTestServer(svc svcscim.Provider) *gin.Engine {

--- a/internal/http_handlers/scim/scim_test.go
+++ b/internal/http_handlers/scim/scim_test.go
@@ -85,7 +85,7 @@ func (f *fakeService) ReplaceGroup(_ context.Context, orgID, groupID string, _ s
 	f.lastOrg, f.lastGroup = orgID, groupID
 	return f.createdGroup, f.groupErr
 }
-func (f *fakeService) PatchGroup(_ context.Context, orgID, groupID string, _ *string, _ []svcscim.MemberOp) (*schemas.ScimGroup, error) {
+func (f *fakeService) PatchGroup(_ context.Context, orgID, groupID string, _, _ *string, _ []svcscim.MemberOp) (*schemas.ScimGroup, error) {
 	f.lastOrg, f.lastGroup = orgID, groupID
 	return f.createdGroup, f.groupErr
 }

--- a/internal/http_handlers/scim/users.go
+++ b/internal/http_handlers/scim/users.go
@@ -24,10 +24,14 @@ type scimEmail struct {
 	Primary bool   `json:"primary,omitempty"`
 }
 
-// scimMeta is the resource metadata block.
+// scimMeta is the resource metadata block (RFC 7643 §3.1). created/lastModified
+// are returned:"default"; they are omitempty so User responses (which do not set
+// them) are unchanged, while Group responses populate them from stored timestamps.
 type scimMeta struct {
 	ResourceType string `json:"resourceType"`
 	Location     string `json:"location,omitempty"`
+	Created      string `json:"created,omitempty"`
+	LastModified string `json:"lastModified,omitempty"`
 }
 
 // scimUserResource is the wire representation of a SCIM User (request + response).

--- a/internal/integration_tests/organization_test.go
+++ b/internal/integration_tests/organization_test.go
@@ -56,6 +56,17 @@ func TestOrganizationAdmin(t *testing.T) {
 		require.Nil(t, res)
 	})
 
+	t.Run("should reject a name with URL/FGA-unsafe characters", func(t *testing.T) {
+		// The org name is a URL-safe slug and, defense-in-depth, an FGA object-id
+		// component — '/' (the FGA namespace separator), ':'/'#' (FGA-reserved),
+		// and whitespace must be rejected by construction.
+		for _, bad := range []string{"acme/evil", "a:b", "a#b", "has space"} {
+			res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{Name: bad})
+			require.Error(t, err, "name %q must be rejected", bad)
+			require.Nil(t, res)
+		}
+	})
+
 	t.Run("should create, get and list an organization", func(t *testing.T) {
 		name := "acme-" + uuid.NewString()
 		res, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{

--- a/internal/integration_tests/scim_groups_test.go
+++ b/internal/integration_tests/scim_groups_test.go
@@ -1,0 +1,235 @@
+package integration_tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	scimhttp "github.com/authorizerdev/authorizer/internal/http_handlers/scim"
+	"github.com/authorizerdev/authorizer/internal/service/scim"
+)
+
+// scimGroupsModel is the minimal ReBAC model SCIM group membership needs: a
+// group's members (and a role's assignees) may be users or nested-group usersets.
+const scimGroupsModel = `model
+  schema 1.1
+type user
+type group
+  relations
+    define member: [user, group#member]
+type role
+  relations
+    define assignee: [user, group#member]
+`
+
+// bootSCIMServerFGA mounts the real inbound SCIM 2.0 handler wired to the given
+// FGA engine (Group membership lives in FGA tuples, so the group ops need it).
+// Mirrors bootSCIMServer but injects AuthzEngine.
+func bootSCIMServerFGA(t *testing.T, ts *testSetup, eng engine.AuthorizationEngine) string {
+	t.Helper()
+	scimService := scim.New(&scim.Dependencies{
+		Log:                 ts.Logger,
+		StorageProvider:     ts.StorageProvider,
+		MemoryStoreProvider: ts.MemoryStoreProvider,
+		AuthzEngine:         eng,
+	})
+	scimHandler := scimhttp.New(&scimhttp.Dependencies{Log: ts.Logger, Service: scimService})
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	scimHandler.Register(r.Group("/scim/v2"))
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestSCIMGroupsHTTPLifecycle drives the whole Group HTTP surface end-to-end
+// through the real handlers (create → get → list-with-filter → patch incl. the
+// clear-members deprovisioning shapes → put → delete), plus externalId
+// correlation and the 409-on-duplicate behaviour. These are exactly the paths
+// the pre-fix code shipped broken: nothing previously exercised createGroup /
+// getGroup / listGroups / writeGroup / toGroupResource as real HTTP handlers.
+func TestSCIMGroupsHTTPLifecycle(t *testing.T) {
+	cfg := getTestConfig()
+	ts, eng := initFGATestSetup(t, cfg)
+	_, err := eng.WriteModel(context.Background(), scimGroupsModel)
+	require.NoError(t, err)
+	_, ctx := createContext(ts)
+	base := bootSCIMServerFGA(t, ts, eng)
+	setAdminCookie(t, ts)
+
+	org, err := ts.GraphQLProvider.CreateOrganization(ctx, &model.CreateOrganizationRequest{
+		Name: "scim-grp-" + uuid.NewString(),
+	})
+	require.NoError(t, err)
+	orgID := org.ID
+
+	tokResp, err := ts.GraphQLProvider.CreateScimEndpoint(ctx, &model.CreateScimEndpointRequest{OrgID: orgID})
+	require.NoError(t, err)
+	token := tokResp.Token
+	require.NotEmpty(t, token)
+
+	// Provision two org members via the SCIM Users surface — group membership is
+	// org-membership-gated, so members must first be users of the org.
+	provisionUser := func(userName string) string {
+		resp, decoded := scimDo(t, base, http.MethodPost, "/scim/v2/Users", token, map[string]any{
+			"userName": userName, "active": true,
+		})
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		id, _ := decoded["id"].(string)
+		require.NotEmpty(t, id)
+		return id
+	}
+	u1 := provisionUser("g1-" + uuid.NewString() + "@authorizer.test")
+	u2 := provisionUser("g2-" + uuid.NewString() + "@authorizer.test")
+
+	memberValues := func(decoded map[string]any) []string {
+		raw, _ := decoded["members"].([]any)
+		out := make([]string, 0, len(raw))
+		for _, m := range raw {
+			if mm, ok := m.(map[string]any); ok {
+				if v, ok := mm["value"].(string); ok {
+					out = append(out, v)
+				}
+			}
+		}
+		return out
+	}
+
+	// --- Create ---
+	resp, decoded := scimDo(t, base, http.MethodPost, "/scim/v2/Groups", token, map[string]any{
+		"displayName": "Engineers",
+		"externalId":  "grp-eng",
+		"members":     []map[string]any{{"value": u1}},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	groupID, _ := decoded["id"].(string)
+	require.NotEmpty(t, groupID)
+	assert.Equal(t, "Engineers", decoded["displayName"])
+	assert.Equal(t, "grp-eng", decoded["externalId"])
+	assert.ElementsMatch(t, []string{u1}, memberValues(decoded))
+	// meta carries resourceType + created/lastModified (RFC 7643 §3.1).
+	meta, _ := decoded["meta"].(map[string]any)
+	require.NotNil(t, meta)
+	assert.Equal(t, "Group", meta["resourceType"])
+	assert.NotEmpty(t, meta["created"], "meta.created must be present")
+	assert.NotEmpty(t, meta["lastModified"], "meta.lastModified must be present")
+
+	// --- Get by id ---
+	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups/"+groupID, token, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "Engineers", decoded["displayName"])
+	assert.ElementsMatch(t, []string{u1}, memberValues(decoded))
+
+	// --- List with displayName eq filter ---
+	filter := url.QueryEscape(`displayName eq "Engineers"`)
+	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups?filter="+filter, token, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(1), decoded["totalResults"])
+
+	// --- Unsupported filter → 400 invalidFilter (not an empty 200) ---
+	badFilter := url.QueryEscape(`displayName sw "Eng"`)
+	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups?filter="+badFilter, token, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalidFilter", decoded["scimType"])
+
+	// --- Duplicate create (same displayName, no externalId) → 409 uniqueness ---
+	resp, decoded = scimDo(t, base, http.MethodPost, "/scim/v2/Groups", token, map[string]any{
+		"displayName": "Engineers",
+	})
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Equal(t, "uniqueness", decoded["scimType"])
+
+	// --- externalId correlation: same externalId, new displayName → update in
+	// place (200 existed), NOT a duplicate row (MEDIUM 3c). ---
+	resp, decoded = scimDo(t, base, http.MethodPost, "/scim/v2/Groups", token, map[string]any{
+		"displayName": "Engineering",
+		"externalId":  "grp-eng",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, groupID, decoded["id"], "same externalId must resolve the same group")
+	assert.Equal(t, "Engineering", decoded["displayName"])
+	// The old name no longer resolves; the new one does.
+	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups?filter="+url.QueryEscape(`displayName eq "Engineers"`), token, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(0), decoded["totalResults"], "renamed group must not still resolve by old name")
+
+	// --- PATCH add u2 ---
+	resp, decoded = scimDo(t, base, http.MethodPatch, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"Operations": []map[string]any{
+			{"op": "add", "path": "members", "value": []map[string]any{{"value": u2}}},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.ElementsMatch(t, []string{u1, u2}, memberValues(decoded))
+
+	// --- HIGH: clear all members via replace with an empty array ---
+	resp, decoded = scimDo(t, base, http.MethodPatch, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"Operations": []map[string]any{
+			{"op": "replace", "path": "members", "value": []any{}},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, memberValues(decoded), "replace with empty array must clear every member")
+	assertNoGroupTuple(t, eng, u1, orgID, groupID)
+	assertNoGroupTuple(t, eng, u2, orgID, groupID)
+
+	// --- HIGH: re-add both, then clear via an unfiltered remove ---
+	_, _ = scimDo(t, base, http.MethodPatch, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"Operations": []map[string]any{
+			{"op": "add", "path": "members", "value": []map[string]any{{"value": u1}, {"value": u2}}},
+		},
+	})
+	resp, decoded = scimDo(t, base, http.MethodPatch, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"Operations": []map[string]any{
+			{"op": "remove", "path": "members"},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, memberValues(decoded), "unfiltered remove must clear every member")
+	assertNoGroupTuple(t, eng, u1, orgID, groupID)
+	assertNoGroupTuple(t, eng, u2, orgID, groupID)
+
+	// --- PUT replace whole resource: rename back + membership exactly {u1} ---
+	resp, decoded = scimDo(t, base, http.MethodPut, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"displayName": "Platform",
+		"members":     []map[string]any{{"value": u1}},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "Platform", decoded["displayName"])
+	assert.ElementsMatch(t, []string{u1}, memberValues(decoded))
+
+	// --- Unsupported PATCH path → 400 invalidPath ---
+	resp, decoded = scimDo(t, base, http.MethodPatch, "/scim/v2/Groups/"+groupID, token, map[string]any{
+		"Operations": []map[string]any{
+			{"op": "replace", "path": "emails", "value": "x@y.com"},
+		},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalidPath", decoded["scimType"])
+
+	// --- Delete → 204, then Get → 404 ---
+	resp, _ = scimDo(t, base, http.MethodDelete, "/scim/v2/Groups/"+groupID, token, nil)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp, _ = scimDo(t, base, http.MethodGet, "/scim/v2/Groups/"+groupID, token, nil)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// assertNoGroupTuple asserts that userID is NOT a member of group:<orgID>/<groupID>
+// in the FGA graph — the exact fact a SAML assertion (assertedGroupsForOrg) and a
+// group-derived JWT role read. Clearing members must delete these tuples.
+func assertNoGroupTuple(t *testing.T, eng engine.AuthorizationEngine, userID, orgID, groupID string) {
+	t.Helper()
+	objects, err := eng.ListObjects(context.Background(), "user:"+userID, "member", "group")
+	require.NoError(t, err)
+	assert.NotContains(t, objects, "group:"+orgID+"/"+groupID,
+		"cleared member must no longer resolve to the group in FGA")
+}

--- a/internal/integration_tests/scim_groups_test.go
+++ b/internal/integration_tests/scim_groups_test.go
@@ -135,6 +135,18 @@ func TestSCIMGroupsHTTPLifecycle(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, float64(1), decoded["totalResults"])
 
+	// displayName is caseExact:false (RFC 7644 §3.4.2.2): a case-variant filter
+	// value must resolve the group actually named "Engineers".
+	ciFilter := url.QueryEscape(`displayName eq "engineers"`)
+	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups?filter="+ciFilter, token, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(1), decoded["totalResults"], "case-insensitive displayName filter must find the group")
+	ciResources, _ := decoded["Resources"].([]any)
+	require.Len(t, ciResources, 1)
+	ciGroup, _ := ciResources[0].(map[string]any)
+	assert.Equal(t, "Engineers", ciGroup["displayName"], "must return the stored-cased displayName")
+	assert.Equal(t, groupID, ciGroup["id"])
+
 	// --- Unsupported filter → 400 invalidFilter (not an empty 200) ---
 	badFilter := url.QueryEscape(`displayName sw "Eng"`)
 	resp, decoded = scimDo(t, base, http.MethodGet, "/scim/v2/Groups?filter="+badFilter, token, nil)

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/authorizerdev/authorizer/internal/audit"
 	"github.com/authorizerdev/authorizer/internal/constants"
@@ -11,6 +12,23 @@ import (
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 	"github.com/authorizerdev/authorizer/internal/utils"
 )
+
+// validateOrgSlug rejects characters that would break the organization name's
+// role as a URL-safe slug and, defense-in-depth, as an FGA object-id component:
+// '/' is the FGA namespace separator this codebase uses (e.g. group:<org>/<id>),
+// ':' and '#' are FGA-reserved, and whitespace/control characters have no place
+// in a slug. FGA namespacing keys off the org UUID, not the slug, so today this
+// is belt-and-suspenders — but the cross-tenant containment argument depends on
+// namespacing keys staying slash-free, so the invariant is enforced by
+// construction here rather than left to assumption.
+func validateOrgSlug(name string) error {
+	for _, r := range name {
+		if r == '/' || r == ':' || r == '#' || unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("organization name must be a URL-safe slug: the character %q is not allowed", string(r))
+		}
+	}
+	return nil
+}
 
 // CreateOrganization provisions a new organization. The name must be a
 // unique, non-empty slug. Requires super-admin auth.
@@ -25,6 +43,11 @@ func (p *provider) CreateOrganization(ctx context.Context, meta RequestMetadata,
 		log.Debug().Msg("name is required")
 		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
 		return nil, nil, fmt.Errorf("name is required")
+	}
+	if err := validateOrgSlug(name); err != nil {
+		log.Debug().Err(err).Msg("invalid organization name")
+		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
+		return nil, nil, err
 	}
 
 	// Unique-name pre-check. The storage layer also enforces uniqueness (unique
@@ -82,6 +105,11 @@ func (p *provider) UpdateOrganization(ctx context.Context, meta RequestMetadata,
 			log.Debug().Msg("name cannot be empty")
 			p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
 			return nil, nil, fmt.Errorf("name cannot be empty")
+		}
+		if err := validateOrgSlug(name); err != nil {
+			log.Debug().Err(err).Msg("invalid organization name")
+			p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
+			return nil, nil, err
 		}
 		if name != org.Name {
 			if existing, _ := p.StorageProvider.GetOrganizationByName(ctx, name); existing != nil {

--- a/internal/service/scim/groups.go
+++ b/internal/service/scim/groups.go
@@ -1,0 +1,331 @@
+package scim
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// Group is the transport-neutral SCIM group projection the handler maps to/from
+// SCIM JSON. Members are Authorizer user ids (the SCIM member "value").
+type Group struct {
+	ExternalID  string
+	DisplayName string
+	Members     []string
+}
+
+// MemberOp is a single parsed SCIM PatchOp entry over the `members` attribute.
+// Op is lower-cased (RFC 7644 §3.5.2 says op is case-insensitive; real IdPs send
+// mixed case). Members are Authorizer user ids extracted from either the RFC/Okta
+// filtered-path shape or the Entra value-array shape (see the handler's parser).
+type MemberOp struct {
+	Op      string // "add" | "remove" | "replace"
+	Members []string
+}
+
+// groupMemberRelation is the FGA relation binding a user (or nested group) to a
+// group. Model: `type group { define member: [user, group#member] }`.
+const groupMemberRelation = "member"
+
+// groupObject builds the org-namespaced FGA object id for a group. The org
+// prefix is the tenant-isolation boundary: a group object always carries the
+// org it belongs to, so a cross-tenant read can never match this org's prefix.
+func groupObject(orgID, groupID string) string {
+	return "group:" + orgID + "/" + groupID
+}
+
+func userSubject(userID string) string {
+	return "user:" + userID
+}
+
+// requireGroup is the H6 isolation gate for groups: a group is visible/mutable
+// through a SCIM connection only if it belongs to that connection's org. A
+// cross-org id therefore returns ErrNotFound, never another org's group.
+func (p *provider) requireGroup(ctx context.Context, orgID, groupID string) (*schemas.ScimGroup, error) {
+	group, err := p.StorageProvider.GetScimGroupByID(ctx, groupID)
+	if err != nil || group == nil || group.OrgID != orgID {
+		return nil, ErrNotFound
+	}
+	return group, nil
+}
+
+// CreateGroup provisions a group into the org (idempotent by displayName/externalId).
+func (p *provider) CreateGroup(ctx context.Context, orgID string, in Group) (*schemas.ScimGroup, bool, error) {
+	log := p.Log.With().Str("func", "scim.CreateGroup").Str("org_id", orgID).Logger()
+	if p.AuthzEngine == nil {
+		return nil, false, ErrGroupsUnavailable
+	}
+	displayName := strings.TrimSpace(in.DisplayName)
+	if displayName == "" {
+		return nil, false, ErrInvalid
+	}
+
+	// Dedup: same displayName already provisioned into this org → idempotent.
+	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil {
+		log.Debug().Msg("dedup by displayName within org")
+		if err := p.syncMembers(ctx, orgID, existing.ID, in.Members, nil); err != nil {
+			return nil, false, err
+		}
+		return existing, true, nil
+	}
+
+	now := time.Now().Unix()
+	newGroup := &schemas.ScimGroup{
+		OrgID:       orgID,
+		DisplayName: displayName,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if in.ExternalID != "" {
+		nsExt := namespacedExternalID(orgID, in.ExternalID)
+		newGroup.ExternalID = &nsExt
+	}
+	created, err := p.StorageProvider.AddScimGroup(ctx, newGroup)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to add scim group")
+		return nil, false, err
+	}
+	if err := p.syncMembers(ctx, orgID, created.ID, in.Members, nil); err != nil {
+		return nil, false, err
+	}
+	return created, false, nil
+}
+
+func (p *provider) GetGroup(ctx context.Context, orgID, groupID string) (*schemas.ScimGroup, error) {
+	return p.requireGroup(ctx, orgID, groupID)
+}
+
+func (p *provider) FindGroupByDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" {
+		return nil, nil
+	}
+	group, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName)
+	if err != nil || group == nil {
+		return nil, nil
+	}
+	return group, nil
+}
+
+func (p *provider) ReplaceGroup(ctx context.Context, orgID, groupID string, in Group) (*schemas.ScimGroup, error) {
+	if p.AuthzEngine == nil {
+		return nil, ErrGroupsUnavailable
+	}
+	group, err := p.requireGroup(ctx, orgID, groupID)
+	if err != nil {
+		return nil, err
+	}
+	if dn := strings.TrimSpace(in.DisplayName); dn != "" && dn != group.DisplayName {
+		group.DisplayName = dn
+		group.UpdatedAt = time.Now().Unix()
+		if group, err = p.StorageProvider.UpdateScimGroup(ctx, group); err != nil {
+			return nil, err
+		}
+	}
+	// PUT replaces the whole membership set: desired = in.Members exactly.
+	if err := p.replaceMembers(ctx, orgID, groupID, in.Members); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displayName *string, ops []MemberOp) (*schemas.ScimGroup, error) {
+	if p.AuthzEngine == nil {
+		return nil, ErrGroupsUnavailable
+	}
+	group, err := p.requireGroup(ctx, orgID, groupID)
+	if err != nil {
+		return nil, err
+	}
+	if displayName != nil {
+		if dn := strings.TrimSpace(*displayName); dn != "" && dn != group.DisplayName {
+			group.DisplayName = dn
+			group.UpdatedAt = time.Now().Unix()
+			if group, err = p.StorageProvider.UpdateScimGroup(ctx, group); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, op := range ops {
+		switch op.Op {
+		case "add":
+			if err := p.syncMembers(ctx, orgID, groupID, op.Members, nil); err != nil {
+				return nil, err
+			}
+		case "remove":
+			if err := p.syncMembers(ctx, orgID, groupID, nil, op.Members); err != nil {
+				return nil, err
+			}
+		case "replace":
+			// replace on `members` sets membership to exactly this list.
+			if err := p.replaceMembers(ctx, orgID, groupID, op.Members); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return group, nil
+}
+
+func (p *provider) DeleteGroup(ctx context.Context, orgID, groupID string) error {
+	group, err := p.requireGroup(ctx, orgID, groupID)
+	if err != nil {
+		return err
+	}
+	if p.AuthzEngine != nil {
+		// Drop every membership tuple (subjects → group) so no member resolves
+		// through the deleted group.
+		//
+		// ponytail: we do NOT hunt down role→group binding tuples
+		// (role:org/r#assignee@group:org/g#member) here — OpenFGA Read needs an
+		// object filter, so a by-subject sweep isn't a clean call. It is safe to
+		// leave them: group ids are UUIDs and never reused, so once the member
+		// tuples above are gone the dangling binding resolves to nobody. An admin
+		// removes the binding via _fga_delete_tuples if desired.
+		if members, err := p.readMemberSubjects(ctx, orgID, groupID); err == nil && len(members) > 0 {
+			tuples := make([]engine.TupleKey, 0, len(members))
+			for _, subj := range members {
+				tuples = append(tuples, engine.TupleKey{User: subj, Relation: groupMemberRelation, Object: groupObject(orgID, groupID)})
+			}
+			_ = p.AuthzEngine.DeleteTuples(ctx, tuples)
+		}
+	}
+	return p.StorageProvider.DeleteScimGroup(ctx, group)
+}
+
+// GroupMembers returns the direct member user ids of an org's group.
+func (p *provider) GroupMembers(ctx context.Context, orgID, groupID string) ([]string, error) {
+	if _, err := p.requireGroup(ctx, orgID, groupID); err != nil {
+		return nil, err
+	}
+	if p.AuthzEngine == nil {
+		return nil, nil
+	}
+	subjects, err := p.readMemberSubjects(ctx, orgID, groupID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(subjects))
+	for _, s := range subjects {
+		// Only surface direct user members (skip nested group usersets) for the
+		// SCIM `members` response.
+		if uid, ok := strings.CutPrefix(s, "user:"); ok {
+			out = append(out, uid)
+		}
+	}
+	return out, nil
+}
+
+// syncMembers adds `add` and removes `remove` member user ids on a group,
+// idempotently. Every added user MUST be a member of the org (H6 cross-tenant
+// gate): a user id belonging to another org is silently skipped, never written.
+func (p *provider) syncMembers(ctx context.Context, orgID, groupID string, add, remove []string) error {
+	log := p.Log.With().Str("func", "scim.syncMembers").Str("org_id", orgID).Logger()
+	existing, err := p.readMemberSubjects(ctx, orgID, groupID)
+	if err != nil {
+		return err
+	}
+	present := make(map[string]bool, len(existing))
+	for _, s := range existing {
+		present[s] = true
+	}
+	obj := groupObject(orgID, groupID)
+
+	var writes, deletes []engine.TupleKey
+	for _, uid := range dedupTrim(add) {
+		subj := userSubject(uid)
+		if present[subj] {
+			continue
+		}
+		// Cross-tenant gate: only org members may be added to this org's group.
+		if _, err := p.StorageProvider.GetOrgMembership(ctx, orgID, uid); err != nil {
+			log.Debug().Str("user_id", uid).Msg("skipping member add: not a member of this org")
+			continue
+		}
+		writes = append(writes, engine.TupleKey{User: subj, Relation: groupMemberRelation, Object: obj})
+		present[subj] = true
+	}
+	for _, uid := range dedupTrim(remove) {
+		subj := userSubject(uid)
+		if !present[subj] {
+			continue
+		}
+		deletes = append(deletes, engine.TupleKey{User: subj, Relation: groupMemberRelation, Object: obj})
+		present[subj] = false
+	}
+	if len(writes) > 0 {
+		if err := p.AuthzEngine.WriteTuples(ctx, writes); err != nil {
+			return err
+		}
+	}
+	if len(deletes) > 0 {
+		if err := p.AuthzEngine.DeleteTuples(ctx, deletes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// replaceMembers sets a group's membership to exactly `desired` (the PUT / SCIM
+// replace semantics): writes the missing, deletes the surplus.
+func (p *provider) replaceMembers(ctx context.Context, orgID, groupID string, desired []string) error {
+	existing, err := p.readMemberSubjects(ctx, orgID, groupID)
+	if err != nil {
+		return err
+	}
+	want := make(map[string]bool)
+	for _, uid := range dedupTrim(desired) {
+		want[userSubject(uid)] = true
+	}
+	var remove []string
+	for _, s := range existing {
+		if uid, ok := strings.CutPrefix(s, "user:"); ok && !want[s] {
+			remove = append(remove, uid)
+		}
+	}
+	return p.syncMembers(ctx, orgID, groupID, desired, remove)
+}
+
+// readMemberSubjects reads the direct member tuple subjects of a group
+// (user:<id> and any group:<...>#member usersets), paginating through the store.
+func (p *provider) readMemberSubjects(ctx context.Context, orgID, groupID string) ([]string, error) {
+	obj := groupObject(orgID, groupID)
+	var subjects []string
+	token := ""
+	for {
+		page, err := p.AuthzEngine.ReadTuples(ctx, engine.ReadTuplesFilter{
+			Relation:          groupMemberRelation,
+			Object:            obj,
+			PageSize:          100,
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range page.Tuples {
+			subjects = append(subjects, t.User)
+		}
+		if page.ContinuationToken == "" {
+			break
+		}
+		token = page.ContinuationToken
+	}
+	return subjects, nil
+}
+
+// dedupTrim trims, drops empties, and de-duplicates a slice of ids.
+func dedupTrim(ids []string) []string {
+	seen := make(map[string]bool, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}

--- a/internal/service/scim/groups.go
+++ b/internal/service/scim/groups.go
@@ -24,6 +24,13 @@ type Group struct {
 type MemberOp struct {
 	Op      string // "add" | "remove" | "replace"
 	Members []string
+	// ClearAll marks an unfiltered full-membership clear: a `remove` op whose
+	// `members` key is present with an empty/absent value (RFC 7644 §3.5.2 — the
+	// deprovisioning shape an IdP sends to empty a group). Without this flag such
+	// an op carries no member ids and would be a silent no-op. (A `replace` with
+	// an empty set already clears via replaceMembers, so ClearAll is only read on
+	// `remove`.)
+	ClearAll bool
 }
 
 // groupMemberRelation is the FGA relation binding a user (or nested group) to a
@@ -52,7 +59,24 @@ func (p *provider) requireGroup(ctx context.Context, orgID, groupID string) (*sc
 	return group, nil
 }
 
-// CreateGroup provisions a group into the org (idempotent by displayName/externalId).
+// ensureDisplayNameFree returns ErrGroupConflict when another group in the org
+// (id != exceptID) already uses displayName. This is the create/rename
+// uniqueness gate — displayName uniqueness within an org is service-enforced,
+// not a DB constraint, so it MUST be checked on every path that sets a name
+// (create AND rename), or two rows could share a name and the LIMIT 1 dedup
+// lookup would then resolve arbitrarily. Pass exceptID="" on create.
+func (p *provider) ensureDisplayNameFree(ctx context.Context, orgID, displayName, exceptID string) error {
+	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil && existing.ID != exceptID {
+		return ErrGroupConflict
+	}
+	return nil
+}
+
+// CreateGroup provisions a group into the org. externalId is the preferred
+// correlation key: a repeat carrying an externalId that already identifies a
+// group is idempotent (adopts a rename, syncs members, existed=true). A create
+// that instead clashes on displayName with no matching externalId is a
+// uniqueness conflict (ErrGroupConflict → 409), never a silent 200.
 func (p *provider) CreateGroup(ctx context.Context, orgID string, in Group) (*schemas.ScimGroup, bool, error) {
 	log := p.Log.With().Str("func", "scim.CreateGroup").Str("org_id", orgID).Logger()
 	if p.AuthzEngine == nil {
@@ -63,13 +87,37 @@ func (p *provider) CreateGroup(ctx context.Context, orgID string, in Group) (*sc
 		return nil, false, ErrInvalid
 	}
 
-	// Dedup: same displayName already provisioned into this org → idempotent.
-	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil {
-		log.Debug().Msg("dedup by displayName within org")
-		if err := p.syncMembers(ctx, orgID, existing.ID, in.Members, nil); err != nil {
-			return nil, false, err
+	// Dedup #1 (correlation key): the same externalId already identifies a group
+	// in this org → the same logical group. Idempotent: adopt a rename from the
+	// IdP and sync members, rather than creating a duplicate row.
+	if in.ExternalID != "" {
+		if existing, err := p.StorageProvider.GetScimGroupByOrgAndExternalID(ctx, orgID, in.ExternalID); err == nil && existing != nil {
+			log.Debug().Msg("dedup by external_id within org")
+			if displayName != existing.DisplayName {
+				if err := p.ensureDisplayNameFree(ctx, orgID, displayName, existing.ID); err != nil {
+					return nil, false, err
+				}
+				existing.DisplayName = displayName
+				existing.UpdatedAt = time.Now().Unix()
+				updated, uErr := p.StorageProvider.UpdateScimGroup(ctx, existing)
+				if uErr != nil {
+					return nil, false, uErr
+				}
+				existing = updated
+			}
+			if err := p.syncMembers(ctx, orgID, existing.ID, in.Members, nil); err != nil {
+				return nil, false, err
+			}
+			return existing, true, nil
 		}
-		return existing, true, nil
+	}
+
+	// Dedup #2 (uniqueness): a group with this displayName already exists in the
+	// org and no externalId matched it → RFC 7644 §3.3 uniqueness conflict (409),
+	// not a silent idempotent 200.
+	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil {
+		log.Debug().Msg("displayName already exists in org")
+		return nil, false, ErrGroupConflict
 	}
 
 	now := time.Now().Unix()
@@ -118,8 +166,25 @@ func (p *provider) ReplaceGroup(ctx context.Context, orgID, groupID string, in G
 	if err != nil {
 		return nil, err
 	}
+	changed := false
 	if dn := strings.TrimSpace(in.DisplayName); dn != "" && dn != group.DisplayName {
+		if err := p.ensureDisplayNameFree(ctx, orgID, dn, group.ID); err != nil {
+			return nil, err
+		}
 		group.DisplayName = dn
+		changed = true
+	}
+	// externalId is an updatable correlation key. Only set it when the payload
+	// carries one — an absent externalId on PUT does not clear a stored value
+	// (many connectors omit it on updates).
+	if ext := strings.TrimSpace(in.ExternalID); ext != "" {
+		nsExt := namespacedExternalID(orgID, ext)
+		if group.ExternalID == nil || *group.ExternalID != nsExt {
+			group.ExternalID = &nsExt
+			changed = true
+		}
+	}
+	if changed {
 		group.UpdatedAt = time.Now().Unix()
 		if group, err = p.StorageProvider.UpdateScimGroup(ctx, group); err != nil {
 			return nil, err
@@ -132,7 +197,7 @@ func (p *provider) ReplaceGroup(ctx context.Context, orgID, groupID string, in G
 	return group, nil
 }
 
-func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displayName *string, ops []MemberOp) (*schemas.ScimGroup, error) {
+func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displayName, externalID *string, ops []MemberOp) (*schemas.ScimGroup, error) {
 	if p.AuthzEngine == nil {
 		return nil, ErrGroupsUnavailable
 	}
@@ -140,13 +205,29 @@ func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displa
 	if err != nil {
 		return nil, err
 	}
+	changed := false
 	if displayName != nil {
 		if dn := strings.TrimSpace(*displayName); dn != "" && dn != group.DisplayName {
-			group.DisplayName = dn
-			group.UpdatedAt = time.Now().Unix()
-			if group, err = p.StorageProvider.UpdateScimGroup(ctx, group); err != nil {
+			if err := p.ensureDisplayNameFree(ctx, orgID, dn, group.ID); err != nil {
 				return nil, err
 			}
+			group.DisplayName = dn
+			changed = true
+		}
+	}
+	if externalID != nil {
+		if ext := strings.TrimSpace(*externalID); ext != "" {
+			nsExt := namespacedExternalID(orgID, ext)
+			if group.ExternalID == nil || *group.ExternalID != nsExt {
+				group.ExternalID = &nsExt
+				changed = true
+			}
+		}
+	}
+	if changed {
+		group.UpdatedAt = time.Now().Unix()
+		if group, err = p.StorageProvider.UpdateScimGroup(ctx, group); err != nil {
+			return nil, err
 		}
 	}
 	for _, op := range ops {
@@ -156,11 +237,18 @@ func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displa
 				return nil, err
 			}
 		case "remove":
-			if err := p.syncMembers(ctx, orgID, groupID, nil, op.Members); err != nil {
+			if op.ClearAll {
+				// Unfiltered "remove members" empties the whole group — the exact
+				// deprovisioning op an IdP sends. Desired set is empty → remove all.
+				if err := p.replaceMembers(ctx, orgID, groupID, nil); err != nil {
+					return nil, err
+				}
+			} else if err := p.syncMembers(ctx, orgID, groupID, nil, op.Members); err != nil {
 				return nil, err
 			}
 		case "replace":
-			// replace on `members` sets membership to exactly this list.
+			// replace on `members` sets membership to exactly this list (an empty
+			// list clears every member — a legitimate full-clear, not a no-op).
 			if err := p.replaceMembers(ctx, orgID, groupID, op.Members); err != nil {
 				return nil, err
 			}

--- a/internal/service/scim/groups.go
+++ b/internal/service/scim/groups.go
@@ -65,6 +65,18 @@ func (p *provider) requireGroup(ctx context.Context, orgID, groupID string) (*sc
 // not a DB constraint, so it MUST be checked on every path that sets a name
 // (create AND rename), or two rows could share a name and the LIMIT 1 dedup
 // lookup would then resolve arbitrarily. Pass exceptID="" on create.
+//
+// Known limitation, not closed here: this is check-then-insert with no unique
+// constraint backing it, so two concurrent creates/renames of the same
+// displayName in the same org can both pass the check and produce a
+// duplicate — there is no atomic conditional-write across all 13 storage
+// backends to lean on instead. On DynamoDB specifically this is compounded by
+// the org_id GSI's eventual consistency: a probe run immediately after a
+// sibling create may not observe that row yet. Low real-world risk (SCIM
+// provisioning is normally one serialized sync job per IdP, not concurrent
+// writers), acceptable for now; a true fix would need a per-backend
+// conditional-write / optimistic-lock scheme, which is a larger undertaking
+// than this uniqueness gate.
 func (p *provider) ensureDisplayNameFree(ctx context.Context, orgID, displayName, exceptID string) error {
 	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil && existing.ID != exceptID {
 		return ErrGroupConflict
@@ -114,7 +126,8 @@ func (p *provider) CreateGroup(ctx context.Context, orgID string, in Group) (*sc
 
 	// Dedup #2 (uniqueness): a group with this displayName already exists in the
 	// org and no externalId matched it → RFC 7644 §3.3 uniqueness conflict (409),
-	// not a silent idempotent 200.
+	// not a silent idempotent 200. Same check-then-insert race as
+	// ensureDisplayNameFree (see its doc comment) — not closed here.
 	if existing, err := p.StorageProvider.GetScimGroupByOrgAndDisplayName(ctx, orgID, displayName); err == nil && existing != nil {
 		log.Debug().Msg("displayName already exists in org")
 		return nil, false, ErrGroupConflict

--- a/internal/service/scim/groups_test.go
+++ b/internal/service/scim/groups_test.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -42,8 +43,10 @@ func (f *fakeStore) GetScimGroupByID(_ context.Context, id string) (*schemas.Sci
 }
 
 func (f *fakeStore) GetScimGroupByOrgAndDisplayName(_ context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	// Mirror the real storage contract: displayName is caseExact:false
+	// (RFC 7644 §3.4.2.2), so the value is matched case-insensitively.
 	for _, g := range f.groups {
-		if g.OrgID == orgID && g.DisplayName == displayName {
+		if g.OrgID == orgID && strings.EqualFold(g.DisplayName, displayName) {
 			return g, nil
 		}
 	}
@@ -173,6 +176,58 @@ func TestGroupLifecycleAndMembership(t *testing.T) {
 	require.NoError(t, p.DeleteGroup(ctx, org, g.ID))
 	_, err = p.GetGroup(ctx, org, g.ID)
 	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestGroupDisplayNameCaseInsensitive proves that displayName (caseExact:false,
+// RFC 7644 §3.4.2.2) is compared case-insensitively across the three paths that
+// share GetScimGroupByOrgAndDisplayName: create-dedup, the rename-uniqueness
+// gate, and the FindGroupByDisplayName probe.
+func TestGroupDisplayNameCaseInsensitive(t *testing.T) {
+	p, store := newGroupSvc(t)
+	ctx := context.Background()
+	const org = "org-a"
+	store.memberships[org+"|u1"] = true
+	store.memberships[org+"|u2"] = true
+
+	// Create "Engineers" with an externalId + one member.
+	g, existed, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers", ExternalID: "ext-eng", Members: []string{"u1"}})
+	require.NoError(t, err)
+	assert.False(t, existed)
+
+	// A create with a case-variant displayName and NO matching externalId is the
+	// SAME group for uniqueness purposes → a 409 conflict, not a second row. This
+	// is the intended reading of caseExact:false: "Engineers" and "engineers" are
+	// one group.
+	_, _, err = p.CreateGroup(ctx, org, Group{DisplayName: "engineers"})
+	assert.ErrorIs(t, err, ErrGroupConflict, "case-variant create must conflict, not duplicate")
+	assert.Len(t, store.groups, 1, "no duplicate row may be created for a case-variant name")
+
+	// Same externalId + a case-variant displayName → idempotent adoption of the
+	// existing row (existed=true, same id), member sync applied to THAT row, and
+	// no duplicate created. The case-only rename passes the uniqueness gate
+	// because it resolves to the group itself (self-exempt).
+	adopted, existed, err := p.CreateGroup(ctx, org, Group{DisplayName: "engineers", ExternalID: "ext-eng", Members: []string{"u1", "u2"}})
+	require.NoError(t, err)
+	assert.True(t, existed, "case-variant name with the same externalId must adopt, not create")
+	assert.Equal(t, g.ID, adopted.ID)
+	assert.Len(t, store.groups, 1, "case-variant externalId create must not duplicate the group")
+	members, err := p.GroupMembers(ctx, org, g.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"u1", "u2"}, members, "members must sync onto the existing row")
+
+	// FindGroupByDisplayName (the listGroups filter probe) is case-insensitive.
+	found, err := p.FindGroupByDisplayName(ctx, org, "eNgInEeRs")
+	require.NoError(t, err)
+	require.NotNil(t, found, "displayName filter must find the group case-insensitively")
+	assert.Equal(t, g.ID, found.ID)
+
+	// The rename-uniqueness gate rejects a case-insensitive collision: a second
+	// group cannot be renamed onto an existing name that differs only in case.
+	other, _, err := p.CreateGroup(ctx, org, Group{DisplayName: "Platform"})
+	require.NoError(t, err)
+	rename := "ENGINEERS"
+	_, err = p.PatchGroup(ctx, org, other.ID, &rename, nil, nil)
+	assert.ErrorIs(t, err, ErrGroupConflict, "rename onto a case-variant of an existing name must conflict")
 }
 
 // TestGroupOrgIsolation proves H6: a group created in org-a is invisible to org-b.

--- a/internal/service/scim/groups_test.go
+++ b/internal/service/scim/groups_test.go
@@ -1,0 +1,169 @@
+package scim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fgaengine "github.com/authorizerdev/authorizer/internal/authorization/engine/openfga"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const groupSvcModel = `model
+  schema 1.1
+type user
+type group
+  relations
+    define member: [user, group#member]
+type role
+  relations
+    define assignee: [user, group#member]
+`
+
+// --- fakeStore ScimGroup methods (state in the groups map added to the struct). ---
+
+func (f *fakeStore) AddScimGroup(_ context.Context, g *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if g.ID == "" {
+		g.ID = uuid.New().String()
+	}
+	f.groups[g.ID] = g
+	return g, nil
+}
+
+func (f *fakeStore) GetScimGroupByID(_ context.Context, id string) (*schemas.ScimGroup, error) {
+	if g, ok := f.groups[id]; ok {
+		return g, nil
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) GetScimGroupByOrgAndDisplayName(_ context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	for _, g := range f.groups {
+		if g.OrgID == orgID && g.DisplayName == displayName {
+			return g, nil
+		}
+	}
+	return nil, errNotFound
+}
+
+func (f *fakeStore) UpdateScimGroup(_ context.Context, g *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	f.groups[g.ID] = g
+	return g, nil
+}
+
+func (f *fakeStore) DeleteScimGroup(_ context.Context, g *schemas.ScimGroup) error {
+	delete(f.groups, g.ID)
+	return nil
+}
+
+// newGroupSvc builds a SCIM provider backed by a real embedded FGA engine.
+func newGroupSvc(t *testing.T) (*provider, *fakeStore) {
+	t.Helper()
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	store := newFakeStore()
+	eng, err := fgaengine.New(
+		&fgaengine.Config{Store: fgaengine.StoreMemory, StoreName: "scim-groups-" + uuid.New().String()},
+		&fgaengine.Dependencies{Log: &log},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if c, ok := eng.(interface{ Close() }); ok {
+			c.Close()
+		}
+	})
+	_, err = eng.WriteModel(context.Background(), groupSvcModel)
+	require.NoError(t, err)
+	p := &provider{Dependencies: Dependencies{Log: &log, StorageProvider: store, AuthzEngine: eng}}
+	return p, store
+}
+
+func TestGroupLifecycleAndMembership(t *testing.T) {
+	p, store := newGroupSvc(t)
+	ctx := context.Background()
+	const org = "org-a"
+	// Two org-a members + one member of a DIFFERENT org.
+	store.memberships[org+"|u1"] = true
+	store.memberships[org+"|u2"] = true
+	store.memberships["org-b|intruder"] = true
+
+	// Create.
+	g, existed, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers", ExternalID: "ext-1"})
+	require.NoError(t, err)
+	assert.False(t, existed)
+	assert.Equal(t, "Engineers", g.DisplayName)
+
+	// Idempotent create by displayName.
+	g2, existed2, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers"})
+	require.NoError(t, err)
+	assert.True(t, existed2)
+	assert.Equal(t, g.ID, g2.ID)
+
+	// Add u1, u2 (org members) AND intruder (org-b member — must be rejected).
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{
+		{Op: "add", Members: []string{"u1", "u2", "intruder"}},
+	})
+	require.NoError(t, err)
+
+	members, err := p.GroupMembers(ctx, org, g.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"u1", "u2"}, members, "cross-org member must not be added")
+	assert.NotContains(t, members, "intruder")
+
+	// Idempotent add (u1 again) — no duplicate, no error.
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "add", Members: []string{"u1"}}})
+	require.NoError(t, err)
+	members, _ = p.GroupMembers(ctx, org, g.ID)
+	assert.ElementsMatch(t, []string{"u1", "u2"}, members)
+
+	// Remove u1 (Entra value-shape already normalised to MemberOp by the parser).
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "remove", Members: []string{"u1"}}})
+	require.NoError(t, err)
+	members, _ = p.GroupMembers(ctx, org, g.ID)
+	assert.ElementsMatch(t, []string{"u2"}, members)
+
+	// Replace whole set → exactly {u1}.
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "replace", Members: []string{"u1"}}})
+	require.NoError(t, err)
+	members, _ = p.GroupMembers(ctx, org, g.ID)
+	assert.ElementsMatch(t, []string{"u1"}, members)
+
+	// Rename via PATCH displayName.
+	newName := "Platform"
+	_, err = p.PatchGroup(ctx, org, g.ID, &newName, nil)
+	require.NoError(t, err)
+	got, err := p.GetGroup(ctx, org, g.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Platform", got.DisplayName)
+
+	// Delete removes the row and its membership tuples.
+	require.NoError(t, p.DeleteGroup(ctx, org, g.ID))
+	_, err = p.GetGroup(ctx, org, g.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestGroupOrgIsolation proves H6: a group created in org-a is invisible to org-b.
+func TestGroupOrgIsolation(t *testing.T) {
+	p, _ := newGroupSvc(t)
+	ctx := context.Background()
+	g, _, err := p.CreateGroup(ctx, "org-a", Group{DisplayName: "Secret"})
+	require.NoError(t, err)
+
+	_, err = p.GetGroup(ctx, "org-b", g.ID)
+	assert.ErrorIs(t, err, ErrNotFound, "a cross-org group id must 404, not leak")
+
+	_, err = p.PatchGroup(ctx, "org-b", g.ID, nil, []MemberOp{{Op: "add", Members: []string{"x"}}})
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestGroupsUnavailableWithoutEngine proves group ops fail cleanly when FGA is off.
+func TestGroupsUnavailableWithoutEngine(t *testing.T) {
+	log := zerolog.Nop()
+	store := newFakeStore()
+	p := &provider{Dependencies: Dependencies{Log: &log, StorageProvider: store}} // no AuthzEngine
+	_, _, err := p.CreateGroup(context.Background(), "org-a", Group{DisplayName: "X"})
+	assert.ErrorIs(t, err, ErrGroupsUnavailable)
+}

--- a/internal/service/scim/groups_test.go
+++ b/internal/service/scim/groups_test.go
@@ -50,6 +50,16 @@ func (f *fakeStore) GetScimGroupByOrgAndDisplayName(_ context.Context, orgID, di
 	return nil, errNotFound
 }
 
+func (f *fakeStore) GetScimGroupByOrgAndExternalID(_ context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	want := orgID + ":" + externalID
+	for _, g := range f.groups {
+		if g.OrgID == orgID && g.ExternalID != nil && *g.ExternalID == want {
+			return g, nil
+		}
+	}
+	return nil, errNotFound
+}
+
 func (f *fakeStore) UpdateScimGroup(_ context.Context, g *schemas.ScimGroup) (*schemas.ScimGroup, error) {
 	f.groups[g.ID] = g
 	return g, nil
@@ -96,14 +106,19 @@ func TestGroupLifecycleAndMembership(t *testing.T) {
 	assert.False(t, existed)
 	assert.Equal(t, "Engineers", g.DisplayName)
 
-	// Idempotent create by displayName.
-	g2, existed2, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers"})
+	// Idempotent create by externalId (same correlation key → same group).
+	g2, existed2, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers", ExternalID: "ext-1"})
 	require.NoError(t, err)
 	assert.True(t, existed2)
 	assert.Equal(t, g.ID, g2.ID)
 
+	// A create clashing on displayName with no matching externalId is a
+	// uniqueness conflict (RFC 7644 §3.3 → 409), not a silent idempotent 200.
+	_, _, err = p.CreateGroup(ctx, org, Group{DisplayName: "Engineers"})
+	assert.ErrorIs(t, err, ErrGroupConflict)
+
 	// Add u1, u2 (org members) AND intruder (org-b member — must be rejected).
-	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{
 		{Op: "add", Members: []string{"u1", "u2", "intruder"}},
 	})
 	require.NoError(t, err)
@@ -114,26 +129,41 @@ func TestGroupLifecycleAndMembership(t *testing.T) {
 	assert.NotContains(t, members, "intruder")
 
 	// Idempotent add (u1 again) — no duplicate, no error.
-	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "add", Members: []string{"u1"}}})
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "add", Members: []string{"u1"}}})
 	require.NoError(t, err)
 	members, _ = p.GroupMembers(ctx, org, g.ID)
 	assert.ElementsMatch(t, []string{"u1", "u2"}, members)
 
 	// Remove u1 (Entra value-shape already normalised to MemberOp by the parser).
-	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "remove", Members: []string{"u1"}}})
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "remove", Members: []string{"u1"}}})
 	require.NoError(t, err)
 	members, _ = p.GroupMembers(ctx, org, g.ID)
 	assert.ElementsMatch(t, []string{"u2"}, members)
 
 	// Replace whole set → exactly {u1}.
-	_, err = p.PatchGroup(ctx, org, g.ID, nil, []MemberOp{{Op: "replace", Members: []string{"u1"}}})
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "replace", Members: []string{"u1"}}})
 	require.NoError(t, err)
 	members, _ = p.GroupMembers(ctx, org, g.ID)
 	assert.ElementsMatch(t, []string{"u1"}, members)
 
+	// Clear ALL members via an unfiltered remove (deprovisioning) — must empty
+	// the group, not no-op.
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "remove", ClearAll: true}})
+	require.NoError(t, err)
+	members, _ = p.GroupMembers(ctx, org, g.ID)
+	assert.Empty(t, members, "unfiltered remove must clear every member")
+
+	// Re-add u1, u2 then clear via replace with an empty set → also empties.
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "add", Members: []string{"u1", "u2"}}})
+	require.NoError(t, err)
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "replace", Members: nil}})
+	require.NoError(t, err)
+	members, _ = p.GroupMembers(ctx, org, g.ID)
+	assert.Empty(t, members, "replace with an empty set must clear every member")
+
 	// Rename via PATCH displayName.
 	newName := "Platform"
-	_, err = p.PatchGroup(ctx, org, g.ID, &newName, nil)
+	_, err = p.PatchGroup(ctx, org, g.ID, &newName, nil, nil)
 	require.NoError(t, err)
 	got, err := p.GetGroup(ctx, org, g.ID)
 	require.NoError(t, err)
@@ -155,7 +185,7 @@ func TestGroupOrgIsolation(t *testing.T) {
 	_, err = p.GetGroup(ctx, "org-b", g.ID)
 	assert.ErrorIs(t, err, ErrNotFound, "a cross-org group id must 404, not leak")
 
-	_, err = p.PatchGroup(ctx, "org-b", g.ID, nil, []MemberOp{{Op: "add", Members: []string{"x"}}})
+	_, err = p.PatchGroup(ctx, "org-b", g.ID, nil, nil, []MemberOp{{Op: "add", Members: []string{"x"}}})
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 

--- a/internal/service/scim/scim.go
+++ b/internal/service/scim/scim.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/authorizerdev/authorizer/internal/authorization/engine"
 	"github.com/authorizerdev/authorizer/internal/memory_store"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
@@ -41,6 +42,9 @@ var (
 	ErrConflict = errors.New("scim: userName already exists")
 	// ErrInvalid — malformed input (e.g. missing userName). Map to 400.
 	ErrInvalid = errors.New("scim: invalid request")
+	// ErrGroupsUnavailable — a Group op was attempted but the FGA engine is not
+	// configured (group membership is stored as FGA tuples). Map to 501.
+	ErrGroupsUnavailable = errors.New("scim: group provisioning requires the authorization engine")
 )
 
 // tokenCost is the bcrypt cost for SCIM bearer-token secrets. Matches the
@@ -76,6 +80,10 @@ type Dependencies struct {
 	Log                 *zerolog.Logger
 	StorageProvider     storage.Provider
 	MemoryStoreProvider memory_store.Provider
+	// AuthzEngine is the FGA engine. SCIM Group membership is stored as FGA
+	// relationship tuples (not a DB column), so the Group ops require it. Nil
+	// when FGA is not configured — Group ops then return ErrGroupsUnavailable.
+	AuthzEngine engine.AuthorizationEngine
 }
 
 // Provider is the org-bounded SCIM operation surface. Every method takes the
@@ -101,6 +109,31 @@ type Provider interface {
 	// SetActive (PATCH active / DELETE) flips the active flag. Deactivation
 	// synchronously revokes the user's sessions + refresh tokens.
 	SetActive(ctx context.Context, orgID, userID string, active bool) (*schemas.User, error)
+
+	// --- SCIM Group provisioning (RFC 7643 §4.2 / RFC 7644 §3.5.2). Membership
+	// is stored as FGA tuples, never on the Group row. ---
+
+	// CreateGroup provisions a group into the org. Idempotent: a repeat with the
+	// same displayName (or externalId) returns the existing group with
+	// existed=true. Any in.Members are added (org-membership-gated).
+	CreateGroup(ctx context.Context, orgID string, in Group) (group *schemas.ScimGroup, existed bool, err error)
+	// GetGroup fetches an org's group by id (404 if it belongs to another org — H6).
+	GetGroup(ctx context.Context, orgID, groupID string) (*schemas.ScimGroup, error)
+	// FindGroupByDisplayName returns the org's group with the given displayName,
+	// or nil when none (the IdP's `displayName eq` probe). Never leaks another org.
+	FindGroupByDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error)
+	// ReplaceGroup (PUT) overwrites displayName and sets membership to exactly
+	// in.Members (org-membership-gated).
+	ReplaceGroup(ctx context.Context, orgID, groupID string, in Group) (*schemas.ScimGroup, error)
+	// PatchGroup applies a parsed SCIM PatchOp: an optional displayName change
+	// plus member add/remove/replace ops. Idempotent.
+	PatchGroup(ctx context.Context, orgID, groupID string, displayName *string, ops []MemberOp) (*schemas.ScimGroup, error)
+	// DeleteGroup removes the group row and all its membership + role-binding
+	// tuples.
+	DeleteGroup(ctx context.Context, orgID, groupID string) error
+	// GroupMembers returns the Authorizer user ids that are direct members of an
+	// org's group (for the SCIM `members` response).
+	GroupMembers(ctx context.Context, orgID, groupID string) ([]string, error)
 }
 
 type provider struct {

--- a/internal/service/scim/scim.go
+++ b/internal/service/scim/scim.go
@@ -45,6 +45,10 @@ var (
 	// ErrGroupsUnavailable — a Group op was attempted but the FGA engine is not
 	// configured (group membership is stored as FGA tuples). Map to 501.
 	ErrGroupsUnavailable = errors.New("scim: group provisioning requires the authorization engine")
+	// ErrGroupConflict — a Group create/rename collides with an existing
+	// displayName in the org (RFC 7644 §3.3 uniqueness). Map to 409/uniqueness.
+	// Distinct from ErrConflict, whose message names userName.
+	ErrGroupConflict = errors.New("scim: displayName already exists")
 )
 
 // tokenCost is the bcrypt cost for SCIM bearer-token secrets. Matches the
@@ -113,9 +117,12 @@ type Provider interface {
 	// --- SCIM Group provisioning (RFC 7643 §4.2 / RFC 7644 §3.5.2). Membership
 	// is stored as FGA tuples, never on the Group row. ---
 
-	// CreateGroup provisions a group into the org. Idempotent: a repeat with the
-	// same displayName (or externalId) returns the existing group with
-	// existed=true. Any in.Members are added (org-membership-gated).
+	// CreateGroup provisions a group into the org. When the payload carries an
+	// externalId that already identifies a group in the org, the create is
+	// idempotent: it adopts a renamed displayName and returns existed=true. A
+	// create that instead clashes on displayName (no matching externalId) is a
+	// uniqueness conflict (ErrGroupConflict → 409), not a silent 200. Any
+	// in.Members are added (org-membership-gated).
 	CreateGroup(ctx context.Context, orgID string, in Group) (group *schemas.ScimGroup, existed bool, err error)
 	// GetGroup fetches an org's group by id (404 if it belongs to another org — H6).
 	GetGroup(ctx context.Context, orgID, groupID string) (*schemas.ScimGroup, error)
@@ -125,9 +132,11 @@ type Provider interface {
 	// ReplaceGroup (PUT) overwrites displayName and sets membership to exactly
 	// in.Members (org-membership-gated).
 	ReplaceGroup(ctx context.Context, orgID, groupID string, in Group) (*schemas.ScimGroup, error)
-	// PatchGroup applies a parsed SCIM PatchOp: an optional displayName change
-	// plus member add/remove/replace ops. Idempotent.
-	PatchGroup(ctx context.Context, orgID, groupID string, displayName *string, ops []MemberOp) (*schemas.ScimGroup, error)
+	// PatchGroup applies a parsed SCIM PatchOp: optional displayName / externalId
+	// changes plus member add/remove/replace ops. A remove op with ClearAll (an
+	// unfiltered "remove members") or a replace with an empty set removes every
+	// member. Idempotent.
+	PatchGroup(ctx context.Context, orgID, groupID string, displayName, externalID *string, ops []MemberOp) (*schemas.ScimGroup, error)
 	// DeleteGroup removes the group row and all its membership + role-binding
 	// tuples.
 	DeleteGroup(ctx context.Context, orgID, groupID string) error

--- a/internal/service/scim/scim_test.go
+++ b/internal/service/scim/scim_test.go
@@ -22,6 +22,7 @@ type fakeStore struct {
 	endpoints   map[string]*schemas.ScimEndpoint // by id
 	users       map[string]*schemas.User         // by id
 	memberships map[string]bool                  // "orgID|userID"
+	groups      map[string]*schemas.ScimGroup    // by id
 	deletedTok  []string                         // user ids passed to DeleteAllSessionTokensByUserID
 }
 
@@ -30,6 +31,7 @@ func newFakeStore() *fakeStore {
 		endpoints:   map[string]*schemas.ScimEndpoint{},
 		users:       map[string]*schemas.User{},
 		memberships: map[string]bool{},
+		groups:      map[string]*schemas.ScimGroup{},
 	}
 }
 

--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -498,6 +498,24 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Unique: true,
 	})
 
+	// ScimGroup collection and indexes. org_id + display_name is the lookup key;
+	// not unique (service enforces displayName uniqueness within an org).
+	scimGroupCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.ScimGroup)
+	if err != nil {
+		return nil, err
+	}
+	if !scimGroupCollectionExists {
+		_, err = arangodb.CreateCollection(ctx, schemas.Collections.ScimGroup, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	scimGroupCollection, err := arangodb.Collection(ctx, schemas.Collections.ScimGroup)
+	if err != nil {
+		return nil, err
+	}
+	_, _, _ = scimGroupCollection.EnsurePersistentIndex(ctx, []string{"org_id", "display_name"}, &arangoDriver.EnsurePersistentIndexOptions{})
+
 	// OrgDomain collection and indexes. Uniqueness is enforced by the document
 	// _key being the normalized domain (atomic first-writer-wins); org_id is
 	// indexed (non-unique) for listing an org's domains.

--- a/internal/storage/db/arangodb/scim_group.go
+++ b/internal/storage/db/arangodb/scim_group.go
@@ -3,6 +3,7 @@ package arangodb
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -108,13 +109,15 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 }
 
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
-// displayName within an org.
+// displayName within an org. displayName is compared case-insensitively:
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so AQL's
+// LOWER() is applied to both sides, mirroring the SQL fix.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	var group *schemas.ScimGroup
-	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.display_name == @display_name LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND LOWER(d.display_name) == @display_name LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
 	bindVars := map[string]interface{}{
 		"org_id":       orgID,
-		"display_name": displayName,
+		"display_name": strings.ToLower(displayName),
 	}
 	cursor, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {

--- a/internal/storage/db/arangodb/scim_group.go
+++ b/internal/storage/db/arangodb/scim_group.go
@@ -108,29 +108,37 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 	return group, nil
 }
 
+// groupScanSafetyCap bounds the org-scoped scan-and-compare-in-app
+// displayName lookup below. It is NOT a realistic ceiling on an org's group
+// count, purely a circuit-breaker against unbounded work on a pathologically
+// large org, mirroring the equivalent cap in the SQL/Cassandra/DynamoDB
+// providers.
+const groupScanSafetyCap = 100_000
+
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
 // displayName within an org. displayName is compared case-insensitively:
-// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so AQL's
-// LOWER() is applied to both sides, mirroring the SQL fix.
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2).
+//
+// This deliberately does NOT use AQL's LOWER() for the comparison, for the
+// same reason the SQL provider doesn't: engine-native case folding is not
+// guaranteed to agree with Go's strings.ToLower/EqualFold for non-ASCII
+// display names, which would make this provider disagree with the others on
+// a "same" displayName. Fetching by org (indexed, cheap) and comparing with
+// strings.EqualFold in Go instead makes every storage backend fold
+// identically, matching the SQL/Cassandra/DynamoDB fetch-then-filter shape.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
-	var group *schemas.ScimGroup
-	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND LOWER(d.display_name) == @display_name LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id LIMIT @cap RETURN d", schemas.Collections.ScimGroup)
 	bindVars := map[string]interface{}{
-		"org_id":       orgID,
-		"display_name": strings.ToLower(displayName),
+		"org_id": orgID,
+		"cap":    groupScanSafetyCap,
 	}
 	cursor, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = cursor.Close() }()
-	for {
-		if !cursor.HasMore() {
-			if group == nil {
-				return nil, fmt.Errorf("scim group not found")
-			}
-			break
-		}
+	examined := 0
+	for cursor.HasMore() {
 		g := &schemas.ScimGroup{}
 		meta, rErr := readDocument(ctx, cursor, g)
 		if rErr != nil {
@@ -142,9 +150,16 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 		// read returns the portable id, matching AddScimGroup/UpdateScimGroup and
 		// the other 5 providers.
 		g.ID = meta.Key
-		group = g
+		if strings.EqualFold(g.DisplayName, displayName) {
+			return g, nil
+		}
+		examined++
 	}
-	return group, nil
+	if examined >= groupScanSafetyCap {
+		p.dependencies.Log.Warn().Str("org_id", orgID).Int("examined", examined).
+			Msg("GetScimGroupByOrgAndDisplayName: hit the scan safety cap without a match")
+	}
+	return nil, fmt.Errorf("scim group not found")
 }
 
 // GetScimGroupByOrgAndExternalID resolves the single group with the given

--- a/internal/storage/db/arangodb/scim_group.go
+++ b/internal/storage/db/arangodb/scim_group.go
@@ -29,7 +29,11 @@ func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (
 		return nil, err
 	}
 	group.Key = meta.Key
-	group.ID = meta.ID.String()
+	// ID is the portable bare identifier — matching every other provider's
+	// contract (ID == Key == bare uuid) and the _key GetScimGroupByID filters on.
+	// It is what URLs and FGA group-object ids are built from, so it must NOT be
+	// arango's full "collection/key" handle (meta.ID.String()).
+	group.ID = meta.Key
 	return group, nil
 }
 
@@ -52,7 +56,8 @@ func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup
 		return nil, err
 	}
 	group.Key = meta.Key
-	group.ID = meta.ID.String()
+	// Keep ID as the bare portable identifier (see AddScimGroup).
+	group.ID = meta.Key
 	return group, nil
 }
 
@@ -103,6 +108,37 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	bindVars := map[string]interface{}{
 		"org_id":       orgID,
 		"display_name": displayName,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if group == nil {
+				return nil, fmt.Errorf("scim group not found")
+			}
+			break
+		}
+		g := &schemas.ScimGroup{}
+		if _, err := readDocument(ctx, cursor, g); err != nil {
+			return nil, err
+		}
+		group = g
+	}
+	return group, nil
+}
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID, so this can never resolve another org's group.
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.external_id == @external_id LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
+	bindVars := map[string]interface{}{
+		"org_id":      orgID,
+		"external_id": orgID + ":" + externalID,
 	}
 	cursor, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {

--- a/internal/storage/db/arangodb/scim_group.go
+++ b/internal/storage/db/arangodb/scim_group.go
@@ -1,0 +1,126 @@
+package arangodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	groupCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimGroup)
+	doc, err := structToDocument(group)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := groupCollection.CreateDocument(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+	group.Key = meta.Key
+	group.ID = meta.ID.String()
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — this is a partial update via UpdateDocument (ArangoDB PATCH
+// semantics), safe here because callers pass a fully-loaded struct.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	groupCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimGroup)
+	doc, err := structToDocument(group)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := groupCollection.UpdateDocument(ctx, group.Key, doc)
+	if err != nil {
+		return nil, err
+	}
+	group.Key = meta.Key
+	group.ID = meta.ID.String()
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group record.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	groupCollection, _ := p.db.Collection(ctx, schemas.Collections.ScimGroup)
+	_, err := groupCollection.RemoveDocument(ctx, group.Key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key. Filters on _key, not
+// _id: every real caller holds the bare id, never the full "collection/key" handle.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	query := fmt.Sprintf("FOR d in %s FILTER d._key == @id LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
+	bindVars := map[string]interface{}{
+		"id": id,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if group == nil {
+				return nil, fmt.Errorf("scim group not found")
+			}
+			break
+		}
+		g := &schemas.ScimGroup{}
+		if _, err := readDocument(ctx, cursor, g); err != nil {
+			return nil, err
+		}
+		group = g
+	}
+	return group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org.
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	query := fmt.Sprintf("FOR d in %s FILTER d.org_id == @org_id AND d.display_name == @display_name LIMIT 1 RETURN d", schemas.Collections.ScimGroup)
+	bindVars := map[string]interface{}{
+		"org_id":       orgID,
+		"display_name": displayName,
+	}
+	cursor, err := p.db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close() }()
+	for {
+		if !cursor.HasMore() {
+			if group == nil {
+				return nil, fmt.Errorf("scim group not found")
+			}
+			break
+		}
+		g := &schemas.ScimGroup{}
+		if _, err := readDocument(ctx, cursor, g); err != nil {
+			return nil, err
+		}
+		group = g
+	}
+	return group, nil
+}

--- a/internal/storage/db/arangodb/scim_group.go
+++ b/internal/storage/db/arangodb/scim_group.go
@@ -92,9 +92,16 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 			break
 		}
 		g := &schemas.ScimGroup{}
-		if _, err := readDocument(ctx, cursor, g); err != nil {
-			return nil, err
+		meta, rErr := readDocument(ctx, cursor, g)
+		if rErr != nil {
+			return nil, rErr
 		}
+		// readDocument decodes ID from the document's _id (the full
+		// "collection/key" handle), but the group ID contract is the bare uuid
+		// (== Key) used in URLs and FGA object ids. Normalize to meta.Key so every
+		// read returns the portable id, matching AddScimGroup/UpdateScimGroup and
+		// the other 5 providers.
+		g.ID = meta.Key
 		group = g
 	}
 	return group, nil
@@ -122,9 +129,16 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 			break
 		}
 		g := &schemas.ScimGroup{}
-		if _, err := readDocument(ctx, cursor, g); err != nil {
-			return nil, err
+		meta, rErr := readDocument(ctx, cursor, g)
+		if rErr != nil {
+			return nil, rErr
 		}
+		// readDocument decodes ID from the document's _id (the full
+		// "collection/key" handle), but the group ID contract is the bare uuid
+		// (== Key) used in URLs and FGA object ids. Normalize to meta.Key so every
+		// read returns the portable id, matching AddScimGroup/UpdateScimGroup and
+		// the other 5 providers.
+		g.ID = meta.Key
 		group = g
 	}
 	return group, nil
@@ -153,9 +167,16 @@ func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, ex
 			break
 		}
 		g := &schemas.ScimGroup{}
-		if _, err := readDocument(ctx, cursor, g); err != nil {
-			return nil, err
+		meta, rErr := readDocument(ctx, cursor, g)
+		if rErr != nil {
+			return nil, rErr
 		}
+		// readDocument decodes ID from the document's _id (the full
+		// "collection/key" handle), but the group ID contract is the bare uuid
+		// (== Key) used in URLs and FGA object ids. Normalize to meta.Key so every
+		// read returns the portable id, matching AddScimGroup/UpdateScimGroup and
+		// the other 5 providers.
+		g.ID = meta.Key
 		group = g
 	}
 	return group, nil

--- a/internal/storage/db/cassandradb/provider.go
+++ b/internal/storage/db/cassandradb/provider.go
@@ -575,6 +575,18 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 	// GetScimEndpointByOrgID and the uniqueness guard) to become queryable.
 	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.ScimEndpoint, "org_id", 30*time.Second)
 
+	// ScimGroup table and index. Membership is NOT stored here (it lives in FGA);
+	// org_id indexes the displayName-eq lookup (org_id + display_name ALLOW FILTERING).
+	scimGroupCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, display_name text, external_id text, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.ScimGroup)
+	if err = session.Query(scimGroupCollectionQuery).Exec(); err != nil {
+		return nil, err
+	}
+	scimGroupOrgIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS authorizer_scim_group_org_id ON %s.%s (org_id)", KeySpace, schemas.Collections.ScimGroup)
+	if err = session.Query(scimGroupOrgIndex).Exec(); err != nil {
+		return nil, err
+	}
+	waitForCassandraSecondaryIndex(session, KeySpace, schemas.Collections.ScimGroup, "org_id", 30*time.Second)
+
 	// OrgDomain table and index. The normalized domain is the partition key, so
 	// INSERT ... IF NOT EXISTS enforces first-writer-wins atomically (LWT).
 	orgDomainCollectionQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id text, org_id text, domain text, verified_at bigint, created_at bigint, updated_at bigint, PRIMARY KEY (id))", KeySpace, schemas.Collections.OrgDomain)

--- a/internal/storage/db/cassandradb/scim_group.go
+++ b/internal/storage/db/cassandradb/scim_group.go
@@ -14,6 +14,15 @@ import (
 
 const scimGroupColumns = "id, org_id, display_name, external_id, created_at, updated_at"
 
+// groupScanSafetyCap bounds the org-scoped scan-and-compare-in-app
+// displayName lookup below. It is NOT a realistic ceiling on an org's group
+// count — gocql's Scanner already pages through the full ALLOW FILTERING
+// result set as Next() is called, so a normal lookup runs to full exhaustion
+// (or an early match) regardless of how many pages that takes. This exists
+// purely as a circuit-breaker against unbounded work on a pathologically
+// large partition, mirroring DynamoDB's groupScanSafetyCap.
+const groupScanSafetyCap = 100_000
+
 // scanScimGroup maps the scimGroupColumns projection onto a struct.
 func scanScimGroup(scan func(...interface{}) error, group *schemas.ScimGroup) error {
 	return scan(&group.ID, &group.OrgID, &group.DisplayName, &group.ExternalID, &group.CreatedAt, &group.UpdatedAt)
@@ -91,8 +100,15 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 // query to the org and compare displayName with strings.EqualFold in Go (an
 // org's group set is small), mirroring the DynamoDB fetch-then-filter shape.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	// No LIMIT here deliberately: a CQL LIMIT truncates the combined result set
+	// across every page, which would silently drop a match beyond it — the
+	// exact bug groupScanSafetyCap exists to avoid. gocql's Scanner pages
+	// through ALLOW FILTERING lazily as Next() is called, so leaving LIMIT off
+	// lets a real match anywhere in the org's group set still be found; the
+	// safety cap below bounds the Go-side loop instead, not the CQL query.
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
 	scanner := p.db.Query(query, orgID).Consistency(gocql.One).Iter().Scanner()
+	examined := 0
 	for scanner.Next() {
 		var group schemas.ScimGroup
 		if err := scanScimGroup(scanner.Scan, &group); err != nil {
@@ -100,6 +116,12 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 		}
 		if strings.EqualFold(group.DisplayName, displayName) {
 			return &group, nil
+		}
+		examined++
+		if examined >= groupScanSafetyCap {
+			p.dependencies.Log.Warn().Str("org_id", orgID).Int("examined", examined).
+				Msg("GetScimGroupByOrgAndDisplayName: hit the scan safety cap without a match")
+			return nil, gocql.ErrNotFound
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/storage/db/cassandradb/scim_group.go
+++ b/internal/storage/db/cassandradb/scim_group.go
@@ -23,6 +23,11 @@ const scimGroupColumns = "id, org_id, display_name, external_id, created_at, upd
 // large partition, mirroring DynamoDB's groupScanSafetyCap.
 const groupScanSafetyCap = 100_000
 
+// cassandraGroupPageSize bounds each fetch of the org-scoped displayName scan
+// to a real page, so an early match doesn't require pulling a large org's
+// entire group set into memory first (see GetScimGroupByOrgAndDisplayName).
+const cassandraGroupPageSize = 1000
+
 // scanScimGroup maps the scimGroupColumns projection onto a struct.
 func scanScimGroup(scan func(...interface{}) error, group *schemas.ScimGroup) error {
 	return scan(&group.ID, &group.OrgID, &group.DisplayName, &group.ExternalID, &group.CreatedAt, &group.UpdatedAt)
@@ -102,12 +107,20 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	// No LIMIT here deliberately: a CQL LIMIT truncates the combined result set
 	// across every page, which would silently drop a match beyond it — the
-	// exact bug groupScanSafetyCap exists to avoid. gocql's Scanner pages
-	// through ALLOW FILTERING lazily as Next() is called, so leaving LIMIT off
-	// lets a real match anywhere in the org's group set still be found; the
-	// safety cap below bounds the Go-side loop instead, not the CQL query.
+	// exact bug groupScanSafetyCap exists to avoid. A real match anywhere in the
+	// org's group set is still found; the safety cap below bounds the Go-side
+	// loop instead of the CQL query.
+	//
+	// PageSize is set explicitly (rather than leaving gocql's session default)
+	// because with none set, ALLOW FILTERING fetches the ENTIRE result in one
+	// frame — the Scanner would just iterate an already-fully-materialized
+	// buffer, not genuinely page. Setting it here makes the driver fetch and
+	// examine the partition incrementally, so an early match (the common case)
+	// avoids pulling the rest of a large org's rows into memory at all, and the
+	// safety cap actually bounds real fetch cost, not just a client-side count
+	// over data that was already all in memory.
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
-	scanner := p.db.Query(query, orgID).Consistency(gocql.One).Iter().Scanner()
+	scanner := p.db.Query(query, orgID).Consistency(gocql.One).PageSize(cassandraGroupPageSize).Iter().Scanner()
 	examined := 0
 	for scanner.Next() {
 		var group schemas.ScimGroup

--- a/internal/storage/db/cassandradb/scim_group.go
+++ b/internal/storage/db/cassandradb/scim_group.go
@@ -94,3 +94,15 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	}
 	return &group, nil
 }
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID, so this can never resolve another org's group.
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND external_id = ? LIMIT 1 ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
+	if err := scanScimGroup(p.db.Query(query, orgID, orgID+":"+externalID).Consistency(gocql.One).Scan, &group); err != nil {
+		return nil, err
+	}
+	return &group, nil
+}

--- a/internal/storage/db/cassandradb/scim_group.go
+++ b/internal/storage/db/cassandradb/scim_group.go
@@ -85,14 +85,27 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 }
 
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
-// displayName within an org.
+// displayName within an org. displayName is compared case-insensitively:
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2). CQL cannot
+// apply a function like LOWER() to a column in a WHERE clause, so scope the
+// query to the org and compare displayName with strings.EqualFold in Go (an
+// org's group set is small), mirroring the DynamoDB fetch-then-filter shape.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
-	var group schemas.ScimGroup
-	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND display_name = ? LIMIT 1 ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
-	if err := scanScimGroup(p.db.Query(query, orgID, displayName).Consistency(gocql.One).Scan, &group); err != nil {
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
+	scanner := p.db.Query(query, orgID).Consistency(gocql.One).Iter().Scanner()
+	for scanner.Next() {
+		var group schemas.ScimGroup
+		if err := scanScimGroup(scanner.Scan, &group); err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(group.DisplayName, displayName) {
+			return &group, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	return &group, nil
+	return nil, gocql.ErrNotFound
 }
 
 // GetScimGroupByOrgAndExternalID resolves the single group with the given

--- a/internal/storage/db/cassandradb/scim_group.go
+++ b/internal/storage/db/cassandradb/scim_group.go
@@ -1,0 +1,96 @@
+package cassandradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const scimGroupColumns = "id, org_id, display_name, external_id, created_at, updated_at"
+
+// scanScimGroup maps the scimGroupColumns projection onto a struct.
+func scanScimGroup(scan func(...interface{}) error, group *schemas.ScimGroup) error {
+	return scan(&group.ID, &group.OrgID, &group.DisplayName, &group.ExternalID, &group.CreatedAt, &group.UpdatedAt)
+}
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	insertQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?, ?, ?, ?, ?, ?)", KeySpace+"."+schemas.Collections.ScimGroup, scimGroupColumns)
+	err := p.db.Query(insertQuery, group.ID, group.OrgID, group.DisplayName, group.ExternalID, group.CreatedAt, group.UpdatedAt).Exec()
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks columns it does not carry.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	groupMap := buildCQLColumnMap(group)
+	updateFields := ""
+	var updateValues []interface{}
+	for key, value := range groupMap {
+		if key == "id" || key == "_key" {
+			continue
+		}
+		if value == nil {
+			updateFields += fmt.Sprintf("%s = null,", key)
+			continue
+		}
+		updateFields += fmt.Sprintf("%s = ?, ", key)
+		updateValues = append(updateValues, value)
+	}
+	updateFields = strings.Trim(updateFields, " ")
+	updateFields = strings.TrimSuffix(updateFields, ",")
+	updateValues = append(updateValues, group.ID)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.ScimGroup, updateFields)
+	if err := p.db.Query(query, updateValues...).Exec(); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group record.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.ScimGroup)
+	return p.db.Query(query, group.ID).Exec()
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE id = ? LIMIT 1", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
+	if err := scanScimGroup(p.db.Query(query, id).Consistency(gocql.One).Scan, &group); err != nil {
+		return nil, err
+	}
+	return &group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org.
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE org_id = ? AND display_name = ? LIMIT 1 ALLOW FILTERING", scimGroupColumns, KeySpace+"."+schemas.Collections.ScimGroup)
+	if err := scanScimGroup(p.db.Query(query, orgID, displayName).Consistency(gocql.One).Scan, &group); err != nil {
+		return nil, err
+	}
+	return &group, nil
+}

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -325,6 +325,10 @@ func getIndex(scopeName string) map[string][]string {
 	scimEndpointIndex1 := fmt.Sprintf("CREATE INDEX ScimEndpointOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.ScimEndpoint)
 	indices[schemas.Collections.ScimEndpoint] = []string{scimEndpointIndex1}
 
+	// ScimGroup index (org_id + display_name lookup).
+	scimGroupIndex1 := fmt.Sprintf("CREATE INDEX ScimGroupOrgIdDisplayNameIndex ON %s.%s(org_id, display_name)", scopeName, schemas.Collections.ScimGroup)
+	indices[schemas.Collections.ScimGroup] = []string{scimGroupIndex1}
+
 	// OrgDomain index (uniqueness is enforced by the document key = domain;
 	// org_id is indexed for listing).
 	orgDomainIndex1 := fmt.Sprintf("CREATE INDEX OrgDomainOrgIdIndex ON %s.%s(org_id)", scopeName, schemas.Collections.OrgDomain)

--- a/internal/storage/db/couchbase/scim_group.go
+++ b/internal/storage/db/couchbase/scim_group.go
@@ -1,0 +1,126 @@
+package couchbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+const scimGroupColumns = "_id, org_id, display_name, external_id, created_at, updated_at"
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	insertOpt := gocb.InsertOptions{
+		Context: ctx,
+	}
+	doc, err := structToDocument(group)
+	if err != nil {
+		return nil, err
+	}
+	_, err = p.db.Collection(schemas.Collections.ScimGroup).Insert(group.ID, doc, &insertOpt)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — a partial struct blanks fields it does not carry.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	groupMap, err := structToDocument(group)
+	if err != nil {
+		return nil, err
+	}
+	updateFields, params := GetSetFields(groupMap)
+	params["_id"] = group.ID
+	query := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE _id=$_id`, p.scopeName, schemas.Collections.ScimGroup, updateFields)
+	_, err = p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group record.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	removeOpt := gocb.RemoveOptions{
+		Context: ctx,
+	}
+	_, err := p.db.Collection(schemas.Collections.ScimGroup).Remove(group.ID, &removeOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	params := make(map[string]interface{}, 1)
+	params["_id"] = id
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE _id=$_id LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	group := &schemas.ScimGroup{}
+	if err := decodeDocument(raw, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org.
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	params := make(map[string]interface{}, 2)
+	params["org_id"] = orgID
+	params["display_name"] = displayName
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND display_name=$display_name LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	group := &schemas.ScimGroup{}
+	if err := decodeDocument(raw, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}

--- a/internal/storage/db/couchbase/scim_group.go
+++ b/internal/storage/db/couchbase/scim_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -100,12 +101,14 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 }
 
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
-// displayName within an org.
+// displayName within an org. displayName is compared case-insensitively:
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so N1QL's
+// LOWER() is applied to both sides, mirroring the SQL fix.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	params := make(map[string]interface{}, 2)
 	params["org_id"] = orgID
-	params["display_name"] = displayName
-	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND display_name=$display_name LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
+	params["display_name"] = strings.ToLower(displayName)
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND LOWER(display_name)=$display_name LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		Context:         ctx,
 		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,

--- a/internal/storage/db/couchbase/scim_group.go
+++ b/internal/storage/db/couchbase/scim_group.go
@@ -124,3 +124,30 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	}
 	return group, nil
 }
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID, so this can never resolve another org's group.
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	params := make(map[string]interface{}, 2)
+	params["org_id"] = orgID
+	params["external_id"] = orgID + ":" + externalID
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND external_id=$external_id LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
+	q, err := p.db.Query(query, &gocb.QueryOptions{
+		Context:         ctx,
+		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
+		NamedParameters: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := q.One(&raw); err != nil {
+		return nil, err
+	}
+	group := &schemas.ScimGroup{}
+	if err := decodeDocument(raw, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}

--- a/internal/storage/db/couchbase/scim_group.go
+++ b/internal/storage/db/couchbase/scim_group.go
@@ -100,16 +100,31 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 	return group, nil
 }
 
+// groupScanSafetyCap bounds the org-scoped scan-and-compare-in-app
+// displayName lookup below. It is NOT a realistic ceiling on an org's group
+// count, purely a circuit-breaker against unbounded work on a pathologically
+// large org, mirroring the equivalent cap in the SQL/Cassandra/DynamoDB/
+// ArangoDB providers.
+const groupScanSafetyCap = 100_000
+
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
 // displayName within an org. displayName is compared case-insensitively:
-// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so N1QL's
-// LOWER() is applied to both sides, mirroring the SQL fix.
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2).
+//
+// This deliberately does NOT use N1QL's LOWER() for the comparison, for the
+// same reason the SQL provider doesn't: engine-native case folding is not
+// guaranteed to agree with Go's strings.ToLower/EqualFold for non-ASCII
+// display names, which would make this provider disagree with the others on
+// a "same" displayName. Fetching by org (indexed, cheap) and comparing with
+// strings.EqualFold in Go instead makes every storage backend fold
+// identically, matching the SQL/Cassandra/DynamoDB/ArangoDB fetch-then-filter
+// shape.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	params := make(map[string]interface{}, 2)
 	params["org_id"] = orgID
-	params["display_name"] = strings.ToLower(displayName)
-	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id AND LOWER(display_name)=$display_name LIMIT 1`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
-	q, err := p.db.Query(query, &gocb.QueryOptions{
+	params["cap"] = groupScanSafetyCap
+	query := fmt.Sprintf(`SELECT %s FROM %s.%s WHERE org_id=$org_id LIMIT $cap`, scimGroupColumns, p.scopeName, schemas.Collections.ScimGroup)
+	queryResult, err := p.db.Query(query, &gocb.QueryOptions{
 		Context:         ctx,
 		ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
 		NamedParameters: params,
@@ -117,15 +132,29 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	if err != nil {
 		return nil, err
 	}
-	var raw json.RawMessage
-	if err := q.One(&raw); err != nil {
+	examined := 0
+	for queryResult.Next() {
+		var raw json.RawMessage
+		if err := queryResult.Row(&raw); err != nil {
+			return nil, err
+		}
+		group := &schemas.ScimGroup{}
+		if err := decodeDocument(raw, group); err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(group.DisplayName, displayName) {
+			return group, nil
+		}
+		examined++
+	}
+	if err := queryResult.Err(); err != nil {
 		return nil, err
 	}
-	group := &schemas.ScimGroup{}
-	if err := decodeDocument(raw, group); err != nil {
-		return nil, err
+	if examined >= groupScanSafetyCap {
+		p.dependencies.Log.Warn().Str("org_id", orgID).Int("examined", examined).
+			Msg("GetScimGroupByOrgAndDisplayName: hit the scan safety cap without a match")
 	}
-	return group, nil
+	return nil, fmt.Errorf("scim group not found")
 }
 
 // GetScimGroupByOrgAndExternalID resolves the single group with the given

--- a/internal/storage/db/dynamodb/ops.go
+++ b/internal/storage/db/dynamodb/ops.go
@@ -211,6 +211,59 @@ func (p *provider) queryEqLimit(ctx context.Context, table, indexName, pkAttr, p
 	return res.Items, nil
 }
 
+// queryEqUntil pages through the pkAttr=pkVal partition (like queryEq) but
+// stops as soon as match reports a hit, instead of materializing every page
+// before filtering. maxItems is a defensive circuit-breaker against unbounded
+// scan cost on a pathologically large partition — NOT a realistic ceiling;
+// normal callers exhaust the partition long before reaching it. match may
+// return an error (e.g. a decode failure), which aborts the scan immediately
+// rather than being swallowed as a non-match; on a hit it is responsible for
+// capturing whatever it needs from the item (queryEqUntil only reports found/
+// not-found, it does not return the raw item — callers already decode it
+// inside match to test it, so returning it again would be redundant).
+func (p *provider) queryEqUntil(ctx context.Context, table, indexName, pkAttr, pkVal string, maxItems int, match func(map[string]types.AttributeValue) (bool, error)) (bool, error) {
+	kc := expression.Key(pkAttr).Equal(expression.Value(pkVal))
+	expr, err := expression.NewBuilder().WithKeyCondition(kc).Build()
+	if err != nil {
+		return false, err
+	}
+	var start map[string]types.AttributeValue
+	examined := 0
+	for {
+		in := &dynamodb.QueryInput{
+			TableName:                 aws.String(table),
+			IndexName:                 aws.String(indexName),
+			KeyConditionExpression:    expr.KeyCondition(),
+			ExpressionAttributeNames:  expr.Names(),
+			ExpressionAttributeValues: expr.Values(),
+			ExclusiveStartKey:         start,
+		}
+		res, err := p.client.Query(ctx, in)
+		if err != nil {
+			return false, err
+		}
+		for _, it := range res.Items {
+			ok, err := match(it)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+			examined++
+			if examined >= maxItems {
+				p.dependencies.Log.Warn().Str("table", table).Str("partition_key", pkVal).Int("examined", examined).
+					Msg("queryEqUntil: hit the scan safety cap without a match")
+				return false, nil
+			}
+		}
+		if res.LastEvaluatedKey == nil {
+			return false, nil
+		}
+		start = res.LastEvaluatedKey
+	}
+}
+
 func (p *provider) scanFilteredLimit(ctx context.Context, table string, index *string, filter *expression.ConditionBuilder, limit int32) ([]map[string]types.AttributeValue, error) {
 	in := &dynamodb.ScanInput{
 		TableName: aws.String(table),

--- a/internal/storage/db/dynamodb/scim_group.go
+++ b/internal/storage/db/dynamodb/scim_group.go
@@ -87,3 +87,25 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	}
 	return nil, errors.New("no document found")
 }
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID. No GSI on external_id, so query the org_id GSI
+// and match in-app (an org's group set is small).
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	want := orgID + ":" + externalID
+	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, nil, groupScanCap)
+	if err != nil {
+		return nil, err
+	}
+	for _, it := range items {
+		var group schemas.ScimGroup
+		if err := unmarshalItem(it, &group); err != nil {
+			return nil, err
+		}
+		if group.ExternalID != nil && *group.ExternalID == want {
+			return &group, nil
+		}
+	}
+	return nil, errors.New("no document found")
+}

--- a/internal/storage/db/dynamodb/scim_group.go
+++ b/internal/storage/db/dynamodb/scim_group.go
@@ -7,16 +7,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-// groupScanCap bounds the org_id query used to resolve a group by displayName.
-// An org's group count is small; this closes over the realistic range without
-// paginating.
-// ponytail: cap at 1000; add pagination if an org ever exceeds it.
-const groupScanCap = 1000
+// groupScanSafetyCap bounds the org-scoped scan-and-compare-in-app lookups
+// below (queryEqUntil). It is NOT a realistic ceiling on an org's group
+// count — normal lookups page through the whole partition — it exists purely
+// as a circuit-breaker against unbounded work on a pathologically large one.
+const groupScanSafetyCap = 100_000
 
 // AddScimGroup creates a new SCIM group record.
 func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
@@ -76,20 +77,25 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 // caseExact:false (RFC 7644 §3.4.2.2), and a DynamoDB GSI lookup is exact-match
 // only, so the case-fold happens here in Go with strings.EqualFold.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
-	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, nil, groupScanCap)
+	var found schemas.ScimGroup
+	ok, err := p.queryEqUntil(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, groupScanSafetyCap, func(it map[string]types.AttributeValue) (bool, error) {
+		var group schemas.ScimGroup
+		if err := unmarshalItem(it, &group); err != nil {
+			return false, err
+		}
+		if !strings.EqualFold(group.DisplayName, displayName) {
+			return false, nil
+		}
+		found = group
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	for _, it := range items {
-		var group schemas.ScimGroup
-		if err := unmarshalItem(it, &group); err != nil {
-			return nil, err
-		}
-		if strings.EqualFold(group.DisplayName, displayName) {
-			return &group, nil
-		}
+	if !ok {
+		return nil, errors.New("no document found")
 	}
-	return nil, errors.New("no document found")
+	return &found, nil
 }
 
 // GetScimGroupByOrgAndExternalID resolves the single group with the given
@@ -98,18 +104,23 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 // and match in-app (an org's group set is small).
 func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
 	want := orgID + ":" + externalID
-	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, nil, groupScanCap)
+	var found schemas.ScimGroup
+	ok, err := p.queryEqUntil(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, groupScanSafetyCap, func(it map[string]types.AttributeValue) (bool, error) {
+		var group schemas.ScimGroup
+		if err := unmarshalItem(it, &group); err != nil {
+			return false, err
+		}
+		if group.ExternalID == nil || *group.ExternalID != want {
+			return false, nil
+		}
+		found = group
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	for _, it := range items {
-		var group schemas.ScimGroup
-		if err := unmarshalItem(it, &group); err != nil {
-			return nil, err
-		}
-		if group.ExternalID != nil && *group.ExternalID == want {
-			return &group, nil
-		}
+	if !ok {
+		return nil, errors.New("no document found")
 	}
-	return nil, errors.New("no document found")
+	return &found, nil
 }

--- a/internal/storage/db/dynamodb/scim_group.go
+++ b/internal/storage/db/dynamodb/scim_group.go
@@ -76,6 +76,12 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 // displayName is compared case-insensitively: SCIM Group.displayName is
 // caseExact:false (RFC 7644 §3.4.2.2), and a DynamoDB GSI lookup is exact-match
 // only, so the case-fold happens here in Go with strings.EqualFold.
+//
+// Note for callers relying on this for uniqueness (service.ensureDisplayNameFree
+// / CreateGroup dedup): the org_id GSI is EVENTUALLY consistent, so a probe run
+// immediately after a sibling create/rename on this org may not observe it yet.
+// Combined with the check-then-insert nature of the callers, this is a known,
+// accepted race — see their doc comments.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	var found schemas.ScimGroup
 	ok, err := p.queryEqUntil(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, groupScanSafetyCap, func(it map[string]types.AttributeValue) (bool, error) {

--- a/internal/storage/db/dynamodb/scim_group.go
+++ b/internal/storage/db/dynamodb/scim_group.go
@@ -1,0 +1,89 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// groupScanCap bounds the org_id query used to resolve a group by displayName.
+// An org's group count is small; this closes over the realistic range without
+// paginating.
+// ponytail: cap at 1000; add pagination if an org ever exceeds it.
+const groupScanCap = 1000
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	if err := p.putItem(ctx, schemas.Collections.ScimGroup, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — UpdateItem applies a partial SET/REMOVE merge, so a partial struct
+// blanks untouched columns to their zero values.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	if err := p.updateByHashKey(ctx, schemas.Collections.ScimGroup, "id", group.ID, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group record.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	if group == nil {
+		return nil
+	}
+	return p.deleteItemByHash(ctx, schemas.Collections.ScimGroup, "id", group.ID)
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	err := p.getItemByHash(ctx, schemas.Collections.ScimGroup, "id", id, &group)
+	if err != nil {
+		return nil, err
+	}
+	if group.ID == "" {
+		return nil, errors.New("no document found")
+	}
+	return &group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org. There is no GSI on display_name, so query the
+// org_id GSI and match displayName in-app (an org's group set is small).
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, nil, groupScanCap)
+	if err != nil {
+		return nil, err
+	}
+	for _, it := range items {
+		var group schemas.ScimGroup
+		if err := unmarshalItem(it, &group); err != nil {
+			return nil, err
+		}
+		if group.DisplayName == displayName {
+			return &group, nil
+		}
+	}
+	return nil, errors.New("no document found")
+}

--- a/internal/storage/db/dynamodb/scim_group.go
+++ b/internal/storage/db/dynamodb/scim_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -71,6 +72,9 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
 // displayName within an org. There is no GSI on display_name, so query the
 // org_id GSI and match displayName in-app (an org's group set is small).
+// displayName is compared case-insensitively: SCIM Group.displayName is
+// caseExact:false (RFC 7644 §3.4.2.2), and a DynamoDB GSI lookup is exact-match
+// only, so the case-fold happens here in Go with strings.EqualFold.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	items, err := p.queryEqLimit(ctx, schemas.Collections.ScimGroup, "org_id", "org_id", orgID, nil, groupScanCap)
 	if err != nil {
@@ -81,7 +85,7 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 		if err := unmarshalItem(it, &group); err != nil {
 			return nil, err
 		}
-		if group.DisplayName == displayName {
+		if strings.EqualFold(group.DisplayName, displayName) {
 			return &group, nil
 		}
 	}

--- a/internal/storage/db/dynamodb/tables.go
+++ b/internal/storage/db/dynamodb/tables.go
@@ -257,6 +257,15 @@ func (p *provider) ensureTables(ctx context.Context) error {
 			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
 		},
 		{
+			name: schemas.Collections.ScimGroup,
+			hash: "id",
+			attr: []types.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				{AttributeName: aws.String("org_id"), AttributeType: types.ScalarAttributeTypeS},
+			},
+			gsi: []types.GlobalSecondaryIndex{gsi("org_id", "org_id")},
+		},
+		{
 			// OrgDomain: partition key "id" holds the normalized domain, so a
 			// conditional PutItem (attribute_not_exists) is a race-free unique insert.
 			name: schemas.Collections.OrgDomain,

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -309,6 +309,16 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 		},
 	}, options.CreateIndexes())
 
+	// ScimGroup collection and indexes. org_id + display_name is the create dedup
+	// and displayName-eq filter lookup; not unique (service enforces uniqueness).
+	_ = mongodb.CreateCollection(ctx, schemas.Collections.ScimGroup, options.CreateCollection())
+	scimGroupCollection := mongodb.Collection(schemas.Collections.ScimGroup, options.Collection())
+	_, _ = scimGroupCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{{Key: "org_id", Value: 1}, {Key: "display_name", Value: 1}},
+		},
+	}, options.CreateIndexes())
+
 	// OrgDomain collection and indexes. Uniqueness is enforced by _id being the
 	// normalized domain (no unique index needed); org_id is indexed for listing.
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.OrgDomain, options.CreateCollection())

--- a/internal/storage/db/mongodb/scim_group.go
+++ b/internal/storage/db/mongodb/scim_group.go
@@ -68,11 +68,15 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 }
 
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
-// displayName within an org.
+// displayName within an org. displayName is compared case-insensitively:
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2). A strength-2
+// collation makes the equality case-insensitive while comparing the value as a
+// literal — no regex, so a displayName with metacharacters is never interpreted.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	var group *schemas.ScimGroup
 	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
-	err := groupCollection.FindOne(ctx, bson.M{"org_id": orgID, "display_name": displayName}).Decode(&group)
+	opts := options.FindOne().SetCollation(&options.Collation{Locale: "en", Strength: 2})
+	err := groupCollection.FindOne(ctx, bson.M{"org_id": orgID, "display_name": displayName}, opts).Decode(&group)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/mongodb/scim_group.go
+++ b/internal/storage/db/mongodb/scim_group.go
@@ -78,3 +78,16 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	}
 	return group, nil
 }
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID, so this can never resolve another org's group.
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	err := groupCollection.FindOne(ctx, bson.M{"org_id": orgID, "external_id": orgID + ":" + externalID}).Decode(&group)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}

--- a/internal/storage/db/mongodb/scim_group.go
+++ b/internal/storage/db/mongodb/scim_group.go
@@ -1,0 +1,80 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	_, err := groupCollection.InsertOne(ctx, group)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — the $set write replaces every column and will blank zero-value
+// fields on a partial struct.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	_, err := groupCollection.UpdateOne(ctx, bson.M{"_id": bson.M{"$eq": group.ID}}, bson.M{"$set": group}, options.MergeUpdateOptions())
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group record.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	_, err := groupCollection.DeleteOne(ctx, bson.M{"_id": group.ID}, options.Delete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	err := groupCollection.FindOne(ctx, bson.M{"_id": id}).Decode(&group)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org.
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	var group *schemas.ScimGroup
+	groupCollection := p.db.Collection(schemas.Collections.ScimGroup, options.Collection())
+	err := groupCollection.FindOne(ctx, bson.M{"org_id": orgID, "display_name": displayName}).Decode(&group)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}

--- a/internal/storage/db/sql/provider.go
+++ b/internal/storage/db/sql/provider.go
@@ -95,7 +95,7 @@ func NewProvider(
 	// name-agnostically, before AutoMigrate runs.
 	clearLegacyColumnUniqueness(sqlDB, deps.Log)
 
-	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{}, &schemas.WebauthnCredential{}, &schemas.OrgDomain{}, &schemas.SAMLServiceProvider{}, &schemas.SAMLIDPKey{})
+	err = sqlDB.AutoMigrate(&schemas.User{}, &schemas.VerificationRequest{}, &schemas.Session{}, &schemas.Env{}, &schemas.Webhook{}, &schemas.WebhookLog{}, &schemas.EmailTemplate{}, &schemas.OTP{}, &schemas.Authenticator{}, &schemas.SessionToken{}, &schemas.MFASession{}, &schemas.OAuthState{}, &schemas.AuditLog{}, &schemas.Client{}, &schemas.TrustedIssuer{}, &schemas.Organization{}, &schemas.OrgMembership{}, &schemas.FederatedIdentity{}, &schemas.ScimEndpoint{}, &schemas.ScimGroup{}, &schemas.WebauthnCredential{}, &schemas.OrgDomain{}, &schemas.SAMLServiceProvider{}, &schemas.SAMLIDPKey{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db/sql/scim_group.go
+++ b/internal/storage/db/sql/scim_group.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -58,10 +59,12 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 }
 
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
-// displayName within an org.
+// displayName within an org. displayName is compared case-insensitively:
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so LOWER()
+// is applied to both sides — portable across GORM's SQL dialects.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
 	var group schemas.ScimGroup
-	res := p.db.Where("org_id = ? AND display_name = ?", orgID, displayName).First(&group)
+	res := p.db.Where("org_id = ? AND LOWER(display_name) = ?", orgID, strings.ToLower(displayName)).First(&group)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/internal/storage/db/sql/scim_group.go
+++ b/internal/storage/db/sql/scim_group.go
@@ -1,0 +1,69 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// AddScimGroup creates a new SCIM group record.
+func (p *provider) AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.ID == "" {
+		group.ID = uuid.New().String()
+	}
+	group.Key = group.ID
+	now := time.Now().Unix()
+	group.CreatedAt = now
+	group.UpdatedAt = now
+	res := p.db.Create(group)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return group, nil
+}
+
+// UpdateScimGroup updates a SCIM group record.
+// Callers MUST load the existing record and mutate it before calling this
+// method — Save writes every column and will blank zero-value fields on a
+// partial struct.
+func (p *provider) UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error) {
+	if group.CreatedAt == 0 {
+		return nil, fmt.Errorf("UpdateScimGroup: caller must load record before updating (CreatedAt is zero — partial struct detected)")
+	}
+	group.UpdatedAt = time.Now().Unix()
+	res := p.db.Save(group)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return group, nil
+}
+
+// DeleteScimGroup removes a SCIM group.
+func (p *provider) DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error {
+	return p.db.Delete(group).Error
+}
+
+// GetScimGroupByID fetches a SCIM group by primary key.
+func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	res := p.db.Where("id = ?", id).First(&group)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &group, nil
+}
+
+// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+// displayName within an org.
+func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	res := p.db.Where("org_id = ? AND display_name = ?", orgID, displayName).First(&group)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &group, nil
+}

--- a/internal/storage/db/sql/scim_group.go
+++ b/internal/storage/db/sql/scim_group.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
@@ -58,17 +59,42 @@ func (p *provider) GetScimGroupByID(ctx context.Context, id string) (*schemas.Sc
 	return &group, nil
 }
 
+// groupScanSafetyCap bounds the org-scoped scan-and-compare-in-app
+// displayName lookup below. It is NOT a realistic ceiling on an org's group
+// count, purely a circuit-breaker against unbounded work on a pathologically
+// large org, mirroring the equivalent cap in the Cassandra/DynamoDB providers.
+const groupScanSafetyCap = 100_000
+
 // GetScimGroupByOrgAndDisplayName resolves the single group with the given
 // displayName within an org. displayName is compared case-insensitively:
-// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2), so LOWER()
-// is applied to both sides — portable across GORM's SQL dialects.
+// SCIM Group.displayName is caseExact:false (RFC 7644 §3.4.2.2).
+//
+// This deliberately does NOT use SQL's LOWER() for the comparison: it isn't
+// actually portable the way it looks. SQLite's built-in LOWER() folds ASCII
+// only, while Postgres/MySQL/SQL Server's LOWER() are collation/Unicode-aware
+// in ways that differ from each other AND from Go's strings.ToLower — so a
+// non-ASCII displayName (e.g. "CAFÉ") could match on one dialect and miss on
+// another, and none of them are guaranteed to agree with the Go-side fold
+// every other provider (Cassandra, DynamoDB, Mongo's collation) uses. Fetching
+// by org (indexed, cheap) and comparing with strings.EqualFold in Go instead
+// makes all 6 storage backends fold identically, matching the Cassandra/
+// DynamoDB fetch-then-filter shape exactly.
 func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error) {
-	var group schemas.ScimGroup
-	res := p.db.Where("org_id = ? AND LOWER(display_name) = ?", orgID, strings.ToLower(displayName)).First(&group)
+	var groups []schemas.ScimGroup
+	res := p.db.Where("org_id = ?", orgID).Limit(groupScanSafetyCap).Find(&groups)
 	if res.Error != nil {
 		return nil, res.Error
 	}
-	return &group, nil
+	for _, g := range groups {
+		if strings.EqualFold(g.DisplayName, displayName) {
+			return &g, nil
+		}
+	}
+	if len(groups) >= groupScanSafetyCap {
+		p.dependencies.Log.Warn().Str("org_id", orgID).Int("examined", len(groups)).
+			Msg("GetScimGroupByOrgAndDisplayName: hit the scan safety cap without a match")
+	}
+	return nil, gorm.ErrRecordNotFound
 }
 
 // GetScimGroupByOrgAndExternalID resolves the single group with the given

--- a/internal/storage/db/sql/scim_group.go
+++ b/internal/storage/db/sql/scim_group.go
@@ -67,3 +67,15 @@ func (p *provider) GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, d
 	}
 	return &group, nil
 }
+
+// GetScimGroupByOrgAndExternalID resolves the single group with the given
+// externalId within an org. externalId is stored org-namespaced ("<orgID>:<raw>")
+// exactly like User.ExternalID, so this can never resolve another org's group.
+func (p *provider) GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error) {
+	var group schemas.ScimGroup
+	res := p.db.Where("org_id = ? AND external_id = ?", orgID, orgID+":"+externalID).First(&group)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return &group, nil
+}

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -350,6 +350,23 @@ type Provider interface {
 	// DeleteScimEndpoint removes an endpoint.
 	DeleteScimEndpoint(ctx context.Context, endpoint *schemas.ScimEndpoint) error
 
+	// ScimGroup methods (per-org SCIM 2.0 Group metadata; membership lives in FGA).
+
+	// AddScimGroup creates a new SCIM group. DisplayName uniqueness within an org
+	// is enforced by the caller (service layer), not the DB.
+	AddScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error)
+	// GetScimGroupByID fetches a group by primary key.
+	GetScimGroupByID(ctx context.Context, id string) (*schemas.ScimGroup, error)
+	// GetScimGroupByOrgAndDisplayName resolves the single group with the given
+	// displayName in an org — the SCIM `displayName eq` filter and the create
+	// dedup probe. Returns an error when no matching row exists.
+	GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error)
+	// UpdateScimGroup writes back a fully-loaded record (PUT displayName change).
+	// Callers MUST load-then-mutate — Save writes every column.
+	UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error)
+	// DeleteScimGroup removes a group.
+	DeleteScimGroup(ctx context.Context, group *schemas.ScimGroup) error
+
 	// OrgDomain methods (verified domain → org mapping for home-realm discovery).
 
 	// AddOrgDomain atomically inserts a verified domain row, keyed by the

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -361,6 +361,12 @@ type Provider interface {
 	// displayName in an org — the SCIM `displayName eq` filter and the create
 	// dedup probe. Returns an error when no matching row exists.
 	GetScimGroupByOrgAndDisplayName(ctx context.Context, orgID, displayName string) (*schemas.ScimGroup, error)
+	// GetScimGroupByOrgAndExternalID resolves the single group with the given
+	// externalId in an org — the IdP correlation key that lets a renamed group
+	// (same externalId, new displayName) update in place instead of duplicating.
+	// externalID is the raw IdP value; the store namespaces it as "<orgID>:<raw>"
+	// exactly like GetUserByExternalID. Returns an error when no matching row exists.
+	GetScimGroupByOrgAndExternalID(ctx context.Context, orgID, externalID string) (*schemas.ScimGroup, error)
 	// UpdateScimGroup writes back a fully-loaded record (PUT displayName change).
 	// Callers MUST load-then-mutate — Save writes every column.
 	UpdateScimGroup(ctx context.Context, group *schemas.ScimGroup) (*schemas.ScimGroup, error)

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -2049,6 +2049,24 @@ func testScimGroupOperations(t *testing.T, ctx context.Context, provider Provide
 	assert.Error(t, err, "displayName must be a literal, not a regex pattern")
 	require.NoError(t, provider.DeleteScimGroup(ctx, metaGroup))
 
+	// Non-ASCII displayName case-folding must agree across every provider. This
+	// specifically guards against relying on the query engine's own native case
+	// folding (SQL LOWER(), AQL LOWER(), N1QL LOWER()) for the comparison: those
+	// disagree with each other AND with Go's strings.EqualFold on non-ASCII
+	// text (SQLite's LOWER() is ASCII-only, e.g. "CAFÉ" -> "cafÉ", not "café"),
+	// so every provider instead fetches by org and folds with strings.EqualFold
+	// in Go.
+	unicodeName := "CAFÉ"
+	unicodeGroup, err := provider.AddScimGroup(ctx, &schemas.ScimGroup{
+		OrgID:       orgID,
+		DisplayName: unicodeName,
+	})
+	require.NoError(t, err)
+	unicodeByName, err := provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, "café")
+	require.NoError(t, err, "non-ASCII displayName must fold case-insensitively via Go's EqualFold, not the engine's native LOWER()")
+	assert.Equal(t, unicodeGroup.ID, unicodeByName.ID)
+	require.NoError(t, provider.DeleteScimGroup(ctx, unicodeGroup))
+
 	// Cross-org displayName lookup must NOT resolve this org's group.
 	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, "another-org", "Engineers")
 	assert.Error(t, err, "displayName lookup must be org-scoped")

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -2002,10 +2002,12 @@ func testScimGroupOperations(t *testing.T, ctx context.Context, provider Provide
 	})
 	require.NoError(t, err)
 	require.NotNil(t, created)
-	// Bare key is the universal by-id lookup key (arango returns ID as the full
-	// "collection/key" handle; every other provider sets Key == ID == uuid).
-	groupID := created.Key
+	// ID is the portable bare identifier used in URLs and FGA tuples — every
+	// provider (arango included, after the ID==Key==uuid fix) returns it as the
+	// bare uuid that GetScimGroupByID resolves. Use it directly, not created.Key.
+	groupID := created.ID
 	require.NotEmpty(t, groupID)
+	require.Equal(t, created.Key, created.ID, "ID must equal the bare document key on every provider")
 
 	byID, err := provider.GetScimGroupByID(ctx, groupID)
 	require.NoError(t, err)
@@ -2022,6 +2024,18 @@ func testScimGroupOperations(t *testing.T, ctx context.Context, provider Provide
 	// Cross-org displayName lookup must NOT resolve this org's group.
 	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, "another-org", "Engineers")
 	assert.Error(t, err, "displayName lookup must be org-scoped")
+
+	// externalId lookup (the IdP correlation key) resolves the same row. The raw
+	// IdP value is passed; the store namespaces it as "<orgID>:<raw>" internally.
+	byExt, err := provider.GetScimGroupByOrgAndExternalID(ctx, orgID, "ext-grp-1")
+	require.NoError(t, err)
+	assert.Equal(t, byID.OrgID, byExt.OrgID)
+	assert.Equal(t, "Engineers", byExt.DisplayName)
+	assert.Equal(t, groupID, byExt.ID, "externalId lookup must return the bare portable id")
+
+	// Cross-org externalId lookup must NOT resolve this org's group.
+	_, err = provider.GetScimGroupByOrgAndExternalID(ctx, "another-org", "ext-grp-1")
+	assert.Error(t, err, "externalId lookup must be org-scoped")
 
 	// Rename (load-then-mutate) round-trips.
 	byID.DisplayName = "Platform"

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -2021,6 +2021,34 @@ func testScimGroupOperations(t *testing.T, ctx context.Context, provider Provide
 	assert.Equal(t, byID.OrgID, byName.OrgID)
 	assert.Equal(t, "Engineers", byName.DisplayName)
 
+	// displayName is caseExact:false (RFC 7644 §3.4.2.2): the (org,displayName)
+	// lookup MUST match the value case-insensitively on every backend.
+	for _, probe := range []string{"engineers", "ENGINEERS", "eNgInEeRs"} {
+		ci, ciErr := provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, probe)
+		require.NoError(t, ciErr, "case-insensitive displayName lookup must match (%q)", probe)
+		assert.Equal(t, groupID, ci.ID, "case-insensitive lookup must resolve the same group (%q)", probe)
+	}
+	// A genuinely different name must still miss (not a blanket match).
+	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, "Engineering")
+	assert.Error(t, err, "a different displayName must not resolve")
+
+	// A displayName carrying regex/query metacharacters must be compared as a
+	// literal, never interpreted as a pattern (guards the Mongo collation path
+	// and any other engine): look it up case-insensitively by its exact chars.
+	metaName := "R&D (Engineering) [v2]"
+	metaGroup, err := provider.AddScimGroup(ctx, &schemas.ScimGroup{
+		OrgID:       orgID,
+		DisplayName: metaName,
+	})
+	require.NoError(t, err)
+	metaByName, err := provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, "r&d (engineering) [v2]")
+	require.NoError(t, err, "metacharacter displayName must match as a literal, case-insensitively")
+	assert.Equal(t, metaGroup.ID, metaByName.ID)
+	// A regex that WOULD match metaName if interpreted as a pattern must not.
+	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, "R.D .Engineering. .v2.")
+	assert.Error(t, err, "displayName must be a literal, not a regex pattern")
+	require.NoError(t, provider.DeleteScimGroup(ctx, metaGroup))
+
 	// Cross-org displayName lookup must NOT resolve this org's group.
 	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, "another-org", "Engineers")
 	assert.Error(t, err, "displayName lookup must be org-scoped")

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -215,6 +215,9 @@ func TestStorageProvider(t *testing.T) {
 			t.Run("SCIM Endpoint Operations", func(t *testing.T) {
 				testScimEndpointOperations(t, ctx, provider)
 			})
+			t.Run("SCIM Group Operations", func(t *testing.T) {
+				testScimGroupOperations(t, ctx, provider)
+			})
 			t.Run("Org Domain Operations", func(t *testing.T) {
 				testOrgDomainOperations(t, ctx, provider)
 			})
@@ -1976,6 +1979,61 @@ func testScimEndpointOperations(t *testing.T, ctx context.Context, provider Prov
 	require.NoError(t, provider.DeleteScimEndpoint(ctx, afterRotate))
 	_, err = provider.GetScimEndpointByID(ctx, endpointID)
 	assert.Error(t, err, "endpoint should be gone after delete")
+
+	require.NoError(t, provider.DeleteOrganization(ctx, org))
+}
+
+// testScimGroupOperations exercises ScimGroup CRUD: create, id + (org,displayName)
+// lookups, displayName rename round-trip, external-id round-trip, and delete.
+// Membership is NOT stored here (it lives in FGA), so this covers metadata only.
+func testScimGroupOperations(t *testing.T, ctx context.Context, provider Provider) {
+	org, err := provider.AddOrganization(ctx, &schemas.Organization{
+		Name:    "scim-grp-org-" + uuid.New().String(),
+		Enabled: true,
+	})
+	require.NoError(t, err)
+	orgID := org.AsAPIOrganization().ID
+
+	ext := orgID + ":ext-grp-1"
+	created, err := provider.AddScimGroup(ctx, &schemas.ScimGroup{
+		OrgID:       orgID,
+		DisplayName: "Engineers",
+		ExternalID:  &ext,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	// Bare key is the universal by-id lookup key (arango returns ID as the full
+	// "collection/key" handle; every other provider sets Key == ID == uuid).
+	groupID := created.Key
+	require.NotEmpty(t, groupID)
+
+	byID, err := provider.GetScimGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, orgID, byID.OrgID)
+	assert.Equal(t, "Engineers", byID.DisplayName)
+	require.NotNil(t, byID.ExternalID)
+	assert.Equal(t, ext, *byID.ExternalID)
+
+	byName, err := provider.GetScimGroupByOrgAndDisplayName(ctx, orgID, "Engineers")
+	require.NoError(t, err)
+	assert.Equal(t, byID.OrgID, byName.OrgID)
+	assert.Equal(t, "Engineers", byName.DisplayName)
+
+	// Cross-org displayName lookup must NOT resolve this org's group.
+	_, err = provider.GetScimGroupByOrgAndDisplayName(ctx, "another-org", "Engineers")
+	assert.Error(t, err, "displayName lookup must be org-scoped")
+
+	// Rename (load-then-mutate) round-trips.
+	byID.DisplayName = "Platform"
+	_, err = provider.UpdateScimGroup(ctx, byID)
+	require.NoError(t, err)
+	afterRename, err := provider.GetScimGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, "Platform", afterRename.DisplayName)
+
+	require.NoError(t, provider.DeleteScimGroup(ctx, afterRename))
+	_, err = provider.GetScimGroupByID(ctx, groupID)
+	assert.Error(t, err, "group should be gone after delete")
 
 	require.NoError(t, provider.DeleteOrganization(ctx, org))
 }

--- a/internal/storage/schemas/model.go
+++ b/internal/storage/schemas/model.go
@@ -22,6 +22,7 @@ type CollectionList struct {
 	OrgMembership          string
 	FederatedIdentity      string
 	ScimEndpoint           string
+	ScimGroup              string
 	WebauthnCredential     string
 	OrgDomain              string
 	SAMLServiceProvider    string
@@ -53,6 +54,7 @@ var (
 		OrgMembership:          Prefix + "org_memberships",
 		FederatedIdentity:      Prefix + "federated_identities",
 		ScimEndpoint:           Prefix + "scim_endpoints",
+		ScimGroup:              Prefix + "scim_groups",
 		WebauthnCredential:     Prefix + "webauthn_credentials",
 		OrgDomain:              Prefix + "org_domains",
 		SAMLServiceProvider:    Prefix + "saml_service_providers",

--- a/internal/storage/schemas/scim_group.go
+++ b/internal/storage/schemas/scim_group.go
@@ -1,0 +1,39 @@
+package schemas
+
+// ScimGroup is a per-organization SCIM 2.0 Group resource (RFC 7643 §4.2). It
+// carries ONLY the group's identity/metadata — displayName, org namespace,
+// externalId, timestamps. Membership is deliberately NOT a column: per RFC 7643
+// §4.1.2 membership is mutated through the Group resource (PATCH members) and is
+// modelled as OpenFGA relationship tuples (group:<org>/<id>#member@user:<uid>),
+// never as a stored list on the row. This keeps the group→role grant, nested
+// groups, and the SAML group projection all resolvable through the one FGA graph.
+//
+// Org isolation: OrgID namespaces the group. A group is visible/mutable through a
+// SCIM connection only for the org the bearer token resolved to (design §4.4 H6,
+// mirrors ScimEndpoint). DisplayName uniqueness within an org is enforced by the
+// service layer (GetScimGroupByOrgAndDisplayName pre-check), not a DB constraint,
+// so behaviour is identical across all providers.
+//
+// Note: any field addition must also be reflected in the cassandradb provider;
+// it does not use GORM AutoMigrate for collection creation.
+type ScimGroup struct {
+	Key string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB document key
+
+	ID string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+
+	// OrgID is the organization this group belongs to. Indexed (NOT unique): an
+	// org has many groups.
+	OrgID string `gorm:"index" json:"org_id" bson:"org_id" cql:"org_id" dynamo:"org_id" index:"org_id,hash"`
+
+	// DisplayName is the SCIM displayName (RFC 7643 §4.2). Unique within an org
+	// (service-enforced).
+	DisplayName string `json:"display_name" bson:"display_name" cql:"display_name" dynamo:"display_name"`
+
+	// ExternalID is the IdP-side identifier, stored org-namespaced ("<orgID>:<raw>")
+	// exactly like User.ExternalID so one org's connection can never resolve
+	// another org's group by external id (H6). Nullable — some IdPs omit it.
+	ExternalID *string `json:"external_id" bson:"external_id" cql:"external_id" dynamo:"external_id"`
+
+	CreatedAt int64 `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+	UpdatedAt int64 `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}


### PR DESCRIPTION
## Summary

Closes #692 (and the piece of #512 left pending after the SAML IdP work in #691). Bridges three previously-disconnected pieces: SCIM Groups (previously entirely absent — deferred by an explicit code comment), OpenFGA org-namespaced roles, and the SAML IdP's attribute assertions.

- **SCIM Group resource** (`/scim/v2/Groups`, full CRUD + PATCH) implemented across all 13 storage providers. Membership is *not* a column — RFC 7643 §4.1.2 requires membership changes flow through the Group resource, never `User.groups` (read-only), so membership lives entirely as FGA tuples.
- **PATCH member parser** handles RFC 7644 §3.5.2 *and* the real-world Entra/Okta deviations: Entra's capitalized `op` values (`Add`/`Remove`/`Replace`) and its non-RFC `remove` shape (member in `value`, not a filtered `path`) — both verified against vendor docs, not just the RFC text.
- **SCIM → OpenFGA**: group membership as `group:<org>/<id>#member@user:<uid>` tuples; group→role binding via the existing userset-as-subject pattern (`role:<org>/<name>#assignee@group:<org>/<id>#member`) — no engine/SPI changes needed, the engine already supports usersets-as-subjects.
- **SAML IdP group attribute emission**: multi-valued `groups`/`memberOf` SAML attribute (SP-configurable name), sourced through a **cross-tenant containment gate** — two independent checks (FGA object namespace prefix + the authoritative `ScimGroup.OrgID` row), fail-closed on any error, routed strictly through the existing `authorizeSAMLIssuance` chokepoint.
- **Group→role JWT-claim projection**: the two genuinely org-scoped token-mint points (inbound org SSO/SAML SP login) now additively union FGA-derived roles into the `roles` claim, using the same two-gate containment discipline. The org-less native login/signup flows are deliberately left untouched — they have no org context to scope a projection against, and inventing one would be worse than not projecting.

## Security-critical piece — read this before approving

The cross-tenant group/role containment gates are the entire point of this PR. A user who is a legitimate member of a group/role in Org B must **never** have that name appear in an assertion or token issued for Org A — a bare-name SP or downstream consumer checking for `"admins"` would otherwise grant Org-A privilege from an Org-B membership. Both the SAML emitter (`assertedGroupsForOrg`) and the JWT projection (`orgGroupDerivedRoles`) implement this independently with the same two-gate pattern, and both have explicit negative tests proving the exact leak scenario from the issue is blocked. Please scrutinize these two functions specifically.

## Deliberately deferred (not silently dropped)

- **Automatic role↔FGA-tuple dual-write** ("D4" in `openfga-modeling` skill) was already a locked-but-unimplemented decision before this PR — group→role bindings today are written manually via `_fga_write_tuples`, not auto-synced from a role-management UI. This PR doesn't change that state.
- **Cross-org group *nesting*** (an admin explicitly nesting one org's group into another's) is a write-time policy question the emission-side gates don't need to answer — they correctly narrow to the issuing org's namespace regardless — but it's worth a explicit policy decision separately.
- Dashboard's default RBAC model generator doesn't emit the `group` type yet — admins add it via the Advanced DSL editor today. Frontend-only follow-up, not required for this backend feature.

## Test plan
- [x] Unit: PATCH parser vs. RFC shape + both confirmed Entra deviations + Okta filtered-path + no-path form.
- [x] Integration: full SCIM Group CRUD lifecycle; group membership → FGA tuple correctness; **cross-tenant negative test** (Org-B "admins" never appears in an Org-A SAML assertion, and vice versa); **cross-org role-leakage negative test** for the JWT projection; regression proving no-FGA-bindings → byte-identical `roles` claim to pre-PR behavior.
- [x] `make test-all-db` — all 7 DB backends, 31 packages, 0 failures.
- [x] `go vet ./...` clean, `golangci-lint run` 0 issues, `gofmt -s` applied.

DB provider coverage note: SQLite was actually executed throughout development; the other 6 providers were implemented by pattern-matching the existing `scim_endpoint` provider and compile clean — `make test-all-db` (this PR's CI run) is the first time all 7 actually executed together, and it's green.