### PR TITLE
security(auth): trusted base URL + email/SMS OTP lockout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/memory_store"
 	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/oauth"
+	"github.com/authorizerdev/authorizer/internal/parsers"
 	"github.com/authorizerdev/authorizer/internal/rate_limit"
 	"github.com/authorizerdev/authorizer/internal/server"
 	"github.com/authorizerdev/authorizer/internal/service"
@@ -260,6 +261,7 @@ func init() {
 	f.StringSliceVar(&rootArgs.config.RobloxScopes, "roblox-scopes", defaultRobloxScopes, "Scopes for Roblox")
 
 	// URLs
+	f.StringVar(&rootArgs.config.AuthorizerURL, "url", "", "Canonical/trusted base URL of this Authorizer instance (e.g. https://auth.example.com). When set, it is the ONLY source used to build verification/reset/magic-link email URLs, the JWT iss claim, and OIDC discovery URLs; all request headers (X-Authorizer-URL, X-Forwarded-Host, Host) are ignored. Leaving it empty keeps legacy header-based derivation but exposes host-header-injection account takeover (CWE-640) — set this in production")
 	f.StringVar(&rootArgs.config.ResetPasswordURL, "reset-password-url", "", "URL for reset password")
 
 	// Back-channel logout (OIDC BCL 1.0)
@@ -431,6 +433,13 @@ func runRoot(c *cobra.Command, args []string) {
 	// the /app bootstrap all key on the exact same string. Closes the whitespace
 	// edge where a padded --client-id would seed a trimmed row but compare raw.
 	rootArgs.config.ClientID = strings.TrimSpace(rootArgs.config.ClientID)
+
+	// Pin the trusted host used for all self-referential URLs (email links,
+	// JWT iss, OIDC discovery) BEFORE any listener starts. When --url is set,
+	// request headers can no longer control the server's own base URL, closing
+	// the host-header-injection account-takeover class (CWE-640). Empty keeps
+	// the legacy header-based derivation.
+	parsers.SetTrustedURL(rootArgs.config.AuthorizerURL)
 
 	// Storage provider
 	storageProvider, err := storage.New(&rootArgs.config, &storage.Dependencies{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,17 @@ type Config struct {
 	EnforceMFA bool
 
 	// URLs
+	// AuthorizerURL is the operator-configured canonical/trusted base URL of
+	// this Authorizer instance (e.g. https://auth.example.com). When set, it is
+	// the ONLY source used to derive the server's own host — verification /
+	// reset / magic-link email URLs, the JWT `iss` claim, and the OIDC
+	// discovery/JWKS document URLs — and ALL request headers
+	// (X-Authorizer-URL, X-Forwarded-Host, Host) are ignored for that purpose.
+	// Leaving it empty preserves the legacy header-based derivation for
+	// reverse-proxy / multi-tenant setups, but that is exactly what exposes the
+	// host-header-injection account-takeover class (CWE-640); operators SHOULD
+	// set --url in production.
+	AuthorizerURL string
 	// ResetPasswordURL is the URL for reset password
 	ResetPasswordURL string
 

--- a/internal/integration_tests/verify_otp_email_lockout_test.go
+++ b/internal/integration_tests/verify_otp_email_lockout_test.go
@@ -1,0 +1,131 @@
+package integration_tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestVerifyOTPEmailLockout guards the per-user email/SMS OTP verification
+// lockout — the mirror of the TOTP lockout (see verify_otp_totp_lockout_test.go).
+// Five failed attempts within the window lock verification, after which even the
+// correct code is refused with the distinct lockout error (not the generic
+// "invalid otp"), and a successful verification resets the counter.
+//
+// This defends the account against a brute-force that spreads guesses across
+// many IPs to slip under the global per-IP rate limiter — the same threat the
+// TOTP branch already mitigated, previously left open on the email/SMS path.
+func TestVerifyOTPEmailLockout(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableEmailOTP = true
+	cfg.SMTPHost = "localhost"
+	cfg.SMTPPort = 1025
+	cfg.SMTPSenderEmail = "test@authorizer.dev"
+	cfg.SMTPSenderName = "Test"
+	cfg.SMTPLocalName = "Test"
+	cfg.SMTPSkipTLSVerification = true
+	cfg.IsEmailServiceEnabled = true
+	ts := initTestSetup(t, cfg)
+	req, ctx := createContext(ts)
+
+	const otpLockoutCachePrefix = "otp_failed_attempts:"
+	const maxFailedAttempts = 5
+	const knownPlainOTP = "123456"
+
+	mkUser := func(t *testing.T) (*schemas.User, string) {
+		t.Helper()
+		email := "verify_otp_lockout_" + uuid.NewString() + "@authorizer.dev"
+		now := time.Now().Unix()
+		user, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+			Email:           refs.NewStringRef(email),
+			EmailVerifiedAt: &now,
+			SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+		})
+		require.NoError(t, err)
+		return user, email
+	}
+
+	// seedOTP writes a known plaintext/digest OTP row (the suite cannot
+	// intercept the outgoing email, so we plant a code we know).
+	seedOTP := func(t *testing.T, email string) {
+		t.Helper()
+		_, err := ts.StorageProvider.UpsertOTP(ctx, &schemas.OTP{
+			Email:     email,
+			Otp:       crypto.HashOTP(knownPlainOTP, cfg.JWTSecret),
+			ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+		})
+		require.NoError(t, err)
+	}
+
+	armMfaSession := func(userID string) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(userID, mfaSession,
+			constants.MFASessionPurposeVerified,
+			time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+	}
+
+	verify := func(email, otp string) error {
+		_, err := ts.GraphQLProvider.VerifyOTP(ctx, &model.VerifyOTPRequest{
+			Email: &email,
+			Otp:   otp,
+		})
+		return err
+	}
+
+	t.Run("five failures lock verification; a correct code is then refused with a distinct error", func(t *testing.T) {
+		user, email := mkUser(t)
+		seedOTP(t, email)
+
+		// Five failed attempts with a wrong code — each the generic
+		// invalid-otp rejection, not the lockout error.
+		for i := 0; i < maxFailedAttempts; i++ {
+			armMfaSession(user.ID)
+			err := verify(email, "000000")
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "too many failed attempts",
+				"attempt %d must still be a normal rejection, not a lockout", i+1)
+		}
+
+		// Sixth attempt with the CORRECT code must be refused: the account is
+		// now locked, so the distinct lockout error is returned, not success.
+		armMfaSession(user.ID)
+		err := verify(email, knownPlainOTP)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many failed attempts",
+			"a correct code offered while locked must return the lockout error")
+	})
+
+	t.Run("successful verification resets the failed-attempt counter", func(t *testing.T) {
+		user, email := mkUser(t)
+		seedOTP(t, email)
+		lockKey := otpLockoutCachePrefix + user.ID
+
+		// Two failed attempts prime the counter.
+		for i := 0; i < 2; i++ {
+			armMfaSession(user.ID)
+			require.Error(t, verify(email, "000000"))
+		}
+		counter, err := ts.MemoryStoreProvider.GetCache(lockKey)
+		require.NoError(t, err)
+		assert.Equal(t, "2", counter, "two failures must be recorded")
+
+		// A successful verification must clear the counter.
+		armMfaSession(user.ID)
+		require.NoError(t, verify(email, knownPlainOTP))
+
+		counter, err = ts.MemoryStoreProvider.GetCache(lockKey)
+		require.NoError(t, err)
+		assert.Empty(t, counter, "a successful verification must reset the failed-attempt counter")
+	})
+}

--- a/internal/parsers/url.go
+++ b/internal/parsers/url.go
@@ -15,11 +15,36 @@ func GetHost(c *gin.Context) string {
 	return GetHostFromRequest(c.Request)
 }
 
+// trustedURL, when non-empty, is the operator-configured canonical base URL
+// (--url). It is set ONCE at startup via SetTrustedURL, before any listener
+// accepts a connection, so no lock is needed: the write happens-before every
+// concurrent read. When set, ALL request headers are ignored for host
+// derivation, closing the host-header-injection account-takeover class
+// (CWE-640). When empty (default) the legacy header-based derivation below is
+// used, preserving reverse-proxy / multi-tenant deployments — operators SHOULD
+// set --url; omitting it is what leaves this attack surface open.
+// ponytail: set-once-at-startup global; a mutex/atomic would only matter if we
+// ever reconfigured this at runtime, which we don't.
+var trustedURL string
+
+// SetTrustedURL records the operator-configured canonical base URL. Called once
+// from cmd/root at startup. The value is normalized to scheme+host (path,
+// query, fragment, userinfo and trailing slash stripped) so it is a valid,
+// consistent issuer; an unparsable/invalid value is treated as unset, keeping
+// the legacy header-based behavior rather than emitting a broken host.
+func SetTrustedURL(u string) {
+	trustedURL = sanitizeAuthorizerURL(strings.TrimSpace(u))
+}
+
 // GetHostFromRequest returns the authorizer host URL from a raw *http.Request.
-// Priority: X-Authorizer-URL header, then scheme (X-Forwarded-Proto) + host
+// When a trusted URL is configured (--url), it wins over every request header.
+// Otherwise: X-Authorizer-URL header, then scheme (X-Forwarded-Proto) + host
 // (X-Forwarded-Host or Request.Host). Headers are validated to prevent host
 // header injection attacks.
 func GetHostFromRequest(r *http.Request) string {
+	if trustedURL != "" {
+		return trustedURL
+	}
 	authorizerURL := strings.TrimSpace(r.Header.Get("X-Authorizer-URL"))
 	if authorizerURL != "" {
 		if sanitized := sanitizeAuthorizerURL(authorizerURL); sanitized != "" {

--- a/internal/parsers/url_test.go
+++ b/internal/parsers/url_test.go
@@ -129,3 +129,50 @@ func TestGetAppURLFromRequest(t *testing.T) {
 	r := &http.Request{Host: "auth.example.com", Header: http.Header{}}
 	assert.Equal(t, "http://auth.example.com/app", GetAppURLFromRequest(r))
 }
+
+// TestGetHostFromRequestTrustedURL is the regression guard for the
+// host-header-injection account-takeover fix (CWE-640): when --url is
+// configured, no request header may control the server's own base URL, and
+// when it is NOT configured the legacy header-based behavior is unchanged.
+func TestGetHostFromRequestTrustedURL(t *testing.T) {
+	// Every attacker-controllable host source points at evil.com.
+	spoofed := func() *http.Request {
+		r := &http.Request{Host: "evil.example.com", Header: http.Header{}}
+		r.Header.Set("X-Authorizer-URL", "https://evil.example.com")
+		r.Header.Set("X-Forwarded-Proto", "https")
+		r.Header.Set("X-Forwarded-Host", "evil.example.com")
+		return r
+	}
+
+	t.Run("trusted URL overrides every spoofed header", func(t *testing.T) {
+		SetTrustedURL("https://auth.example.com")
+		defer SetTrustedURL("")
+
+		assert.Equal(t, "https://auth.example.com", GetHostFromRequest(spoofed()),
+			"a configured trusted URL must win over X-Authorizer-URL / X-Forwarded-Host / Host")
+		// The email-link builder rides on the same helper, so the reset/verify/
+		// magic-link URL host is now the trusted host, not the attacker's.
+		assert.Equal(t, "https://auth.example.com/app", GetAppURLFromRequest(spoofed()))
+	})
+
+	t.Run("trusted URL is normalized to scheme+host", func(t *testing.T) {
+		SetTrustedURL("https://auth.example.com/some/path/")
+		defer SetTrustedURL("")
+		assert.Equal(t, "https://auth.example.com", GetHostFromRequest(spoofed()))
+	})
+
+	t.Run("invalid trusted URL is treated as unset (falls back to headers)", func(t *testing.T) {
+		SetTrustedURL("not-a-url")
+		defer SetTrustedURL("")
+		// sanitizeAuthorizerURL rejects it, so header-based derivation resumes.
+		assert.Equal(t, "https://evil.example.com", GetHostFromRequest(spoofed()))
+	})
+
+	t.Run("no regression: header behavior unchanged when trusted URL is unset", func(t *testing.T) {
+		// Explicitly ensure the global is clear (defaults to empty, but be
+		// robust to test ordering).
+		SetTrustedURL("")
+		assert.Equal(t, "https://evil.example.com", GetHostFromRequest(spoofed()),
+			"with no --url configured, the legacy X-Authorizer-URL priority must be preserved")
+	})
+}

--- a/internal/service/verify_otp.go
+++ b/internal/service/verify_otp.go
@@ -32,6 +32,13 @@ const (
 	// in the memory store. This is transient state, deliberately kept out
 	// of the DB schema so no storage provider needs a new column.
 	totpLockoutCachePrefix = "totp_failed_attempts:"
+	// otpLockoutCachePrefix namespaces the per-user email/SMS OTP
+	// failed-attempt counter, mirroring totpLockoutCachePrefix. The email/SMS
+	// OTP branch reuses the TOTP threshold/window policy constants above
+	// (totpMaxFailedAttempts / totpLockoutWindowSeconds) — same brute-force
+	// exposure past the per-IP limiter, same mitigation — but on its own cache
+	// key so the two factors' counters never collide.
+	otpLockoutCachePrefix = "otp_failed_attempts:"
 )
 
 // VerifyOTP verifies a one-time passcode (email/SMS OTP, TOTP, or recovery
@@ -169,6 +176,26 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 			log.Debug().Err(cErr).Msg("Failed to reset totp failed-attempt counter")
 		}
 	} else {
+		// Per-user lockout for email/SMS OTP, identical in shape to the TOTP
+		// branch above: atomically reserve this attempt's slot BEFORE
+		// validating, then check whether it exceeded the budget. Increment-
+		// then-check (not check-then-increment) so concurrent requests get
+		// strictly increasing unique counts and at most totpMaxFailedAttempts
+		// can ever reach validation in a window. The MFA session was already
+		// validated above, so an attacker who only knows the victim's email
+		// cannot reach here to exhaust this counter (no unauthenticated
+		// account-lockout DoS).
+		otpLockKey := otpLockoutCachePrefix + user.ID
+		attempts, incErr := p.MemoryStoreProvider.IncrementCache(otpLockKey, totpLockoutWindowSeconds)
+		if incErr != nil {
+			// A memory-store fault must not be counted as a user failure or
+			// lock out a legitimate user (fail-open, matching the TOTP branch).
+			log.Debug().Err(incErr).Msg("Failed to increment otp failed-attempt counter")
+		} else if attempts > totpMaxFailedAttempts {
+			log.Debug().Int64("attempts", attempts).Msg("OTP verification locked: too many failed attempts")
+			return nil, nil, TooManyRequests(`too many failed attempts, please try again later`)
+		}
+
 		var otp *schemas.OTP
 		if isEmailVerification {
 			otp, err = p.StorageProvider.GetOTPByEmail(ctx, email)
@@ -197,6 +224,10 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 		if expiresIn < 0 {
 			log.Debug().Msg("OTP expired")
 			return nil, nil, InvalidArgument("otp expired")
+		}
+		// Successful verification clears the failed-attempt counter for this user.
+		if cErr := p.MemoryStoreProvider.DeleteCacheByPrefix(otpLockKey); cErr != nil {
+			log.Debug().Err(cErr).Msg("Failed to reset otp failed-attempt counter")
 		}
 		if err := p.StorageProvider.DeleteOTP(ctx, otp); err != nil {
 			log.Debug().Err(err).Msg("Failed to delete otp")


### PR DESCRIPTION
## Why
`GetHostFromRequest` derived the server's own base URL from attacker-controlled
headers (`X-Authorizer-URL` → `X-Forwarded-Host` → `Host`) with no trusted
fallback. An attacker could set that header on a forgot-password/signup/magic-link
request and have the victim's verification email link point at an attacker-controlled
host while still carrying a live, single-use token — deliverable back to the
attacker, then replayable against the real server (CWE-640, account takeover).

Separately, email/SMS OTP verification had no brute-force lockout, while TOTP
already did.

## What
- New `--url` flag (`config.AuthorizerURL`). When set, it's the single trusted
  source for the server's own URL — email links, JWT `iss`, OIDC discovery all
  flow through the same `parsers.GetHostFromRequest` chokepoint.
- Unset preserves today's header-based behavior (backward compatible);
  operators should set it in production.
- Email/SMS OTP now gets the same per-user lockout TOTP already has.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` — 0 issues
- [x] New: trusted-URL overrides spoofed headers; normalization; unset = no regression
- [x] New: `TestVerifyOTPEmailLockout` (5 failures locks out, success resets)
- [x] `make test` — full SQLite suite green