### PR TITLE
fix(storage): UpdateUsers empty-ids guard + atomic cascade deletes

### DIFF
--- a/internal/storage/db/arangodb/provider.go
+++ b/internal/storage/db/arangodb/provider.go
@@ -112,6 +112,12 @@ func NewProvider(cfg *config.Config, deps *Dependencies) (*provider, error) {
 		Unique: true,
 		Sparse: true,
 	})
+	// Non-unique: external_id is empty for non-provisioned users and is
+	// namespaced "<orgID>:<externalID>". Backs GetUserByExternalID on every
+	// SCIM/SSO lookup so it does not full-scan the collection.
+	_, _, _ = userCollection.EnsureHashIndex(ctx, []string{"external_id"}, &arangoDriver.EnsureHashIndexOptions{
+		Sparse: true,
+	})
 
 	verificationRequestCollectionExists, err := arangodb.CollectionExists(ctx, schemas.Collections.VerificationRequest)
 	if err != nil {

--- a/internal/storage/db/arangodb/user.go
+++ b/internal/storage/db/arangodb/user.go
@@ -218,21 +218,20 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, e
 	return user, nil
 }
 
-// UpdateUsers to update multiple users, with parameters of user IDs slice
-// If ids set to nil / empty all the users will be updated
+// UpdateUsers updates the users identified by ids. An empty ids slice is
+// rejected with schemas.ErrUpdateUsersEmptyIDs — global updates are disabled so
+// a missing filter can never mutate every user row.
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {
+	if len(ids) == 0 {
+		return schemas.ErrUpdateUsersEmptyIDs
+	}
 	// set updated_at time for all users
 	data["updated_at"] = time.Now().Unix()
 	bindVars := map[string]interface{}{
 		"data": data,
+		"ids":  ids,
 	}
-	query := ""
-	if len(ids) > 0 {
-		bindVars["ids"] = ids
-		query = fmt.Sprintf("FOR u IN %s FILTER u._id IN @ids UPDATE u._key WITH @data IN %s", schemas.Collections.User, schemas.Collections.User)
-	} else {
-		query = fmt.Sprintf("FOR u IN %s UPDATE u._key WITH @data IN %s", schemas.Collections.User, schemas.Collections.User)
-	}
+	query := fmt.Sprintf("FOR u IN %s FILTER u._id IN @ids UPDATE u._key WITH @data IN %s", schemas.Collections.User, schemas.Collections.User)
 	_, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {
 		return err

--- a/internal/storage/db/arangodb/user_update_users_test.go
+++ b/internal/storage/db/arangodb/user_update_users_test.go
@@ -1,0 +1,22 @@
+package arangodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestUpdateUsersRejectsEmptyIDs proves UpdateUsers refuses an empty ids slice
+// with schemas.ErrUpdateUsersEmptyIDs instead of silently updating every user
+// row. The guard returns before any DB access, so no live connection is required.
+func TestUpdateUsersRejectsEmptyIDs(t *testing.T) {
+	p := &provider{}
+	for _, ids := range [][]string{nil, {}} {
+		err := p.UpdateUsers(context.Background(), map[string]interface{}{"given_name": "x"}, ids)
+		if !errors.Is(err, schemas.ErrUpdateUsersEmptyIDs) {
+			t.Fatalf("UpdateUsers(ids=%v) must return ErrUpdateUsersEmptyIDs, got: %v", ids, err)
+		}
+	}
+}

--- a/internal/storage/db/cassandradb/user.go
+++ b/internal/storage/db/cassandradb/user.go
@@ -243,9 +243,13 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, e
 	return &user, nil
 }
 
-// UpdateUsers to update multiple users, with parameters of user IDs slice
-// If ids set to nil / empty all the users will be updated
+// UpdateUsers updates the users identified by ids. An empty ids slice is
+// rejected with schemas.ErrUpdateUsersEmptyIDs — global updates are disabled so
+// a missing filter can never mutate every user row.
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {
+	if len(ids) == 0 {
+		return schemas.ErrUpdateUsersEmptyIDs
+	}
 	// set updated_at time for all users
 	data["updated_at"] = time.Now().Unix()
 	convertMapValues(data)
@@ -272,39 +276,14 @@ func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{},
 	updateFields = strings.Trim(updateFields, " ")
 	updateFields = strings.TrimSuffix(updateFields, ",")
 
-	if len(ids) > 0 {
-		for _, id := range ids {
-			vals := make([]interface{}, len(updateValues))
-			copy(vals, updateValues)
-			vals = append(vals, id)
-			query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.User, updateFields)
-			err := p.db.Query(query, vals...).Exec()
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		// get all ids
-		getUserIDsQuery := fmt.Sprintf(`SELECT id FROM %s`, KeySpace+"."+schemas.Collections.User)
-		scanner := p.db.Query(getUserIDsQuery).Iter().Scanner()
-		var allIDs []string
-		for scanner.Next() {
-			var id string
-			err := scanner.Scan(&id)
-			if err == nil {
-				allIDs = append(allIDs, id)
-			}
-		}
-
-		for _, id := range allIDs {
-			vals := make([]interface{}, len(updateValues))
-			copy(vals, updateValues)
-			vals = append(vals, id)
-			query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.User, updateFields)
-			err := p.db.Query(query, vals...).Exec()
-			if err != nil {
-				return err
-			}
+	for _, id := range ids {
+		vals := make([]interface{}, len(updateValues))
+		copy(vals, updateValues)
+		vals = append(vals, id)
+		query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", KeySpace+"."+schemas.Collections.User, updateFields)
+		err := p.db.Query(query, vals...).Exec()
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/storage/db/cassandradb/user_update_users_test.go
+++ b/internal/storage/db/cassandradb/user_update_users_test.go
@@ -1,0 +1,22 @@
+package cassandradb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestUpdateUsersRejectsEmptyIDs proves UpdateUsers refuses an empty ids slice
+// with schemas.ErrUpdateUsersEmptyIDs instead of silently updating every user
+// row. The guard returns before any DB access, so no live connection is required.
+func TestUpdateUsersRejectsEmptyIDs(t *testing.T) {
+	p := &provider{}
+	for _, ids := range [][]string{nil, {}} {
+		err := p.UpdateUsers(context.Background(), map[string]interface{}{"given_name": "x"}, ids)
+		if !errors.Is(err, schemas.ErrUpdateUsersEmptyIDs) {
+			t.Fatalf("UpdateUsers(ids=%v) must return ErrUpdateUsersEmptyIDs, got: %v", ids, err)
+		}
+	}
+}

--- a/internal/storage/db/couchbase/provider.go
+++ b/internal/storage/db/couchbase/provider.go
@@ -235,7 +235,10 @@ func getIndex(scopeName string) map[string][]string {
 	// User Index
 	userIndex1 := fmt.Sprintf("CREATE INDEX userEmailIndex ON %s.%s(email)", scopeName, schemas.Collections.User)
 	userIndex2 := fmt.Sprintf("CREATE INDEX userPhoneIndex ON %s.%s(phone_number)", scopeName, schemas.Collections.User)
-	indices[schemas.Collections.User] = []string{userIndex1, userIndex2}
+	// Backs GetUserByExternalID on every SCIM/SSO lookup so it does not
+	// full-scan the collection.
+	userIndex3 := fmt.Sprintf("CREATE INDEX userExternalIDIndex ON %s.%s(external_id)", scopeName, schemas.Collections.User)
+	indices[schemas.Collections.User] = []string{userIndex1, userIndex2, userIndex3}
 
 	// VerificationRequest
 	verificationIndex1 := fmt.Sprintf("CREATE INDEX verificationRequestTokenIndex ON %s.%s(token)", scopeName, schemas.Collections.VerificationRequest)

--- a/internal/storage/db/couchbase/user.go
+++ b/internal/storage/db/couchbase/user.go
@@ -221,28 +221,20 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, e
 	return user, nil
 }
 
-// UpdateUsers to update multiple users, with parameters of user IDs slice
-// If ids set to nil / empty all the users will be updated
+// UpdateUsers updates the users identified by ids. An empty ids slice is
+// rejected with schemas.ErrUpdateUsersEmptyIDs — global updates are disabled so
+// a missing filter can never mutate every user row.
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {
+	if len(ids) == 0 {
+		return schemas.ErrUpdateUsersEmptyIDs
+	}
 	// set updated_at time for all users
 	data["updated_at"] = time.Now().Unix()
 	updateFields, params := GetSetFields(data)
-	if len(ids) > 0 {
-		for _, id := range ids {
-			params["id"] = id
-			userQuery := fmt.Sprintf("UPDATE %s.%s SET %s WHERE _id = $id", p.scopeName, schemas.Collections.User, updateFields)
+	for _, id := range ids {
+		params["id"] = id
+		userQuery := fmt.Sprintf("UPDATE %s.%s SET %s WHERE _id = $id", p.scopeName, schemas.Collections.User, updateFields)
 
-			_, err := p.db.Query(userQuery, &gocb.QueryOptions{
-				ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
-				Context:         ctx,
-				NamedParameters: params,
-			})
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		userQuery := fmt.Sprintf("UPDATE %s.%s SET %s WHERE _id IS NOT NULL", p.scopeName, schemas.Collections.User, updateFields)
 		_, err := p.db.Query(userQuery, &gocb.QueryOptions{
 			ScanConsistency: gocb.QueryScanConsistencyRequestPlus,
 			Context:         ctx,

--- a/internal/storage/db/couchbase/user_update_users_test.go
+++ b/internal/storage/db/couchbase/user_update_users_test.go
@@ -1,0 +1,22 @@
+package couchbase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestUpdateUsersRejectsEmptyIDs proves UpdateUsers refuses an empty ids slice
+// with schemas.ErrUpdateUsersEmptyIDs instead of silently updating every user
+// row. The guard returns before any DB access, so no live connection is required.
+func TestUpdateUsersRejectsEmptyIDs(t *testing.T) {
+	p := &provider{}
+	for _, ids := range [][]string{nil, {}} {
+		err := p.UpdateUsers(context.Background(), map[string]interface{}{"given_name": "x"}, ids)
+		if !errors.Is(err, schemas.ErrUpdateUsersEmptyIDs) {
+			t.Fatalf("UpdateUsers(ids=%v) must return ErrUpdateUsersEmptyIDs, got: %v", ids, err)
+		}
+	}
+}

--- a/internal/storage/db/dynamodb/user.go
+++ b/internal/storage/db/dynamodb/user.go
@@ -278,32 +278,20 @@ func (p *provider) GetUserByID(ctx context.Context, id string) (*schemas.User, e
 	return &user, nil
 }
 
-// UpdateUsers to update multiple users, with parameters of user IDs slice
+// UpdateUsers updates the users identified by ids. An empty ids slice is
+// rejected with schemas.ErrUpdateUsersEmptyIDs — global updates are disabled so
+// a missing filter can never mutate every user row.
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {
+	if len(ids) == 0 {
+		return schemas.ErrUpdateUsersEmptyIDs
+	}
 	var res int64
 	var err error
-	if len(ids) > 0 {
-		for _, v := range ids {
-			err = p.updateByHashKey(ctx, schemas.Collections.User, "id", v, data)
+	for _, v := range ids {
+		if err = p.updateByHashKey(ctx, schemas.Collections.User, "id", v, data); err != nil {
+			return err
 		}
-	} else {
-		items, errScan := p.scanAllRaw(ctx, schemas.Collections.User, nil, nil)
-		if errScan != nil {
-			return errScan
-		}
-		for _, it := range items {
-			var user schemas.User
-			if err := unmarshalItem(it, &user); err != nil {
-				return err
-			}
-			err = p.updateByHashKey(ctx, schemas.Collections.User, "id", user.ID, data)
-			if err == nil {
-				res++
-			}
-		}
-	}
-	if err != nil {
-		return err
+		res++
 	}
 	p.dependencies.Log.Info().Int64("modified_count", res).Msg("users updated")
 	return nil

--- a/internal/storage/db/dynamodb/user_update_users_test.go
+++ b/internal/storage/db/dynamodb/user_update_users_test.go
@@ -1,0 +1,22 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestUpdateUsersRejectsEmptyIDs proves UpdateUsers refuses an empty ids slice
+// with schemas.ErrUpdateUsersEmptyIDs instead of silently updating every user
+// row. The guard returns before any DB access, so no live connection is required.
+func TestUpdateUsersRejectsEmptyIDs(t *testing.T) {
+	p := &provider{}
+	for _, ids := range [][]string{nil, {}} {
+		err := p.UpdateUsers(context.Background(), map[string]interface{}{"given_name": "x"}, ids)
+		if !errors.Is(err, schemas.ErrUpdateUsersEmptyIDs) {
+			t.Fatalf("UpdateUsers(ids=%v) must return ErrUpdateUsersEmptyIDs, got: %v", ids, err)
+		}
+	}
+}

--- a/internal/storage/db/mongodb/provider.go
+++ b/internal/storage/db/mongodb/provider.go
@@ -64,6 +64,16 @@ func NewProvider(config *config.Config, deps *Dependencies) (*provider, error) {
 			}),
 		},
 	}, options.CreateIndexes())
+	// external_id index is created in its own call, NOT merged into the batch
+	// above: MongoDB's createIndexes command is all-or-nothing, and that batch can
+	// fail as a whole on some specs, which would silently take this index down
+	// with it. Non-unique because external_id is empty for non-provisioned users
+	// and namespaced "<orgID>:<externalID>". Backs GetUserByExternalID on every
+	// SCIM/SSO lookup so it does not full-scan the collection.
+	_, _ = userCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.M{"external_id": 1},
+		Options: options.Index().SetSparse(true),
+	}, options.CreateIndexes())
 	_ = mongodb.CreateCollection(ctx, schemas.Collections.VerificationRequest, options.CreateCollection())
 	verificationRequestCollection := mongodb.Collection(schemas.Collections.VerificationRequest, options.Collection())
 	if _, err := verificationRequestCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{

--- a/internal/storage/db/mongodb/user.go
+++ b/internal/storage/db/mongodb/user.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
@@ -154,24 +153,21 @@ func (p *provider) GetUserByExternalID(ctx context.Context, orgID, externalID st
 	return user, nil
 }
 
-// UpdateUsers to update multiple users, with parameters of user IDs slice
-// If ids set to nil / empty all the users will be updated
+// UpdateUsers updates the users identified by ids. An empty ids slice is
+// rejected with schemas.ErrUpdateUsersEmptyIDs — global updates are disabled so
+// a missing filter can never mutate every user row.
 func (p *provider) UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error {
+	if len(ids) == 0 {
+		return schemas.ErrUpdateUsersEmptyIDs
+	}
 	// set updated_at time for all users
 	data["updated_at"] = time.Now().Unix()
 	userCollection := p.db.Collection(schemas.Collections.User, options.Collection())
-	var res *mongo.UpdateResult
-	var err error
-	if len(ids) > 0 {
-		res, err = userCollection.UpdateMany(ctx, bson.M{"_id": bson.M{"$in": ids}}, bson.M{"$set": data})
-	} else {
-		res, err = userCollection.UpdateMany(ctx, bson.M{}, bson.M{"$set": data})
-	}
+	res, err := userCollection.UpdateMany(ctx, bson.M{"_id": bson.M{"$in": ids}}, bson.M{"$set": data})
 	if err != nil {
 		return err
-	} else {
-		p.dependencies.Log.Info().Int64("modified_count", res.ModifiedCount).Msg("users updated")
 	}
+	p.dependencies.Log.Info().Int64("modified_count", res.ModifiedCount).Msg("users updated")
 	return nil
 }
 

--- a/internal/storage/db/mongodb/user_update_users_test.go
+++ b/internal/storage/db/mongodb/user_update_users_test.go
@@ -1,0 +1,22 @@
+package mongodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestUpdateUsersRejectsEmptyIDs proves UpdateUsers refuses an empty ids slice
+// with schemas.ErrUpdateUsersEmptyIDs instead of silently updating every user
+// row. The guard returns before any DB access, so no live connection is required.
+func TestUpdateUsersRejectsEmptyIDs(t *testing.T) {
+	p := &provider{}
+	for _, ids := range [][]string{nil, {}} {
+		err := p.UpdateUsers(context.Background(), map[string]interface{}{"given_name": "x"}, ids)
+		if !errors.Is(err, schemas.ErrUpdateUsersEmptyIDs) {
+			t.Fatalf("UpdateUsers(ids=%v) must return ErrUpdateUsersEmptyIDs, got: %v", ids, err)
+		}
+	}
+}

--- a/internal/storage/db/sql/cascade_delete_test.go
+++ b/internal/storage/db/sql/cascade_delete_test.go
@@ -1,0 +1,50 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// TestDeleteWebhookAtomicRollback proves the cascade delete in DeleteWebhook runs
+// inside a single transaction: when the second step (deleting webhook_logs) fails,
+// the first step (deleting the webhook row) is rolled back rather than committed
+// on its own. It exercises the same p.db.WithContext(ctx).Transaction pattern
+// shared by DeleteClient, DeleteOrganization and DeleteUser — before the fix the
+// first delete auto-committed and left the row lost when the second step errored.
+func TestDeleteWebhookAtomicRollback(t *testing.T) {
+	for _, dbType := range sqlMigrationTestDBTypes() {
+		t.Run(dbType, func(t *testing.T) {
+			cfg := sqlMigrationTestConfig(t, dbType)
+			p, err := NewProvider(cfg, sqlTestDeps(t))
+			require.NoError(t, err)
+			defer func() { _ = p.Close() }()
+
+			ctx := context.Background()
+
+			wh, err := p.AddWebhook(ctx, &schemas.Webhook{
+				EventName: "user.access.granted",
+				EndPoint:  "https://example.com/hook",
+			})
+			require.NoError(t, err)
+
+			// Force the SECOND cascade step to fail deterministically by removing
+			// the webhook_logs table. With no transaction the first delete would
+			// already be committed and the webhook row lost.
+			require.NoError(t, p.db.Migrator().DropTable(&schemas.WebhookLog{}))
+
+			err = p.DeleteWebhook(ctx, wh)
+			require.Error(t, err, "delete must fail when the second cascade step errors")
+
+			// Atomicity: the webhook row survived because the whole cascade rolled back.
+			got, err := p.GetWebhookByID(ctx, wh.ID)
+			require.NoError(t, err, "webhook must still exist after the cascade rolled back")
+			require.NotNil(t, got)
+			assert.Equal(t, wh.ID, got.ID)
+		})
+	}
+}

--- a/internal/storage/db/sql/client.go
+++ b/internal/storage/db/sql/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
@@ -47,12 +48,15 @@ func (p *provider) UpdateClient(ctx context.Context, sa *schemas.Client) (*schem
 }
 
 // DeleteClient removes a service account and all its associated
-// TrustedIssuers. Mirrors the webhook cascade-delete pattern.
+// TrustedIssuers. Mirrors the webhook cascade-delete pattern. Both deletes run
+// in a single transaction so a failure cannot orphan trusted issuers.
 func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
-	if err := p.db.Where("client_id = ?", sa.ID).Delete(&schemas.TrustedIssuer{}).Error; err != nil {
-		return err
-	}
-	return p.db.Delete(sa).Error
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("client_id = ?", sa.ID).Delete(&schemas.TrustedIssuer{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(sa).Error
+	})
 }
 
 // GetClientByID fetches a service account by primary key.

--- a/internal/storage/db/sql/organization.go
+++ b/internal/storage/db/sql/organization.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
@@ -44,17 +45,21 @@ func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organiza
 }
 
 // DeleteOrganization removes an organization and all its memberships.
-// Mirrors the DeleteClient cascade-delete pattern.
+// Mirrors the DeleteClient cascade-delete pattern. The whole cascade runs in a
+// single transaction so a mid-cascade failure cannot orphan memberships or
+// domains.
 func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
-	if err := p.db.Where("org_id = ?", org.ID).Delete(&schemas.OrgMembership{}).Error; err != nil {
-		return err
-	}
-	// Cascade verified domains — otherwise the domain becomes permanently
-	// unclaimable (it is the unique PK of org_domains).
-	if err := p.DeleteOrgDomainsByOrg(ctx, org.ID); err != nil {
-		return err
-	}
-	return p.db.Delete(org).Error
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("org_id = ?", org.ID).Delete(&schemas.OrgMembership{}).Error; err != nil {
+			return err
+		}
+		// Cascade verified domains — otherwise the domain becomes permanently
+		// unclaimable (it is the unique PK of org_domains).
+		if err := tx.Where("org_id = ?", org.ID).Delete(&schemas.OrgDomain{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(org).Error
+	})
 }
 
 // GetOrganizationByID fetches an organization by primary key.

--- a/internal/storage/db/sql/user.go
+++ b/internal/storage/db/sql/user.go
@@ -75,17 +75,14 @@ func (p *provider) UpdateUser(ctx context.Context, user *schemas.User) (*schemas
 
 // DeleteUser to delete user information from database
 func (p *provider) DeleteUser(ctx context.Context, user *schemas.User) error {
-	result := p.db.Where("user_id = ?", user.ID).Delete(&schemas.Session{})
-	if result.Error != nil {
-		return result.Error
-	}
-
-	result = p.db.Delete(&user)
-	if result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	// Delete the user and their sessions atomically so a failure cannot leave
+	// orphaned session rows behind.
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", user.ID).Delete(&schemas.Session{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&user).Error
+	})
 }
 
 // ListUsers to get list of users from database. When query is non-empty it is

--- a/internal/storage/db/sql/webhook.go
+++ b/internal/storage/db/sql/webhook.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
@@ -84,16 +85,12 @@ func (p *provider) GetWebhookByEventName(ctx context.Context, eventName string) 
 
 // DeleteWebhook to delete webhook
 func (p *provider) DeleteWebhook(ctx context.Context, webhook *schemas.Webhook) error {
-	result := p.db.Delete(&schemas.Webhook{
-		ID: webhook.ID,
+	// Delete the webhook and its logs atomically so a failure cannot leave
+	// orphaned webhook_logs rows behind.
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&schemas.Webhook{ID: webhook.ID}).Error; err != nil {
+			return err
+		}
+		return tx.Where("webhook_id = ?", webhook.ID).Delete(&schemas.WebhookLog{}).Error
 	})
-	if result.Error != nil {
-		return result.Error
-	}
-
-	result = p.db.Where("webhook_id = ?", webhook.ID).Delete(&schemas.WebhookLog{})
-	if result.Error != nil {
-		return result.Error
-	}
-	return nil
 }

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -53,8 +53,9 @@ type Provider interface {
 	GetUserByExternalID(ctx context.Context, orgID, externalID string) (*schemas.User, error)
 	// UpdateUsers to update multiple users, identified by the ids slice.
 	// If ids is nil / empty NO update is performed: global updates are disabled,
-	// so implementations return an error (SQL: gorm.ErrMissingWhereClause) rather
-	// than silently updating every user.
+	// so implementations return an error rather than silently updating every
+	// user (SQL: gorm.ErrMissingWhereClause; all other backends:
+	// schemas.ErrUpdateUsersEmptyIDs).
 	UpdateUsers(ctx context.Context, data map[string]interface{}, ids []string) error
 
 	// AddVerificationRequest to save verification request in database

--- a/internal/storage/schemas/user.go
+++ b/internal/storage/schemas/user.go
@@ -2,11 +2,18 @@ package schemas
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/refs"
 )
+
+// ErrUpdateUsersEmptyIDs is returned by Provider.UpdateUsers when the ids filter
+// is empty. Global user updates are disabled on every backend: an empty ids slice
+// must never mutate every row. The SQL provider enforces the same contract via
+// GORM's AllowGlobalUpdate:false (which surfaces gorm.ErrMissingWhereClause).
+var ErrUpdateUsersEmptyIDs = errors.New("UpdateUsers: ids must not be empty (global update disabled)")
 
 // Note: any change here should be reflected in providers/casandra/provider.go as it does not have model support in collection creation
 //


### PR DESCRIPTION
## Why
`UpdateUsers` is documented to reject an empty `ids` filter rather than mutate
every row. Only the SQL provider enforced this — MongoDB, ArangoDB, Cassandra,
Couchbase, and DynamoDB (found during this fix) would silently apply the
update to every user in the table. Separately, `DeleteOrganization`/`DeleteClient`
(and `DeleteWebhook`/`DeleteUser`, found during this fix) ran multi-step cascade
deletes with no transaction, risking orphaned rows on partial failure.

## What
- Empty-ids guard added to Mongo/Arango/Cassandra/Couchbase/DynamoDB, matching
  the SQL provider's existing contract.
- `DeleteOrganization`, `DeleteClient`, `DeleteWebhook`, `DeleteUser` cascades
  now wrapped in `Transaction(...)`, using `tx` throughout.
- `external_id` indexed on Mongo/Arango/Couchbase (previously only Cassandra/DynamoDB).

## Known follow-up (not fixed here, flagged for a separate PR)
- MongoDB's existing `email`+`phone_number` index batch silently fails
  (`sparse` + `partialFilterExpression` can't combine) — the unique email
  index has never actually been created on Mongo.
- `internal/storage/db/sql/` never uses `.WithContext(ctx)` (package-wide,
  pre-existing gap, out of scope for a targeted fix).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` — 0 issues
- [x] New empty-ids tests on all 5 backends
- [x] New `TestDeleteWebhookAtomicRollback` (forces mid-cascade failure, asserts rollback)
- [x] `make test` (SQLite) — green
- [x] Live MongoDB container run — `TestStorageProvider` + index verified via `getIndexes()`
- [ ] Arango/Cassandra/Couchbase/DynamoDB only verified via no-DB unit tests (guard
      returns pre-DB) — recommend `make test-all-db` before merge