### PR TITLE
fix(grpc): type admin service errors, tighten public-method bypass

### DIFF
--- a/internal/grpcsrv/interceptors/auth.go
+++ b/internal/grpcsrv/interceptors/auth.go
@@ -24,6 +24,11 @@ const (
 	adminServiceName  = "authorizer.v1.AuthorizerAdminService"
 	publicServiceName = "authorizer.v1.AuthorizerService"
 	sessionMethodName = "Session"
+	// adminLoginMethodName is the ONLY AuthorizerAdminService RPC allowed to be
+	// reached without super-admin auth: it establishes that auth. Every other
+	// admin RPC marked `public` is a mistake and must still require super-admin
+	// (see the bypass guard in Auth).
+	adminLoginMethodName = "AdminLogin"
 )
 
 // infrastructureServices are gRPC surfaces registered alongside Authorizer that
@@ -51,7 +56,16 @@ func Auth(tp token.Provider) grpc.UnaryServerInterceptor {
 		if shouldRejectUnlistedService(serviceName) {
 			return nil, status.Error(codes.Unauthenticated, "unauthorized")
 		}
-		if isPublicMethod(methodDesc) {
+		// The `public` proto annotation grants no-auth access. Honor it for the
+		// public service's methods and for the admin auth-bootstrap RPC
+		// (AdminLogin), which must be reachable before super-admin auth exists.
+		// Any OTHER AuthorizerAdminService method mistakenly marked `public`
+		// must NOT skip admin auth — it falls through to the super-admin check
+		// below (mirroring the Session RPC's explicit service guard, closing the
+		// latent footgun where a future admin RPC is accidentally made public).
+		if isPublicMethod(methodDesc) &&
+			(serviceName == publicServiceName ||
+				(serviceName == adminServiceName && string(methodDesc.Name()) == adminLoginMethodName)) {
 			return handler(ctx, req)
 		}
 		if tp == nil {

--- a/internal/grpcsrv/interceptors/auth_test.go
+++ b/internal/grpcsrv/interceptors/auth_test.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 
 	authorizerv1 "github.com/authorizerdev/authorizer/gen/go/authorizer/v1"
 	"github.com/authorizerdev/authorizer/internal/authctx"
@@ -226,6 +228,48 @@ func TestAuth_LogoutRequiresAuth(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 	assert.False(t, called)
+}
+
+// TestAuth_AdminLoginRemainsPublic guards the auth-bootstrap exception: the
+// AdminLogin RPC establishes super-admin auth, so it MUST stay reachable without
+// it. Regression guard that scoping the `public` bypass did not lock admins out.
+func TestAuth_AdminLoginRemainsPublic(t *testing.T) {
+	stub := &stubTokenProvider{superAdmin: false}
+	mw := Auth(stub)
+	called := false
+	_, err := mw(context.Background(), &authorizerv1.AdminLoginRequest{}, info(authorizerv1.AuthorizerAdminService_AdminLogin_FullMethodName), func(ctx context.Context, _ any) (any, error) {
+		called = true
+		_, ok := authctx.FromContext(ctx)
+		assert.False(t, ok, "the public bootstrap login must not attach a principal")
+		return &authorizerv1.AdminLoginResponse{}, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called, "AdminLogin must bypass auth (it establishes it)")
+	assert.Equal(t, 0, stub.superAdminChecks, "AdminLogin must not require a pre-existing super-admin")
+}
+
+// TestAuth_OnlyAdminLoginIsPublicOnAdminService is the two-layer defense against
+// the latent footgun: (1) the interceptor guard honors `public` on the admin
+// service only for AdminLogin (see Auth), and (2) this invariant ensures no
+// OTHER admin RPC carries `public` in the proto. If a future admin mutation is
+// accidentally annotated public, this fails — and even if it merged, the
+// interceptor guard would still deny it (falling through to the super-admin
+// check), because adminLoginMethodName is an exact allowlist of one.
+func TestAuth_OnlyAdminLoginIsPublicOnAdminService(t *testing.T) {
+	adminSvc, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(adminServiceName))
+	require.NoError(t, err)
+	svc, ok := adminSvc.(protoreflect.ServiceDescriptor)
+	require.True(t, ok)
+	methods := svc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		if string(m.Name()) == adminLoginMethodName {
+			assert.Truef(t, isPublicMethod(m), "%s is expected to be public (auth bootstrap)", m.Name())
+			continue
+		}
+		assert.Falsef(t, isPublicMethod(m),
+			"admin RPC %s must never be marked public — only %s may bypass super-admin auth", m.Name(), adminLoginMethodName)
+	}
 }
 
 func TestShouldRejectUnlistedService(t *testing.T) {

--- a/internal/grpcsrv/interceptors/errormap.go
+++ b/internal/grpcsrv/interceptors/errormap.go
@@ -14,7 +14,7 @@ import (
 // kindToCode maps a transport-neutral service.ErrorKind onto the gRPC status
 // code. grpc-gateway then derives the REST HTTP status from this code
 // (InvalidArgument->400, Unauthenticated->401, PermissionDenied->403,
-// NotFound->404, FailedPrecondition->400, Internal->500).
+// NotFound->404, FailedPrecondition->400, AlreadyExists->409, Internal->500).
 func kindToCode(kind service.ErrorKind) codes.Code {
 	switch kind {
 	case service.KindInvalidArgument:
@@ -29,6 +29,8 @@ func kindToCode(kind service.ErrorKind) codes.Code {
 		return codes.FailedPrecondition
 	case service.KindTooManyRequests:
 		return codes.ResourceExhausted
+	case service.KindAlreadyExists:
+		return codes.AlreadyExists
 	default:
 		return codes.Internal
 	}

--- a/internal/grpcsrv/interceptors/errormap_test.go
+++ b/internal/grpcsrv/interceptors/errormap_test.go
@@ -1,0 +1,94 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/authorizerdev/authorizer/internal/service"
+)
+
+// runErrorMap feeds handlerErr through the ErrorMap interceptor and returns the
+// mapped error, exactly as a gRPC/REST client would receive it.
+func runErrorMap(t *testing.T, handlerErr error) error {
+	t.Helper()
+	mw := ErrorMap()
+	_, err := mw(context.Background(), nil, info("/authorizer.v1.AuthorizerAdminService/CreateOrganization"), func(_ context.Context, _ any) (any, error) {
+		return nil, handlerErr
+	})
+	return err
+}
+
+// TestErrorMap_KindToCode locks the transport-neutral Kind -> gRPC code mapping,
+// including the newly-added AlreadyExists -> codes.AlreadyExists (HTTP 409).
+func TestErrorMap_KindToCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"invalid argument", service.InvalidArgument("name is required"), codes.InvalidArgument},
+		{"already exists", service.AlreadyExists("an organization with this name already exists"), codes.AlreadyExists},
+		{"not found", service.NotFound("organization not found"), codes.NotFound},
+		{"failed precondition", service.FailedPrecondition("email sending is disabled"), codes.FailedPrecondition},
+		{"too many requests", service.TooManyRequests("slow down"), codes.ResourceExhausted},
+		{"unauthenticated", service.Unauthenticated("unauthorized"), codes.Unauthenticated},
+		{"permission denied", service.PermissionDenied("nope"), codes.PermissionDenied},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runErrorMap(t, c.err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "expected a gRPC status error")
+			assert.Equal(t, c.want, st.Code())
+			assert.Equal(t, c.err.Error(), st.Message(), "message text must be preserved verbatim")
+		})
+	}
+}
+
+// TestErrorMap_AlreadyExistsIsNot500 is the regression guard for the previously
+// unimplemented ALREADY_EXISTS contract: a conflict must surface as 409-class
+// AlreadyExists, never as Internal/500.
+func TestErrorMap_AlreadyExistsIsNot500(t *testing.T) {
+	err := runErrorMap(t, service.AlreadyExists("issuer_url already registered: https://idp.example.com"))
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.AlreadyExists, st.Code())
+	assert.NotEqual(t, codes.Internal, st.Code())
+}
+
+// TestErrorMap_WrappedTypedErrorKeepsKind mirrors the admin SAML/OIDC helpers:
+// a typed validation error wrapped with extra field context via %w must still
+// map to InvalidArgument (errors.As reaches the inner Kind), not Internal.
+func TestErrorMap_WrappedTypedErrorKeepsKind(t *testing.T) {
+	wrapped := fmt.Errorf("idp_sso_url %w", service.InvalidArgument("must be a valid https URL"))
+	err := runErrorMap(t, wrapped)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestErrorMap_BareErrorIsInternal confirms unclassified errors (storage
+// failures, secret generation, etc.) remain Internal — the correct default.
+func TestErrorMap_BareErrorIsInternal(t *testing.T) {
+	err := runErrorMap(t, errors.New("failed to store connection"))
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// TestErrorMap_NilPassesThrough confirms the happy path is untouched.
+func TestErrorMap_NilPassesThrough(t *testing.T) {
+	mw := ErrorMap()
+	resp, err := mw(context.Background(), nil, info("/svc/M"), func(_ context.Context, _ any) (any, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}

--- a/internal/http_handlers/graphql.go
+++ b/internal/http_handlers/graphql.go
@@ -49,6 +49,8 @@ func kindToGraphQLCode(kind service.ErrorKind) string {
 		return "FAILED_PRECONDITION"
 	case service.KindTooManyRequests:
 		return "TOO_MANY_REQUESTS"
+	case service.KindAlreadyExists:
+		return "ALREADY_EXISTS"
 	default:
 		return "INTERNAL"
 	}

--- a/internal/service/admin_access.go
+++ b/internal/service/admin_access.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -74,7 +73,7 @@ func (p *provider) EnableAccess(ctx context.Context, meta RequestMetadata, param
 	}
 
 	if params.UserID == "" {
-		return nil, nil, fmt.Errorf("user ID is missing")
+		return nil, nil, InvalidArgument("user ID is missing")
 	}
 
 	log = log.With().Str("user_id", params.UserID).Logger()
@@ -110,6 +109,12 @@ func (p *provider) EnableAccess(ctx context.Context, meta RequestMetadata, param
 	}, nil, nil
 }
 
+// maxInviteMembersBatch caps how many emails a single InviteMembers request may
+// carry. Each email drives sequential DB writes and a goroutine email send, so
+// an unbounded list is a self-inflicted DoS vector; reject oversized batches up
+// front.
+const maxInviteMembersBatch = 100
+
 // InviteMembers creates accounts for the supplied emails that do not yet exist
 // and sends each an invite (magic-link or setup-password) email. Requires
 // super-admin auth and a configured email service. Logic migrated from
@@ -120,17 +125,22 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 		return nil, nil, err
 	}
 
+	if len(params.Emails) > maxInviteMembersBatch {
+		log.Debug().Int("count", len(params.Emails)).Msg("too many emails in a single invite request")
+		return nil, nil, InvalidArgument(fmt.Sprintf("cannot invite more than %d members in a single request", maxInviteMembersBatch))
+	}
+
 	// this feature is only allowed if email server is configured
 	if !p.Config.IsEmailServiceEnabled {
 		log.Debug().Msg("Email sending is disabled")
-		return nil, nil, errors.New("email sending is disabled")
+		return nil, nil, FailedPrecondition("email sending is disabled")
 	}
 
 	isBasicAuthEnabled := p.Config.EnableBasicAuthentication
 	isMagicLinkLoginEnabled := p.Config.EnableMagicLinkLogin
 	if !isBasicAuthEnabled && !isMagicLinkLoginEnabled {
 		log.Debug().Msg("Either basic authentication or magic link login is required")
-		return nil, nil, errors.New("either basic authentication or magic link login is required")
+		return nil, nil, FailedPrecondition("either basic authentication or magic link login is required")
 	}
 
 	// filter valid emails
@@ -143,7 +153,7 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 
 	if len(emails) == 0 {
 		log.Debug().Msg("No valid emails found")
-		return nil, nil, errors.New("no valid emails found")
+		return nil, nil, InvalidArgument("no valid emails found")
 	}
 
 	// TODO: optimise to use like query instead of looping through emails and getting user individually
@@ -161,13 +171,14 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 
 	if len(newEmails) == 0 {
 		log.Debug().Msg("All emails already exist")
-		return nil, nil, errors.New("all emails already exist")
+		return nil, nil, AlreadyExists("all emails already exist")
 	}
 
 	// gin-shim: parsers.GetHost / GetAppURL still take a *gin.Context.
 	gc := &gin.Context{Request: meta.Request}
 
 	// invite new emails
+	invitedUsers := make([]*model.User, 0, len(newEmails))
 	for _, email := range newEmails {
 		user := &schemas.User{
 			Email: refs.NewStringRef(email),
@@ -182,7 +193,7 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 			redirectURL = *params.RedirectURI
 			if !validators.IsValidRedirectURI(redirectURL, p.Config.AllowedOrigins, hostname) {
 				log.Debug().Msg("Invalid redirect URI")
-				return nil, nil, fmt.Errorf("invalid redirect URI")
+				return nil, nil, InvalidArgument("invalid redirect URI")
 			}
 		}
 
@@ -199,7 +210,9 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 		}, redirectURL, constants.VerificationTypeInviteMember)
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to create verification token")
-			// continue to next email
+			// Skip this email: an empty/broken token must never be persisted or
+			// emailed as an invite.
+			continue
 		}
 
 		verificationRequest := &schemas.VerificationRequest{
@@ -238,6 +251,13 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 			return nil, nil, err
 		}
 
+		// AddUser returned the persisted user (with its generated ID) above —
+		// reuse it directly for the response instead of re-fetching every email.
+		invitedUsers = append(invitedUsers, &model.User{
+			Email: user.Email,
+			ID:    user.ID,
+		})
+
 		// exec it as go routine so that we can reduce the api latency
 		go func() {
 			_ = p.EmailProvider.SendEmail([]string{refs.StringValue(user.Email)}, constants.VerificationTypeInviteMember, map[string]interface{}{
@@ -246,19 +266,6 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 				"verification_url": utils.GetInviteVerificationURL(verifyEmailURL, verificationToken, redirectURL),
 			})
 		}()
-	}
-
-	invitedUsers := []*model.User{}
-	for _, email := range newEmails {
-		user, err := p.StorageProvider.GetUserByEmail(ctx, email)
-		if err != nil {
-			log.Debug().Err(err).Msg("Failed to get user by email")
-			return nil, nil, err
-		}
-		invitedUsers = append(invitedUsers, &model.User{
-			Email: user.Email,
-			ID:    user.ID,
-		})
 	}
 
 	p.AuditProvider.LogEvent(audit.Event{
@@ -270,7 +277,7 @@ func (p *provider) InviteMembers(ctx context.Context, meta RequestMetadata, para
 	})
 
 	return &model.InviteMembersResponse{
-		Message: fmt.Sprintf("%d user(s) invited successfully.", len(newEmails)),
+		Message: fmt.Sprintf("%d user(s) invited successfully.", len(invitedUsers)),
 		Users:   invitedUsers,
 	}, nil, nil
 }

--- a/internal/service/admin_access_invite_test.go
+++ b/internal/service/admin_access_invite_test.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/audit"
+	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/email"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+	"github.com/authorizerdev/authorizer/internal/token"
+)
+
+// --- test doubles ---------------------------------------------------------
+//
+// Each embeds the full interface so only the handful of methods InviteMembers /
+// the representative admin methods touch need overriding; any other call panics
+// (nil embedded interface), which is the desired "this test should not reach
+// here" behaviour.
+
+type inviteStorage struct {
+	storage.Provider
+	getUserByEmailCalls  int
+	addUserCalls         int
+	addVerificationCalls int
+	userExists           func(email string) bool
+	getOrgByName         func(name string) *schemas.Organization
+}
+
+func (s *inviteStorage) GetUserByEmail(_ context.Context, email string) (*schemas.User, error) {
+	s.getUserByEmailCalls++
+	if s.userExists != nil && s.userExists(email) {
+		return &schemas.User{ID: "existing-" + email, Email: refs.NewStringRef(email)}, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (s *inviteStorage) AddUser(_ context.Context, u *schemas.User) (*schemas.User, error) {
+	s.addUserCalls++
+	// Emulate the storage layer assigning a persisted id so the test can prove
+	// the response is sourced from AddUser's return value, not a re-fetch.
+	u.ID = "id-" + refs.StringValue(u.Email)
+	return u, nil
+}
+
+func (s *inviteStorage) AddVerificationRequest(_ context.Context, v *schemas.VerificationRequest) (*schemas.VerificationRequest, error) {
+	s.addVerificationCalls++
+	return v, nil
+}
+
+func (s *inviteStorage) GetOrganizationByName(_ context.Context, name string) (*schemas.Organization, error) {
+	if s.getOrgByName != nil {
+		if org := s.getOrgByName(name); org != nil {
+			return org, nil
+		}
+	}
+	return nil, errors.New("organization not found")
+}
+
+type inviteToken struct {
+	token.Provider
+	createVerificationToken func(cfg *token.AuthTokenConfig) (string, error)
+}
+
+func (inviteToken) IsSuperAdmin(_ *gin.Context) bool { return true }
+
+func (tp inviteToken) CreateVerificationToken(cfg *token.AuthTokenConfig, _ string, _ string) (string, error) {
+	if tp.createVerificationToken != nil {
+		return tp.createVerificationToken(cfg)
+	}
+	return "verification-token", nil
+}
+
+type inviteEmail struct{ email.Provider }
+
+func (inviteEmail) SendEmail(_ []string, _ string, _ map[string]interface{}) error { return nil }
+
+type inviteAudit struct{ audit.Provider }
+
+func (inviteAudit) LogEvent(_ audit.Event) {}
+
+func newInviteProvider(cfg *config.Config, st storage.Provider, tp token.Provider) *provider {
+	log := zerolog.Nop()
+	return &provider{
+		Config: cfg,
+		Dependencies: Dependencies{
+			Log:             &log,
+			StorageProvider: st,
+			TokenProvider:   tp,
+			EmailProvider:   inviteEmail{},
+			AuditProvider:   inviteAudit{},
+		},
+	}
+}
+
+func inviteConfig() *config.Config {
+	return &config.Config{
+		IsEmailServiceEnabled:     true,
+		EnableBasicAuthentication: true,
+		EnableMagicLinkLogin:      true,
+		DefaultRoles:              []string{"user"},
+		AllowedOrigins:            []string{"*"},
+	}
+}
+
+func inviteMeta() RequestMetadata {
+	return RequestMetadata{Request: httptest.NewRequest(http.MethodPost, "http://example.com/", nil)}
+}
+
+func requireKind(t *testing.T, err error, want ErrorKind) {
+	t.Helper()
+	require.Error(t, err)
+	var se *Error
+	require.Truef(t, errors.As(err, &se), "error must be a typed *service.Error, got %v", err)
+	assert.Equal(t, want, se.Kind)
+}
+
+// TestInviteMembers_ReusesAddUserResult proves the redundant third loop was
+// removed: GetUserByEmail is called exactly once per email (the existence
+// pre-check), and every response user is sourced from AddUser's returned value.
+func TestInviteMembers_ReusesAddUserResult(t *testing.T) {
+	st := &inviteStorage{} // all emails new
+	p := newInviteProvider(inviteConfig(), st, inviteToken{})
+
+	emails := []string{"a@authorizer.dev", "b@authorizer.dev", "c@authorizer.dev"}
+	res, _, err := p.InviteMembers(context.Background(), inviteMeta(), &model.InviteMemberRequest{Emails: emails})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 3)
+
+	assert.Equal(t, 3, st.getUserByEmailCalls,
+		"GetUserByEmail must run once per email (existence check) — no redundant re-fetch after AddUser")
+	assert.Equal(t, 3, st.addUserCalls)
+	for _, u := range res.Users {
+		// AddUser assigned ID = "id-"+email; a re-fetch path could not have.
+		assert.Equal(t, "id-"+refs.StringValue(u.Email), u.ID)
+	}
+}
+
+// TestInviteMembers_TokenErrorSkipsEmail proves the missing `continue` is fixed:
+// a CreateVerificationToken failure on one email skips that email entirely
+// (no AddUser, no invite) without corrupting or blocking the others.
+func TestInviteMembers_TokenErrorSkipsEmail(t *testing.T) {
+	st := &inviteStorage{}
+	tp := inviteToken{createVerificationToken: func(cfg *token.AuthTokenConfig) (string, error) {
+		if refs.StringValue(cfg.User.Email) == "bad@authorizer.dev" {
+			return "", errors.New("token backend unavailable")
+		}
+		return "ok-token", nil
+	}}
+	p := newInviteProvider(inviteConfig(), st, tp)
+
+	emails := []string{"good1@authorizer.dev", "bad@authorizer.dev", "good2@authorizer.dev"}
+	res, _, err := p.InviteMembers(context.Background(), inviteMeta(), &model.InviteMemberRequest{Emails: emails})
+	require.NoError(t, err, "one email's token failure must not fail the whole request")
+
+	require.Len(t, res.Users, 2, "the failing email must be skipped, not invited with an empty token")
+	assert.Equal(t, 2, st.addUserCalls, "AddUser must not run for the skipped email")
+	assert.Equal(t, 2, st.addVerificationCalls)
+	for _, u := range res.Users {
+		assert.NotEqual(t, "bad@authorizer.dev", refs.StringValue(u.Email))
+	}
+}
+
+// TestInviteMembers_RejectsOversizedBatch proves the batch cap: >100 emails is
+// rejected as InvalidArgument before any storage work happens.
+func TestInviteMembers_RejectsOversizedBatch(t *testing.T) {
+	st := &inviteStorage{}
+	p := newInviteProvider(inviteConfig(), st, inviteToken{})
+
+	emails := make([]string, maxInviteMembersBatch+1)
+	for i := range emails {
+		emails[i] = fmt.Sprintf("u%d@authorizer.dev", i)
+	}
+	_, _, err := p.InviteMembers(context.Background(), inviteMeta(), &model.InviteMemberRequest{Emails: emails})
+
+	requireKind(t, err, KindInvalidArgument)
+	assert.Equal(t, 0, st.getUserByEmailCalls, "oversized batch must be rejected before touching storage")
+	assert.Equal(t, 0, st.addUserCalls)
+}
+
+// TestAdminMethods_ValidationErrorsAreTyped covers representative admin methods
+// (across three files) whose bare fmt.Errorf validation/conflict errors used to
+// fall through to Internal/500. They must now carry the correct typed Kind so
+// the transport maps them to 400 / 409.
+func TestAdminMethods_ValidationErrorsAreTyped(t *testing.T) {
+	ctx := context.Background()
+	meta := inviteMeta()
+
+	t.Run("CreateClient empty name -> InvalidArgument", func(t *testing.T) {
+		p := newInviteProvider(inviteConfig(), &inviteStorage{}, inviteToken{})
+		_, _, err := p.CreateClient(ctx, meta, &model.CreateClientRequest{Name: "   "})
+		requireKind(t, err, KindInvalidArgument)
+	})
+
+	t.Run("AddTrustedIssuer missing service_account_id -> InvalidArgument", func(t *testing.T) {
+		p := newInviteProvider(inviteConfig(), &inviteStorage{}, inviteToken{})
+		_, _, err := p.AddTrustedIssuer(ctx, meta, &model.AddTrustedIssuerRequest{})
+		requireKind(t, err, KindInvalidArgument)
+	})
+
+	t.Run("CreateOrganization duplicate name -> AlreadyExists", func(t *testing.T) {
+		st := &inviteStorage{getOrgByName: func(name string) *schemas.Organization {
+			return &schemas.Organization{ID: "org-1", Name: name}
+		}}
+		p := newInviteProvider(inviteConfig(), st, inviteToken{})
+		_, _, err := p.CreateOrganization(ctx, meta, &model.CreateOrganizationRequest{Name: "acme"})
+		requireKind(t, err, KindAlreadyExists)
+	})
+}

--- a/internal/service/admin_clients.go
+++ b/internal/service/admin_clients.go
@@ -69,13 +69,13 @@ func (p *provider) CreateClient(ctx context.Context, meta RequestMetadata, param
 
 	if strings.TrimSpace(params.Name) == "" {
 		log.Debug().Msg("name is required")
-		return nil, nil, fmt.Errorf("name is required")
+		return nil, nil, InvalidArgument("name is required")
 	}
 
 	scopes := normalizeScopes(params.AllowedScopes)
 	if scopes == "" {
 		log.Debug().Msg("empty allowed_scopes rejected")
-		return nil, nil, fmt.Errorf("at least one allowed scope is required")
+		return nil, nil, InvalidArgument("at least one allowed scope is required")
 	}
 
 	secret, err := generateClientSecret()
@@ -149,7 +149,7 @@ func (p *provider) UpdateClient(ctx context.Context, meta RequestMetadata, param
 		scopes := normalizeScopes(params.AllowedScopes)
 		if scopes == "" {
 			log.Debug().Msg("empty allowed_scopes rejected")
-			return nil, nil, fmt.Errorf("at least one allowed scope is required")
+			return nil, nil, InvalidArgument("at least one allowed scope is required")
 		}
 		sa.AllowedScopes = scopes
 	}
@@ -185,7 +185,7 @@ func (p *provider) DeleteClient(ctx context.Context, meta RequestMetadata, param
 
 	if params.ID == "" {
 		log.Debug().Msg("service account ID required")
-		return nil, nil, fmt.Errorf("service account ID required")
+		return nil, nil, InvalidArgument("service account ID required")
 	}
 
 	sa, err := p.StorageProvider.GetClientByID(ctx, params.ID)
@@ -224,7 +224,7 @@ func (p *provider) RotateClientSecret(ctx context.Context, meta RequestMetadata,
 
 	if params.ID == "" {
 		log.Debug().Msg("service account ID required")
-		return nil, nil, fmt.Errorf("service account ID required")
+		return nil, nil, InvalidArgument("service account ID required")
 	}
 
 	sa, err := p.StorageProvider.GetClientByID(ctx, params.ID)

--- a/internal/service/admin_email_templates.go
+++ b/internal/service/admin_email_templates.go
@@ -25,17 +25,17 @@ func (p *provider) AddEmailTemplate(ctx context.Context, meta RequestMetadata, p
 
 	if !validators.IsValidEmailTemplateEventName(params.EventName) {
 		log.Debug().Str("EventName", params.EventName).Msg("Invalid Event Name")
-		return nil, nil, fmt.Errorf("invalid event name %s", params.EventName)
+		return nil, nil, InvalidArgument(fmt.Sprintf("invalid event name %s", params.EventName))
 	}
 
 	if strings.TrimSpace(params.Subject) == "" {
 		log.Debug().Msg("subject is missing")
-		return nil, nil, fmt.Errorf("empty subject not allowed")
+		return nil, nil, InvalidArgument("empty subject not allowed")
 	}
 
 	if strings.TrimSpace(params.Template) == "" {
 		log.Debug().Msg("template is missing")
-		return nil, nil, fmt.Errorf("empty template not allowed")
+		return nil, nil, InvalidArgument("empty template not allowed")
 	}
 
 	var design string
@@ -98,7 +98,7 @@ func (p *provider) UpdateEmailTemplate(ctx context.Context, meta RequestMetadata
 	if params.EventName != nil && emailTemplateDetails.EventName != refs.StringValue(params.EventName) {
 		if isValid := validators.IsValidEmailTemplateEventName(refs.StringValue(params.EventName)); !isValid {
 			log.Debug().Str("event_name", refs.StringValue(params.EventName)).Msg("invalid event name")
-			return nil, nil, fmt.Errorf("invalid event name %s", refs.StringValue(params.EventName))
+			return nil, nil, InvalidArgument(fmt.Sprintf("invalid event name %s", refs.StringValue(params.EventName)))
 		}
 		emailTemplateDetails.EventName = refs.StringValue(params.EventName)
 	}
@@ -106,7 +106,7 @@ func (p *provider) UpdateEmailTemplate(ctx context.Context, meta RequestMetadata
 	if params.Subject != nil && emailTemplateDetails.Subject != refs.StringValue(params.Subject) {
 		if strings.TrimSpace(refs.StringValue(params.Subject)) == "" {
 			log.Debug().Msg("empty subject not allowed")
-			return nil, nil, fmt.Errorf("empty subject not allowed")
+			return nil, nil, InvalidArgument("empty subject not allowed")
 		}
 		emailTemplateDetails.Subject = refs.StringValue(params.Subject)
 	}
@@ -114,7 +114,7 @@ func (p *provider) UpdateEmailTemplate(ctx context.Context, meta RequestMetadata
 	if params.Template != nil && emailTemplateDetails.Template != refs.StringValue(params.Template) {
 		if strings.TrimSpace(refs.StringValue(params.Template)) == "" {
 			log.Debug().Msg("empty template not allowed")
-			return nil, nil, fmt.Errorf("empty template not allowed")
+			return nil, nil, InvalidArgument("empty template not allowed")
 		}
 		emailTemplateDetails.Template = refs.StringValue(params.Template)
 	}
@@ -122,7 +122,7 @@ func (p *provider) UpdateEmailTemplate(ctx context.Context, meta RequestMetadata
 	if params.Design != nil && emailTemplateDetails.Design != refs.StringValue(params.Design) {
 		if strings.TrimSpace(refs.StringValue(params.Design)) == "" {
 			log.Debug().Msg("empty design not allowed")
-			return nil, nil, fmt.Errorf("empty design not allowed")
+			return nil, nil, InvalidArgument("empty design not allowed")
 		}
 		emailTemplateDetails.Design = refs.StringValue(params.Design)
 	}
@@ -157,7 +157,7 @@ func (p *provider) DeleteEmailTemplate(ctx context.Context, meta RequestMetadata
 
 	if strings.TrimSpace(params.ID) == "" {
 		log.Debug().Msg("email template ID required")
-		return nil, nil, fmt.Errorf("email template ID required")
+		return nil, nil, InvalidArgument("email template ID required")
 	}
 
 	log = log.With().Str("emailTemplateID", params.ID).Logger()

--- a/internal/service/admin_org_domains.go
+++ b/internal/service/admin_org_domains.go
@@ -17,7 +17,7 @@ import (
 // errDomainOwnedByAnotherOrg is the uniform, stable API error when a domain is
 // already verified by a different org (invariant 2). Kept as one string so the
 // three write paths (verify, trusted-assert) return it identically.
-var errDomainOwnedByAnotherOrg = fmt.Errorf("domain_already_verified_by_another_org")
+var errDomainOwnedByAnotherOrg = AlreadyExists("domain_already_verified_by_another_org")
 
 // RequestOrgDomain mints a DNS TXT challenge proving control of a domain and
 // returns the record to publish. It creates NO durable row — the pending token
@@ -31,7 +31,7 @@ func (p *provider) RequestOrgDomain(ctx context.Context, meta RequestMetadata, p
 	orgID := strings.TrimSpace(params.OrgID)
 	if orgID == "" {
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("org_id is required")
+		return nil, nil, InvalidArgument("org_id is required")
 	}
 	domain, err := normalizeDomain(params.Domain)
 	if err != nil {
@@ -48,13 +48,13 @@ func (p *provider) RequestOrgDomain(ctx context.Context, meta RequestMetadata, p
 		allowed, rlErr := p.RateLimitProvider.Allow(ctx, "org_domain_request:"+orgID)
 		if rlErr == nil && !allowed {
 			log.Debug().Msg("domain request rate limit exceeded")
-			return nil, nil, fmt.Errorf("too many domain requests, please retry later")
+			return nil, nil, TooManyRequests("too many domain requests, please retry later")
 		}
 	}
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Msg("organization not found")
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainRequestFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("organization not found")
+		return nil, nil, NotFound("organization not found")
 	}
 
 	token, err := generateDomainChallengeToken()
@@ -112,7 +112,7 @@ func (p *provider) VerifyOrgDomain(ctx context.Context, meta RequestMetadata, pa
 		allowed, rlErr := p.RateLimitProvider.Allow(ctx, "org_domain_verify:"+orgID)
 		if rlErr == nil && !allowed {
 			log.Debug().Msg("domain verify rate limit exceeded")
-			return nil, nil, fmt.Errorf("too many verification attempts, please retry later")
+			return nil, nil, TooManyRequests("too many verification attempts, please retry later")
 		}
 	}
 
@@ -130,19 +130,19 @@ func (p *provider) VerifyOrgDomain(ctx context.Context, meta RequestMetadata, pa
 	if err != nil || token == "" {
 		log.Debug().Err(err).Msg("no pending domain challenge")
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("no pending verification challenge for this domain; request one first")
+		return nil, nil, FailedPrecondition("no pending verification challenge for this domain; request one first")
 	}
 
 	matched, dnsErr := p.lookupDomainTXTMatches(ctx, domain, token)
 	if dnsErr != nil {
 		log.Debug().Err(dnsErr).Msg("domain TXT lookup failed")
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("dns verification failed: could not resolve the challenge TXT record")
+		return nil, nil, FailedPrecondition("dns verification failed: could not resolve the challenge TXT record")
 	}
 	if !matched {
 		// Leave the challenge in place so the tenant can retry after DNS propagates.
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("dns verification failed: challenge TXT record not found or does not match")
+		return nil, nil, FailedPrecondition("dns verification failed: challenge TXT record not found or does not match")
 	}
 
 	row, err := p.StorageProvider.AddOrgDomain(ctx, &schemas.OrgDomain{
@@ -179,7 +179,7 @@ func (p *provider) AddVerifiedOrgDomain(ctx context.Context, meta RequestMetadat
 	orgID := strings.TrimSpace(params.OrgID)
 	if orgID == "" {
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("org_id is required")
+		return nil, nil, InvalidArgument("org_id is required")
 	}
 	domain, err := normalizeDomain(params.Domain)
 	if err != nil {
@@ -193,7 +193,7 @@ func (p *provider) AddVerifiedOrgDomain(ctx context.Context, meta RequestMetadat
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Msg("organization not found")
 		p.logOrgDomainFailure(meta, constants.AuditOrgDomainVerifyFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("organization not found")
+		return nil, nil, NotFound("organization not found")
 	}
 
 	row, err := p.StorageProvider.AddOrgDomain(ctx, &schemas.OrgDomain{
@@ -225,7 +225,7 @@ func (p *provider) OrgDomains(ctx context.Context, meta RequestMetadata, params 
 	}
 	orgID := strings.TrimSpace(params.OrgID)
 	if orgID == "" {
-		return nil, nil, fmt.Errorf("org_id is required")
+		return nil, nil, InvalidArgument("org_id is required")
 	}
 	pagination := utils.GetPagination(params.Pagination)
 	domains, pagination, err := p.StorageProvider.ListOrgDomainsByOrg(ctx, orgID, pagination)
@@ -255,7 +255,7 @@ func (p *provider) DeleteOrgDomain(ctx context.Context, meta RequestMetadata, pa
 	row, err := p.StorageProvider.GetOrgDomainByDomain(ctx, domain)
 	if err != nil || row == nil {
 		log.Debug().Err(err).Msg("org domain not found")
-		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("org domain not found"))
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, NotFound("org domain not found"))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, row.OrgID); err != nil {
 		return nil, nil, err

--- a/internal/service/admin_org_oidc.go
+++ b/internal/service/admin_org_oidc.go
@@ -45,7 +45,7 @@ func asAPIOrgOIDCConnection(t *schemas.TrustedIssuer) *model.OrgOIDCConnection {
 func validateSSOIssuerURL(raw string) error {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || u.Scheme != "https" || u.Host == "" {
-		return fmt.Errorf("issuer_url must be a valid https URL")
+		return InvalidArgument("issuer_url must be a valid https URL")
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (p *provider) CreateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	clientID := strings.TrimSpace(params.ClientID)
 	clientSecret := params.ClientSecret // preserve verbatim (secret may be non-trimmable)
 	if orgID == "" || name == "" || issuerURL == "" || clientID == "" || strings.TrimSpace(clientSecret) == "" {
-		return nil, nil, fmt.Errorf("org_id, name, issuer_url, client_id and client_secret are required")
+		return nil, nil, InvalidArgument("org_id, name, issuer_url, client_id and client_secret are required")
 	}
 	if err := validateSSOIssuerURL(issuerURL); err != nil {
 		return nil, nil, err
@@ -74,17 +74,17 @@ func (p *provider) CreateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	// The organization must exist.
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Str("org_id", orgID).Msg("organization not found")
-		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+		return nil, nil, NotFound(fmt.Sprintf("organization not found: %s", orgID))
 	}
 	// At most one OIDC connection per org.
 	if existing, _ := p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOOIDC); existing != nil {
-		return nil, nil, fmt.Errorf("an OIDC connection already exists for this organization")
+		return nil, nil, AlreadyExists("an OIDC connection already exists for this organization")
 	}
 	// issuer_url is globally unique (DB unique index + service guard) — this also
 	// prevents an SSO row from shadowing a client_assertion_trust row at the same
 	// URL, and vice-versa.
 	if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, issuerURL); existing != nil {
-		return nil, nil, fmt.Errorf("issuer_url already registered: %s", issuerURL)
+		return nil, nil, AlreadyExists(fmt.Sprintf("issuer_url already registered: %s", issuerURL))
 	}
 
 	// The upstream secret is stored AES-encrypted (reversible: replayed to the
@@ -149,7 +149,7 @@ func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 	}
 	// Guard: this op only edits sso_oidc rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
-		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("not an OIDC connection"))
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, NotFound("not an OIDC connection"))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -166,7 +166,7 @@ func (p *provider) UpdateOrgOIDCConnection(ctx context.Context, meta RequestMeta
 		// Preserve global issuer_url uniqueness on change.
 		if u != issuer.IssuerURL {
 			if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, u); existing != nil {
-				return nil, nil, fmt.Errorf("issuer_url already registered: %s", u)
+				return nil, nil, AlreadyExists(fmt.Sprintf("issuer_url already registered: %s", u))
 			}
 		}
 		issuer.IssuerURL = u
@@ -217,13 +217,13 @@ func (p *provider) resolveOrgOIDCConnection(ctx context.Context, id, orgID *stri
 			return nil, err
 		}
 		if issuer.EffectiveKind() != constants.TrustKindSSOOIDC {
-			return nil, fmt.Errorf("not an OIDC connection")
+			return nil, NotFound("not an OIDC connection")
 		}
 		return issuer, nil
 	case orgID != nil && strings.TrimSpace(*orgID) != "":
 		return p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, strings.TrimSpace(*orgID), constants.TrustKindSSOOIDC)
 	default:
-		return nil, fmt.Errorf("supply either id or org_id")
+		return nil, InvalidArgument("supply either id or org_id")
 	}
 }
 

--- a/internal/service/admin_org_saml.go
+++ b/internal/service/admin_org_saml.go
@@ -45,7 +45,7 @@ func asAPIOrgSAMLConnection(t *schemas.TrustedIssuer) *model.OrgSAMLConnection {
 func validateSAMLHTTPSURL(raw string) error {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || u.Scheme != "https" || u.Host == "" {
-		return fmt.Errorf("must be a valid https URL")
+		return InvalidArgument("must be a valid https URL")
 	}
 	return nil
 }
@@ -56,10 +56,10 @@ func validateSAMLHTTPSURL(raw string) error {
 func validateSAMLCertPEM(raw string) error {
 	block, _ := pem.Decode([]byte(strings.TrimSpace(raw)))
 	if block == nil {
-		return fmt.Errorf("idp_certificate must be a PEM-encoded X.509 certificate")
+		return InvalidArgument("idp_certificate must be a PEM-encoded X.509 certificate")
 	}
 	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
-		return fmt.Errorf("idp_certificate is not a valid X.509 certificate: %w", err)
+		return InvalidArgument(fmt.Sprintf("idp_certificate is not a valid X.509 certificate: %v", err))
 	}
 	return nil
 }
@@ -72,7 +72,7 @@ func validateSAMLAttributeMapping(raw string) error {
 	}
 	var m map[string]string
 	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		return fmt.Errorf("attribute_mapping must be a JSON object of string values: %w", err)
+		return InvalidArgument(fmt.Sprintf("attribute_mapping must be a JSON object of string values: %v", err))
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (p *provider) CreateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	idpSSOURL := strings.TrimSpace(params.IdpSsoURL)
 	idpCert := strings.TrimSpace(params.IdpCertificate)
 	if orgID == "" || name == "" || idpEntityID == "" || idpSSOURL == "" || idpCert == "" {
-		return nil, nil, fmt.Errorf("org_id, name, idp_entity_id, idp_sso_url and idp_certificate are required")
+		return nil, nil, InvalidArgument("org_id, name, idp_entity_id, idp_sso_url and idp_certificate are required")
 	}
 	if err := validateSAMLHTTPSURL(idpSSOURL); err != nil {
 		return nil, nil, fmt.Errorf("idp_sso_url %w", err)
@@ -109,17 +109,17 @@ func (p *provider) CreateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	// The organization must exist.
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Str("org_id", orgID).Msg("organization not found")
-		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+		return nil, nil, NotFound(fmt.Sprintf("organization not found: %s", orgID))
 	}
 	// At most one SAML connection per org.
 	if existing, _ := p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, orgID, constants.TrustKindSSOSAML); existing != nil {
-		return nil, nil, fmt.Errorf("a SAML connection already exists for this organization")
+		return nil, nil, AlreadyExists("a SAML connection already exists for this organization")
 	}
 	// idp_entity_id is stored in the globally-unique IssuerURL column — this also
 	// prevents a SAML row from shadowing an OIDC/client_assertion_trust row at the
 	// same issuer value, and vice-versa.
 	if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, idpEntityID); existing != nil {
-		return nil, nil, fmt.Errorf("idp_entity_id already registered: %s", idpEntityID)
+		return nil, nil, AlreadyExists(fmt.Sprintf("idp_entity_id already registered: %s", idpEntityID))
 	}
 
 	allowIDPInitiated := params.AllowIdpInitiated != nil && *params.AllowIdpInitiated
@@ -205,7 +205,7 @@ func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	}
 	// Guard: this op only edits sso_saml rows — never a client_assertion row.
 	if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
-		return nil, nil, p.maskNonSuperAdminError(ctx, meta, fmt.Errorf("not a SAML connection"))
+		return nil, nil, p.maskNonSuperAdminError(ctx, meta, NotFound("not a SAML connection"))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, issuer.OrgID); err != nil {
 		return nil, nil, err
@@ -217,12 +217,12 @@ func (p *provider) UpdateOrgSAMLConnection(ctx context.Context, meta RequestMeta
 	if params.IdpEntityID != nil {
 		v := strings.TrimSpace(*params.IdpEntityID)
 		if v == "" {
-			return nil, nil, fmt.Errorf("idp_entity_id cannot be empty")
+			return nil, nil, InvalidArgument("idp_entity_id cannot be empty")
 		}
 		// Preserve global issuer_url (idp_entity_id) uniqueness on change.
 		if v != issuer.IssuerURL {
 			if existing, _ := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, v); existing != nil {
-				return nil, nil, fmt.Errorf("idp_entity_id already registered: %s", v)
+				return nil, nil, AlreadyExists(fmt.Sprintf("idp_entity_id already registered: %s", v))
 			}
 		}
 		issuer.IssuerURL = v
@@ -307,13 +307,13 @@ func (p *provider) resolveOrgSAMLConnection(ctx context.Context, id, orgID *stri
 			return nil, err
 		}
 		if issuer.EffectiveKind() != constants.TrustKindSSOSAML {
-			return nil, fmt.Errorf("not a SAML connection")
+			return nil, NotFound("not a SAML connection")
 		}
 		return issuer, nil
 	case orgID != nil && strings.TrimSpace(*orgID) != "":
 		return p.StorageProvider.GetTrustedIssuerByOrgIDAndKind(ctx, strings.TrimSpace(*orgID), constants.TrustKindSSOSAML)
 	default:
-		return nil, fmt.Errorf("supply either id or org_id")
+		return nil, InvalidArgument("supply either id or org_id")
 	}
 }
 

--- a/internal/service/admin_organizations.go
+++ b/internal/service/admin_organizations.go
@@ -24,7 +24,7 @@ import (
 func validateOrgSlug(name string) error {
 	for _, r := range name {
 		if r == '/' || r == ':' || r == '#' || unicode.IsSpace(r) || unicode.IsControl(r) {
-			return fmt.Errorf("organization name must be a URL-safe slug: the character %q is not allowed", string(r))
+			return InvalidArgument(fmt.Sprintf("organization name must be a URL-safe slug: the character %q is not allowed", string(r)))
 		}
 	}
 	return nil
@@ -42,7 +42,7 @@ func (p *provider) CreateOrganization(ctx context.Context, meta RequestMetadata,
 	if name == "" {
 		log.Debug().Msg("name is required")
 		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
-		return nil, nil, fmt.Errorf("name is required")
+		return nil, nil, InvalidArgument("name is required")
 	}
 	if err := validateOrgSlug(name); err != nil {
 		log.Debug().Err(err).Msg("invalid organization name")
@@ -55,7 +55,7 @@ func (p *provider) CreateOrganization(ctx context.Context, meta RequestMetadata,
 	if existing, _ := p.StorageProvider.GetOrganizationByName(ctx, name); existing != nil {
 		log.Debug().Msg("organization name already exists")
 		p.logOrgFailure(meta, constants.AuditOrganizationCreateFailedEvent, "")
-		return nil, nil, fmt.Errorf("an organization with this name already exists")
+		return nil, nil, AlreadyExists("an organization with this name already exists")
 	}
 
 	org, err := p.StorageProvider.AddOrganization(ctx, &schemas.Organization{
@@ -104,7 +104,7 @@ func (p *provider) UpdateOrganization(ctx context.Context, meta RequestMetadata,
 		if name == "" {
 			log.Debug().Msg("name cannot be empty")
 			p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
-			return nil, nil, fmt.Errorf("name cannot be empty")
+			return nil, nil, InvalidArgument("name cannot be empty")
 		}
 		if err := validateOrgSlug(name); err != nil {
 			log.Debug().Err(err).Msg("invalid organization name")
@@ -115,7 +115,7 @@ func (p *provider) UpdateOrganization(ctx context.Context, meta RequestMetadata,
 			if existing, _ := p.StorageProvider.GetOrganizationByName(ctx, name); existing != nil {
 				log.Debug().Msg("organization name already exists")
 				p.logOrgFailure(meta, constants.AuditOrganizationUpdateFailedEvent, params.ID)
-				return nil, nil, fmt.Errorf("an organization with this name already exists")
+				return nil, nil, AlreadyExists("an organization with this name already exists")
 			}
 			org.Name = name
 		}
@@ -157,7 +157,7 @@ func (p *provider) DeleteOrganization(ctx context.Context, meta RequestMetadata,
 	if params.ID == "" {
 		log.Debug().Msg("organization ID required")
 		p.logOrgFailure(meta, constants.AuditOrganizationDeleteFailedEvent, "")
-		return nil, nil, fmt.Errorf("organization ID required")
+		return nil, nil, InvalidArgument("organization ID required")
 	}
 
 	org, err := p.StorageProvider.GetOrganizationByID(ctx, params.ID)
@@ -253,26 +253,26 @@ func (p *provider) AddOrgMember(ctx context.Context, meta RequestMetadata, param
 	if orgID == "" || userID == "" {
 		log.Debug().Msg("org_id and user_id are required")
 		p.logOrgMemberFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("org_id and user_id are required")
+		return nil, nil, InvalidArgument("org_id and user_id are required")
 	}
 
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Msg("organization not found")
 		p.logOrgMemberFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("organization not found")
+		return nil, nil, NotFound("organization not found")
 	}
 
 	if _, err := p.StorageProvider.GetUserByID(ctx, userID); err != nil {
 		log.Debug().Err(err).Msg("user not found")
 		p.logOrgMemberFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("user not found")
+		return nil, nil, NotFound("user not found")
 	}
 
 	// Membership uniqueness pre-check. The storage layer also enforces it.
 	if existing, _ := p.StorageProvider.GetOrgMembership(ctx, orgID, userID); existing != nil {
 		log.Debug().Msg("user is already a member of this organization")
 		p.logOrgMemberFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("user is already a member of this organization")
+		return nil, nil, AlreadyExists("user is already a member of this organization")
 	}
 
 	membership, err := p.StorageProvider.AddOrgMembership(ctx, &schemas.OrgMembership{
@@ -315,14 +315,14 @@ func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, pa
 	if orgID == "" || userID == "" {
 		log.Debug().Msg("org_id and user_id are required")
 		p.logOrgMemberRemoveFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("org_id and user_id are required")
+		return nil, nil, InvalidArgument("org_id and user_id are required")
 	}
 
 	membership, err := p.StorageProvider.GetOrgMembership(ctx, orgID, userID)
 	if err != nil {
 		log.Debug().Err(err).Msg("membership not found")
 		p.logOrgMemberRemoveFailure(meta, orgID)
-		return nil, nil, fmt.Errorf("membership not found")
+		return nil, nil, NotFound("membership not found")
 	}
 
 	// Last-admin guard. Skip for super-admins (recovery escape hatch).
@@ -337,7 +337,7 @@ func (p *provider) RemoveOrgMember(ctx context.Context, meta RequestMetadata, pa
 		if !hasOther {
 			log.Debug().Msg("refusing to remove the last org admin")
 			p.logOrgMemberRemoveFailure(meta, orgID)
-			return nil, nil, fmt.Errorf("cannot remove the last %s of the organization", constants.OrgRoleAdmin)
+			return nil, nil, FailedPrecondition(fmt.Sprintf("cannot remove the last %s of the organization", constants.OrgRoleAdmin))
 		}
 	}
 
@@ -371,7 +371,7 @@ func (p *provider) OrgMembers(ctx context.Context, meta RequestMetadata, params 
 
 	if params.OrgID == "" {
 		log.Debug().Msg("org_id is required")
-		return nil, nil, fmt.Errorf("org_id is required")
+		return nil, nil, InvalidArgument("org_id is required")
 	}
 	pagination := utils.GetPagination(params.Pagination)
 
@@ -412,7 +412,7 @@ func (p *provider) UserOrganizations(ctx context.Context, meta RequestMetadata, 
 	}
 	if params == nil || strings.TrimSpace(params.UserID) == "" {
 		log.Debug().Msg("user_id is required")
-		return nil, nil, fmt.Errorf("user_id is required")
+		return nil, nil, InvalidArgument("user_id is required")
 	}
 
 	var pagination *model.Pagination

--- a/internal/service/admin_saml_idp.go
+++ b/internal/service/admin_saml_idp.go
@@ -43,7 +43,7 @@ func asAPISAMLIDPKey(k *schemas.SAMLIDPKey) *model.SAMLIDPKey {
 func validateSAMLACSURL(raw string) error {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
-		return fmt.Errorf("acs_url must be a valid http(s) URL")
+		return InvalidArgument("acs_url must be a valid http(s) URL")
 	}
 	return nil
 }
@@ -61,7 +61,7 @@ func (p *provider) CreateSAMLServiceProvider(ctx context.Context, meta RequestMe
 	entityID := strings.TrimSpace(params.EntityID)
 	acsURL := strings.TrimSpace(params.AcsURL)
 	if orgID == "" || name == "" || entityID == "" || acsURL == "" {
-		return nil, nil, fmt.Errorf("org_id, name, entity_id and acs_url are required")
+		return nil, nil, InvalidArgument("org_id, name, entity_id and acs_url are required")
 	}
 	if err := validateSAMLACSURL(acsURL); err != nil {
 		return nil, nil, err
@@ -77,10 +77,10 @@ func (p *provider) CreateSAMLServiceProvider(ctx context.Context, meta RequestMe
 		}
 	}
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
-		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+		return nil, nil, NotFound(fmt.Sprintf("organization not found: %s", orgID))
 	}
 	if existing, _ := p.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, orgID, entityID); existing != nil {
-		return nil, nil, fmt.Errorf("a service provider with entity_id %q is already registered for this organization", entityID)
+		return nil, nil, AlreadyExists(fmt.Sprintf("a service provider with entity_id %q is already registered for this organization", entityID))
 	}
 
 	sp := &schemas.SAMLServiceProvider{
@@ -109,11 +109,11 @@ func (p *provider) CreateSAMLServiceProvider(ctx context.Context, meta RequestMe
 func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.UpdateSAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error) {
 	id := strings.TrimSpace(params.ID)
 	if id == "" {
-		return nil, nil, fmt.Errorf("id is required")
+		return nil, nil, InvalidArgument("id is required")
 	}
 	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, id)
 	if err != nil || existing == nil {
-		return nil, nil, fmt.Errorf("service provider not found: %s", id)
+		return nil, nil, NotFound(fmt.Sprintf("service provider not found: %s", id))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
 		return nil, nil, err
@@ -128,7 +128,7 @@ func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, meta RequestMe
 		v := strings.TrimSpace(*params.EntityID)
 		if v != "" && v != existing.EntityID {
 			if conflict, _ := p.StorageProvider.GetSAMLServiceProviderByOrgAndEntityID(ctx, existing.OrgID, v); conflict != nil && conflict.ID != existing.ID {
-				return nil, nil, fmt.Errorf("a service provider with entity_id %q is already registered for this organization", v)
+				return nil, nil, AlreadyExists(fmt.Sprintf("a service provider with entity_id %q is already registered for this organization", v))
 			}
 			existing.EntityID = v
 		}
@@ -188,7 +188,7 @@ func (p *provider) UpdateSAMLServiceProvider(ctx context.Context, meta RequestMe
 func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.Response, *ResponseSideEffects, error) {
 	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, strings.TrimSpace(params.ID))
 	if err != nil || existing == nil {
-		return nil, nil, fmt.Errorf("service provider not found: %s", params.ID)
+		return nil, nil, NotFound(fmt.Sprintf("service provider not found: %s", params.ID))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
 		return nil, nil, err
@@ -206,7 +206,7 @@ func (p *provider) DeleteSAMLServiceProvider(ctx context.Context, meta RequestMe
 func (p *provider) SAMLServiceProvider(ctx context.Context, meta RequestMetadata, params *model.SAMLServiceProviderRequest) (*model.SAMLServiceProvider, *ResponseSideEffects, error) {
 	existing, err := p.StorageProvider.GetSAMLServiceProviderByID(ctx, strings.TrimSpace(params.ID))
 	if err != nil || existing == nil {
-		return nil, nil, fmt.Errorf("service provider not found: %s", params.ID)
+		return nil, nil, NotFound(fmt.Sprintf("service provider not found: %s", params.ID))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, existing.OrgID); err != nil {
 		return nil, nil, err
@@ -243,7 +243,7 @@ func (p *provider) RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, 
 		return nil, nil, err
 	}
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
-		return nil, nil, fmt.Errorf("organization not found: %s", orgID)
+		return nil, nil, NotFound(fmt.Sprintf("organization not found: %s", orgID))
 	}
 	keys, err := p.StorageProvider.ListSAMLIDPKeys(ctx, orgID)
 	if err != nil {
@@ -291,13 +291,13 @@ func (p *provider) RotateSAMLIDPCert(ctx context.Context, meta RequestMetadata, 
 func (p *provider) RetireSAMLIDPKey(ctx context.Context, meta RequestMetadata, params *model.RetireSAMLIDPKeyRequest) (*model.Response, *ResponseSideEffects, error) {
 	key, err := p.StorageProvider.GetSAMLIDPKeyByID(ctx, strings.TrimSpace(params.ID))
 	if err != nil || key == nil {
-		return nil, nil, fmt.Errorf("signing key not found: %s", params.ID)
+		return nil, nil, NotFound(fmt.Sprintf("signing key not found: %s", params.ID))
 	}
 	if err := p.requireOrgAdmin(ctx, meta, key.OrgID); err != nil {
 		return nil, nil, err
 	}
 	if key.Status == schemas.SAMLIDPKeyStatusCurrent {
-		return nil, nil, fmt.Errorf("cannot retire the current signing key; rotate to a new key first")
+		return nil, nil, FailedPrecondition("cannot retire the current signing key; rotate to a new key first")
 	}
 	if key.Status == schemas.SAMLIDPKeyStatusRetired {
 		return &model.Response{Message: "signing key already retired"}, nil, nil
@@ -341,11 +341,11 @@ func (p *provider) ImportSAMLSPMetadata(ctx context.Context, meta RequestMetadat
 	}
 	raw := strings.TrimSpace(params.MetadataXML)
 	if raw == "" {
-		return nil, nil, fmt.Errorf("metadata_xml is required")
+		return nil, nil, InvalidArgument("metadata_xml is required")
 	}
 	ed, err := samlsp.ParseMetadata([]byte(raw))
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not parse SP metadata XML: %w", err)
+		return nil, nil, InvalidArgument(fmt.Sprintf("could not parse SP metadata XML: %v", err))
 	}
 	acsURL := ""
 	certPEM := ""
@@ -364,7 +364,7 @@ func (p *provider) ImportSAMLSPMetadata(ctx context.Context, meta RequestMetadat
 		}
 	}
 	if ed.EntityID == "" || acsURL == "" {
-		return nil, nil, fmt.Errorf("metadata did not contain an SP entity ID and Assertion Consumer Service URL")
+		return nil, nil, InvalidArgument("metadata did not contain an SP entity ID and Assertion Consumer Service URL")
 	}
 	res := &model.SAMLSPMetadataParseResult{EntityID: ed.EntityID, AcsURL: acsURL}
 	if certPEM != "" {

--- a/internal/service/admin_scim.go
+++ b/internal/service/admin_scim.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -26,17 +25,17 @@ func (p *provider) CreateScimEndpoint(ctx context.Context, meta RequestMetadata,
 	orgID := strings.TrimSpace(params.OrgID)
 	if orgID == "" {
 		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, "")
-		return nil, nil, fmt.Errorf("org_id is required")
+		return nil, nil, InvalidArgument("org_id is required")
 	}
 	if _, err := p.StorageProvider.GetOrganizationByID(ctx, orgID); err != nil {
 		log.Debug().Err(err).Msg("organization not found")
 		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("organization not found")
+		return nil, nil, NotFound("organization not found")
 	}
 	if existing, _ := p.StorageProvider.GetScimEndpointByOrgID(ctx, orgID); existing != nil {
 		log.Debug().Msg("scim endpoint already exists for org")
 		p.logScimFailure(meta, constants.AuditScimEndpointCreateFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("a scim endpoint already exists for this organization")
+		return nil, nil, AlreadyExists("a scim endpoint already exists for this organization")
 	}
 
 	// The endpoint id is embedded (non-secret) in the token; generate it first
@@ -89,7 +88,7 @@ func (p *provider) RotateScimToken(ctx context.Context, meta RequestMetadata, pa
 	if err != nil || endpoint == nil {
 		log.Debug().Err(err).Msg("scim endpoint not found")
 		p.logScimFailure(meta, constants.AuditScimTokenRotateFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("scim endpoint not found")
+		return nil, nil, NotFound("scim endpoint not found")
 	}
 	token, hash, err := scim.GenerateToken(endpoint.ID)
 	if err != nil {
@@ -131,7 +130,7 @@ func (p *provider) DeleteScimEndpoint(ctx context.Context, meta RequestMetadata,
 	if err != nil || endpoint == nil {
 		log.Debug().Err(err).Msg("scim endpoint not found")
 		p.logScimFailure(meta, constants.AuditScimEndpointDeleteFailedEvent, orgID)
-		return nil, nil, fmt.Errorf("scim endpoint not found")
+		return nil, nil, NotFound("scim endpoint not found")
 	}
 	if err := p.StorageProvider.DeleteScimEndpoint(ctx, endpoint); err != nil {
 		log.Debug().Err(err).Msg("failed to delete scim endpoint")
@@ -160,7 +159,7 @@ func (p *provider) ScimEndpoint(ctx context.Context, meta RequestMetadata, param
 	endpoint, err := p.StorageProvider.GetScimEndpointByOrgID(ctx, strings.TrimSpace(params.OrgID))
 	if err != nil || endpoint == nil {
 		log.Debug().Err(err).Msg("scim endpoint not found")
-		return nil, nil, fmt.Errorf("scim endpoint not found")
+		return nil, nil, NotFound("scim endpoint not found")
 	}
 	return endpoint.AsAPIScimEndpoint(), nil, nil
 }

--- a/internal/service/admin_trusted_issuers.go
+++ b/internal/service/admin_trusted_issuers.go
@@ -41,19 +41,19 @@ func validateTokenReviewConfig(enableTokenReview bool, apiServerURL *string) err
 	raw := refs.StringValue(apiServerURL)
 	if raw == "" {
 		if enableTokenReview {
-			return fmt.Errorf("kubernetes_api_server_url is required when enable_token_review is true")
+			return InvalidArgument("kubernetes_api_server_url is required when enable_token_review is true")
 		}
 		return nil
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return fmt.Errorf("kubernetes_api_server_url is not a valid URL: %w", err)
+		return InvalidArgument(fmt.Sprintf("kubernetes_api_server_url is not a valid URL: %v", err))
 	}
 	if !strings.EqualFold(u.Scheme, "https") {
-		return fmt.Errorf("kubernetes_api_server_url must be an https URL")
+		return InvalidArgument("kubernetes_api_server_url must be an https URL")
 	}
 	if u.Host == "" {
-		return fmt.Errorf("kubernetes_api_server_url must include a host")
+		return InvalidArgument("kubernetes_api_server_url must include a host")
 	}
 	return nil
 }
@@ -67,29 +67,29 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, meta RequestMetadata, p
 	}
 
 	if strings.TrimSpace(params.ServiceAccountID) == "" {
-		return nil, nil, fmt.Errorf("service_account_id is required")
+		return nil, nil, InvalidArgument("service_account_id is required")
 	}
 	if strings.TrimSpace(params.Name) == "" {
-		return nil, nil, fmt.Errorf("name is required")
+		return nil, nil, InvalidArgument("name is required")
 	}
 	if strings.TrimSpace(params.IssuerURL) == "" {
-		return nil, nil, fmt.Errorf("issuer_url is required")
+		return nil, nil, InvalidArgument("issuer_url is required")
 	}
 	if strings.TrimSpace(params.KeySourceType) == "" {
-		return nil, nil, fmt.Errorf("key_source_type is required")
+		return nil, nil, InvalidArgument("key_source_type is required")
 	}
 	if strings.TrimSpace(params.ExpectedAud) == "" {
-		return nil, nil, fmt.Errorf("expected_aud is required")
+		return nil, nil, InvalidArgument("expected_aud is required")
 	}
 	if strings.TrimSpace(params.IssuerType) == "" {
-		return nil, nil, fmt.Errorf("issuer_type is required")
+		return nil, nil, InvalidArgument("issuer_type is required")
 	}
 
 	// Reject issuers bound to a non-existent service account — otherwise a typo
 	// creates an orphan that can never be reached via the parent.
 	if _, err := p.StorageProvider.GetClientByID(ctx, params.ServiceAccountID); err != nil {
 		log.Debug().Err(err).Str("service_account_id", params.ServiceAccountID).Msg("service account not found")
-		return nil, nil, fmt.Errorf("service account not found: %s", params.ServiceAccountID)
+		return nil, nil, NotFound(fmt.Sprintf("service account not found: %s", params.ServiceAccountID))
 	}
 
 	// Enforce issuer_url uniqueness at the service layer. Storage providers use a
@@ -99,7 +99,7 @@ func (p *provider) AddTrustedIssuer(ctx context.Context, meta RequestMetadata, p
 	// backends uniformly.
 	if existing, err := p.StorageProvider.GetTrustedIssuerByIssuerURL(ctx, params.IssuerURL); err == nil && existing != nil {
 		log.Debug().Str("issuer_url", params.IssuerURL).Msg("issuer_url already registered")
-		return nil, nil, fmt.Errorf("issuer_url already registered: %s", params.IssuerURL)
+		return nil, nil, AlreadyExists(fmt.Sprintf("issuer_url already registered: %s", params.IssuerURL))
 	}
 
 	subjectClaim := defaultSubjectClaim
@@ -185,7 +185,7 @@ func (p *provider) UpdateTrustedIssuer(ctx context.Context, meta RequestMetadata
 	if params.ExpectedAud != nil {
 		if strings.TrimSpace(*params.ExpectedAud) == "" {
 			log.Debug().Msg("expected_aud cannot be empty")
-			return nil, nil, fmt.Errorf("expected_aud cannot be empty")
+			return nil, nil, InvalidArgument("expected_aud cannot be empty")
 		}
 		issuer.ExpectedAud = *params.ExpectedAud
 	}
@@ -239,7 +239,7 @@ func (p *provider) DeleteTrustedIssuer(ctx context.Context, meta RequestMetadata
 
 	if params.ID == "" {
 		log.Debug().Msg("trusted issuer ID required")
-		return nil, nil, fmt.Errorf("trusted issuer ID required")
+		return nil, nil, InvalidArgument("trusted issuer ID required")
 	}
 
 	issuer, err := p.StorageProvider.GetTrustedIssuerByID(ctx, params.ID)

--- a/internal/service/admin_users.go
+++ b/internal/service/admin_users.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -95,7 +93,7 @@ func (p *provider) User(ctx context.Context, meta RequestMetadata, params *model
 		return res.AsAPIUser(), nil, nil
 	}
 	// Return error if no params are provided.
-	return nil, nil, fmt.Errorf("invalid params, user id or email is required")
+	return nil, nil, InvalidArgument("invalid params, user id or email is required")
 }
 
 // UpdateUser updates a user's profile, roles, MFA, or verification state and
@@ -109,7 +107,7 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 
 	if params.ID == "" {
 		log.Debug().Msg("user id is missing")
-		return nil, nil, fmt.Errorf("user_id is missing")
+		return nil, nil, InvalidArgument("user_id is missing")
 	}
 
 	log = log.With().Str("user_id", params.ID).Logger()
@@ -128,13 +126,13 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		params.ResetMfa == nil &&
 		params.AppData == nil {
 		log.Debug().Msg("please enter atleast one param to update")
-		return nil, nil, fmt.Errorf("please enter atleast one param to update")
+		return nil, nil, InvalidArgument("please enter atleast one param to update")
 	}
 
 	user, err := p.StorageProvider.GetUserByID(ctx, params.ID)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed GetUserByID")
-		return nil, nil, fmt.Errorf(`User not found`)
+		return nil, nil, NotFound(`User not found`)
 	}
 
 	if params.GivenName != nil && refs.StringValue(user.GivenName) != refs.StringValue(params.GivenName) {
@@ -169,7 +167,7 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		appDataBytes, err := json.Marshal(params.AppData)
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to marshal app_data")
-			return nil, nil, errors.New("malformed app_data")
+			return nil, nil, InvalidArgument("malformed app_data")
 		}
 		appDataString = string(appDataBytes)
 		user.AppData = &appDataString
@@ -180,14 +178,14 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		// can still turn it off after the server has stopped offering any method.
 		if refs.BoolValue(params.IsMultiFactorAuthEnabled) && !p.isMFAServiceAvailable() {
 			log.Debug().Msg("cannot enable multi factor authentication as no mfa method is available")
-			return nil, nil, errors.New("cannot enable MFA: no MFA method is available on this server — ensure TOTP is enabled (do not set --disable-totp-login) or configure an email (SMTP) or SMS (Twilio) provider for OTP")
+			return nil, nil, FailedPrecondition("cannot enable MFA: no MFA method is available on this server — ensure TOTP is enabled (do not set --disable-totp-login) or configure an email (SMTP) or SMS (Twilio) provider for OTP")
 		}
 		// EnforceMFA is absolute: an admin must not be able to persist an opt-out
 		// while the org enforces MFA (same guard self-service update_profile.go
 		// already applies).
 		if p.Config.EnforceMFA && !refs.BoolValue(params.IsMultiFactorAuthEnabled) {
 			log.Debug().Msg("cannot disable multi factor authentication as it is enforced by organization")
-			return nil, nil, errors.New("cannot disable multi factor authentication as it is enforced by organization")
+			return nil, nil, FailedPrecondition("cannot disable multi factor authentication as it is enforced by organization")
 		}
 		user.IsMultiFactorAuthEnabled = params.IsMultiFactorAuthEnabled
 	}
@@ -213,7 +211,7 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		// check if valid email
 		if !validators.IsValidEmail(*params.Email) {
 			log.Debug().Str("email", *params.Email).Msg("Invalid email address")
-			return nil, nil, fmt.Errorf("invalid email address")
+			return nil, nil, InvalidArgument("invalid email address")
 		}
 		newEmail := strings.ToLower(*params.Email)
 		// check if user with new email exists
@@ -221,7 +219,7 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		// err = nil means user exists
 		if err == nil {
 			log.Debug().Str("email", newEmail).Msg("User with email already exists")
-			return nil, nil, fmt.Errorf("user with this email address already exists")
+			return nil, nil, AlreadyExists("user with this email address already exists")
 		}
 
 		go func() { _ = p.MemoryStoreProvider.DeleteAllUserSessions(user.ID) }()
@@ -277,14 +275,14 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		phone := strings.TrimSpace(refs.StringValue(params.PhoneNumber))
 		if len(phone) < 10 || len(phone) > 15 {
 			log.Debug().Str("phone", phone).Msg("Invalid phone number")
-			return nil, nil, fmt.Errorf("invalid phone number")
+			return nil, nil, InvalidArgument("invalid phone number")
 		}
 		// check if user with new phone number exists
 		_, err = p.StorageProvider.GetUserByPhoneNumber(ctx, phone)
 		// err = nil means user exists
 		if err == nil {
 			log.Debug().Str("phone", phone).Msg("User with phone number already exists")
-			return nil, nil, fmt.Errorf("user with this phone number already exists")
+			return nil, nil, AlreadyExists("user with this phone number already exists")
 		}
 		go func() { _ = p.MemoryStoreProvider.DeleteAllUserSessions(user.ID) }()
 		user.PhoneNumber = &phone
@@ -304,7 +302,7 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 
 		if !validators.IsValidRoles(inputRoles, append([]string{}, append(roles, protectedRoles...)...)) {
 			log.Debug().Msg("Invalid list of roles")
-			return nil, nil, fmt.Errorf("invalid list of roles")
+			return nil, nil, InvalidArgument("invalid list of roles")
 		}
 
 		if !validators.IsStringArrayEqual(inputRoles, currentRoles) {

--- a/internal/service/admin_webhooks.go
+++ b/internal/service/admin_webhooks.go
@@ -35,17 +35,17 @@ func (p *provider) AddWebhook(ctx context.Context, meta RequestMetadata, params 
 
 	if !validators.IsValidWebhookEventName(params.EventName) {
 		log.Debug().Str("EventName", params.EventName).Msg("Invalid Event Name")
-		return nil, nil, fmt.Errorf("invalid event name %s", params.EventName)
+		return nil, nil, InvalidArgument(fmt.Sprintf("invalid event name %s", params.EventName))
 	}
 	if strings.TrimSpace(params.Endpoint) == "" {
 		log.Debug().Msg("endpoint is missing")
-		return nil, nil, fmt.Errorf("empty endpoint not allowed")
+		return nil, nil, InvalidArgument("empty endpoint not allowed")
 	}
 	// SSRF protection: validate endpoint URL and resolved IPs (skip in test env).
 	if p.Env != constants.TestEnv {
 		if err := validators.ValidateEndpointURL(params.Endpoint); err != nil {
 			log.Debug().Err(err).Str("endpoint", params.Endpoint).Msg("endpoint URL rejected by SSRF filter")
-			return nil, nil, fmt.Errorf("invalid endpoint: %s", err.Error())
+			return nil, nil, InvalidArgument(fmt.Sprintf("invalid endpoint: %s", err.Error()))
 		}
 	}
 
@@ -127,20 +127,20 @@ func (p *provider) UpdateWebhook(ctx context.Context, meta RequestMetadata, para
 	if params.EventName != nil && webhookDetails.EventName != refs.StringValue(params.EventName) {
 		if isValid := validators.IsValidWebhookEventName(refs.StringValue(params.EventName)); !isValid {
 			log.Debug().Str("event_name", refs.StringValue(params.EventName)).Msg("invalid event name")
-			return nil, nil, fmt.Errorf("invalid event name %s", refs.StringValue(params.EventName))
+			return nil, nil, InvalidArgument(fmt.Sprintf("invalid event name %s", refs.StringValue(params.EventName)))
 		}
 		webhookDetails.EventName = refs.StringValue(params.EventName)
 	}
 	if params.Endpoint != nil && webhookDetails.EndPoint != refs.StringValue(params.Endpoint) {
 		if strings.TrimSpace(refs.StringValue(params.Endpoint)) == "" {
 			log.Debug().Msg("empty endpoint not allowed")
-			return nil, nil, fmt.Errorf("empty endpoint not allowed")
+			return nil, nil, InvalidArgument("empty endpoint not allowed")
 		}
 		// SSRF protection: validate endpoint URL and resolved IPs (skip in test env).
 		if p.Env != constants.TestEnv {
 			if err := validators.ValidateEndpointURL(refs.StringValue(params.Endpoint)); err != nil {
 				log.Debug().Err(err).Str("endpoint", refs.StringValue(params.Endpoint)).Msg("endpoint URL rejected by SSRF filter")
-				return nil, nil, fmt.Errorf("invalid endpoint: %s", err.Error())
+				return nil, nil, InvalidArgument(fmt.Sprintf("invalid endpoint: %s", err.Error()))
 			}
 		}
 		webhookDetails.EndPoint = refs.StringValue(params.Endpoint)
@@ -189,7 +189,7 @@ func (p *provider) DeleteWebhook(ctx context.Context, meta RequestMetadata, para
 
 	if params.ID == "" {
 		log.Debug().Msg("Webhook ID required")
-		return nil, nil, fmt.Errorf("webhook ID required")
+		return nil, nil, InvalidArgument("webhook ID required")
 	}
 
 	log = log.With().Str("webhookID", params.ID).Logger()
@@ -306,7 +306,7 @@ func (p *provider) TestEndpoint(ctx context.Context, meta RequestMetadata, param
 
 	if !validators.IsValidWebhookEventName(params.EventName) {
 		log.Debug().Str("event_name", params.EventName).Msg("Invalid event name")
-		return nil, nil, fmt.Errorf("invalid event_name %s", params.EventName)
+		return nil, nil, InvalidArgument(fmt.Sprintf("invalid event_name %s", params.EventName))
 	}
 
 	user := model.User{
@@ -355,7 +355,7 @@ func (p *provider) TestEndpoint(ctx context.Context, meta RequestMetadata, param
 		client, err = validators.SafeHTTPClient(ctx, params.Endpoint, testEndpointHTTPTimeout)
 		if err != nil {
 			log.Debug().Err(err).Str("endpoint", params.Endpoint).Msg("endpoint URL rejected by SSRF filter")
-			return nil, nil, fmt.Errorf("invalid endpoint: %w", err)
+			return nil, nil, InvalidArgument(fmt.Sprintf("invalid endpoint: %v", err))
 		}
 	}
 

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -43,6 +43,10 @@ const (
 	// a rate/attempt limit (e.g. MFA verification locked after repeated
 	// failures). Maps to gRPC ResourceExhausted / HTTP 429.
 	KindTooManyRequests
+	// KindAlreadyExists is a request that violates a uniqueness constraint
+	// (e.g. an organization/email/issuer that is already registered).
+	// Maps to gRPC AlreadyExists / HTTP 409.
+	KindAlreadyExists
 )
 
 // Error is a typed service error carrying a transport-neutral Kind alongside a
@@ -98,4 +102,9 @@ func FailedPrecondition(msg string) error {
 // TooManyRequests reports a request rejected for exceeding a rate/attempt limit.
 func TooManyRequests(msg string) error {
 	return &Error{Kind: KindTooManyRequests, msg: msg}
+}
+
+// AlreadyExists reports a request that violates a uniqueness constraint.
+func AlreadyExists(msg string) error {
+	return &Error{Kind: KindAlreadyExists, msg: msg}
 }


### PR DESCRIPTION
## Why
Admin service methods returned bare `fmt.Errorf`/`errors.New` for ordinary
validation/conflict cases, which the interceptor's `ErrorMap` can't type —
every one collapsed to `codes.Internal` (500) instead of 400/409. Separately,
the gRPC `public` bypass was checked before the admin-service guard for any
service, not just the intentionally-public one — a footgun for a future
admin RPC accidentally marked `public`. `InviteMembers` also had three bugs:
a redundant N+1 re-fetch, a `// continue to next email` comment with no
actual `continue`, and no cap on the invite batch size.

## What
- New `KindAlreadyExists` error kind → `codes.AlreadyExists` (409), wired into
  gRPC, REST, and GraphQL error mapping consistently.
- All `admin_*.go` validation/conflict/missing/precondition errors now use the
  typed constructors (`InvalidArgument`, `AlreadyExists`, `NotFound`,
  `FailedPrecondition`) instead of bare errors.
- Public-method bypass scoped to the public service **and** `AdminLogin` only
  (which legitimately must stay public to bootstrap admin auth — the naive
  "no admin RPC is public" premise was wrong and would have locked out login;
  caught by the new interceptor test before it shipped).
- `InviteMembers`: reuses `AddUser`'s return instead of re-fetching, adds the
  missing `continue`, caps the batch at 100 emails.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `make lint-go` — 0 issues
- [x] New errormap tests: `AlreadyExists` mapping, wrapped-typed-error still resolves
- [x] New interceptor tests: `AdminLogin` stays public, no *other* admin RPC does
- [x] New `InviteMembers` tests: call-count, continue-on-error, >100 rejected
- [x] `make test` — 32 packages, 0 failures