### PR TITLE
fix(panics): guard claim/header type assertions that could crash the process

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -135,7 +135,10 @@ func (p *provider) RegisterEvent(ctx context.Context, eventName string, authReci
 			log.Debug().Err(err).Msg("error un-marshalling headers")
 		}
 		for key, val := range headersMap {
-			req.Header.Set(key, val.(string))
+			// Header values come from admin-configured JSON (a Map scalar), so a
+			// value may be a number/bool/object; coerce instead of asserting to
+			// avoid panicking this bare goroutine (which would crash the process).
+			req.Header.Set(key, headerValueString(val))
 		}
 
 		resp, err := client.Do(req)
@@ -164,4 +167,17 @@ func (p *provider) RegisterEvent(ctx context.Context, eventName string, authReci
 		}
 	}
 	return nil
+}
+
+// headerValueString coerces a free-form JSON header value to a string without
+// panicking. Mirrors the identically named helper in internal/service used by
+// the webhook TestEndpoint path (kept local to avoid an import cycle).
+func headerValueString(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v)
 }

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1,0 +1,25 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Webhook custom headers are stored as a JSON object (the GraphQL Map scalar),
+// so an admin can persist a value that is a number, bool, null or nested object
+// (e.g. {"X-Retry": 3}). RegisterEvent's header loop previously did
+// val.(string) — a single-return assertion that PANICS on any non-string value.
+// That loop runs inside a bare `go func()` (see the RegisterEvent call sites),
+// so the panic is unrecovered and crashes the whole process.
+//
+// headerValueString coerces the value instead. These cases cover the exact
+// inputs that used to panic.
+func TestHeaderValueString_NonStringDoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		require.Equal(t, "hello", headerValueString("hello"))
+		require.Equal(t, "", headerValueString(nil))
+		require.Equal(t, "3", headerValueString(float64(3))) // JSON numbers decode to float64
+		require.Equal(t, "true", headerValueString(true))
+	})
+}

--- a/internal/http_handlers/verify_email.go
+++ b/internal/http_handlers/verify_email.go
@@ -93,7 +93,7 @@ func (h *httpProvider) VerifyEmailHandler() gin.HandlerFunc {
 		// Resolved once, early: needed both for the MFA-gate-withheld redirect
 		// below and the success redirect further down.
 		if redirectURL == "" {
-			redirectURL = claim["redirect_uri"].(string)
+			redirectURL = claimString(claim, "redirect_uri")
 		}
 		if !validators.IsValidRedirectURI(redirectURL, h.Config.AllowedOrigins, hostname) {
 			log.Debug().Msg("Invalid redirect URI in token claim")

--- a/internal/http_handlers/verify_email_claim_test.go
+++ b/internal/http_handlers/verify_email_claim_test.go
@@ -1,0 +1,33 @@
+package http_handlers
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// VerifyEmailHandler reads the redirect_uri out of a server-signed verification
+// token when no redirect_uri query param is supplied. redirect_uri is NOT
+// checked by ValidateJWTClaims, so a token minted for a signup/magic-link flow
+// that carried no redirect_uri simply has no "redirect_uri" claim. The handler
+// previously did claim["redirect_uri"].(string) — a single-return assertion
+// that PANICS on an absent (or non-string) claim, crashing the request.
+//
+// The fix routes the read through the package's claimString helper. These cases
+// reproduce the panic-triggering inputs and assert a graceful zero value.
+func TestVerifyEmailRedirectClaim_NoPanicOnMissingOrNonString(t *testing.T) {
+	// Absent claim (token minted without a redirect_uri).
+	require.NotPanics(t, func() {
+		require.Equal(t, "", claimString(jwt.MapClaims{}, "redirect_uri"))
+	})
+
+	// Present but non-string (e.g. a numeric/bool value in the claim).
+	require.NotPanics(t, func() {
+		require.Equal(t, "", claimString(jwt.MapClaims{"redirect_uri": 12345}, "redirect_uri"))
+	})
+
+	// Present and a string is returned unchanged.
+	require.Equal(t, "https://app.example.com/cb",
+		claimString(jwt.MapClaims{"redirect_uri": "https://app.example.com/cb"}, "redirect_uri"))
+}


### PR DESCRIPTION
## Why
Two unguarded single-return type assertions on untrusted map values could
panic. The email-verify one crashes a single request. The webhook-events one
is worse: `RegisterEvent` (a `map[string]any` GraphQL scalar for headers) runs
from bare goroutines with no recover, so an admin saving a webhook with a
non-string header value (e.g. `{"X-Retry": 3}`) crashes the **entire process**
on the next login/signup that fires the event.

## What
- `internal/http_handlers/verify_email.go`: missing/non-string `redirect_uri`
  claim now resolves through the existing `claimString` helper instead of a
  bare assertion — falls back to a clean 400 instead of panicking.
- `internal/events/events.go`: webhook header values now coerced safely instead
  of asserted, mirroring the coercion the `TestEndpoint` path already uses.

Everything else audited (JWT `sub` claims, bearer-token splits, `@@`-state
splits, rate-limit division) was already guarded — left untouched.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` — 0 issues
- [x] New regression tests reproduce both panic-triggering inputs, assert
      graceful handling instead
- [x] `make test` — 33 packages, 0 failures