### PR TITLE
fix(web): dashboard CSV/InputField crashes, app login a11y

### DIFF
--- a/web/app/src/pages/dashboard.tsx
+++ b/web/app/src/pages/dashboard.tsx
@@ -8,9 +8,15 @@ export default function Dashboard() {
 
 	const onLogout = async () => {
 		setLoading(true);
-		await authorizerRef.logout();
-		setToken(null);
-		setLoading(false);
+		try {
+			await authorizerRef.logout();
+		} finally {
+			// Always clear the local session and drop the loading state, even if
+			// the server logout call fails — the user is logged out client-side
+			// regardless, so the UI must never get stuck on "Processing....".
+			setToken(null);
+			setLoading(false);
+		}
 	};
 
 	return (
@@ -34,15 +40,25 @@ export default function Dashboard() {
 			{loading ? (
 				<h3>Processing....</h3>
 			) : (
-				<h3
+				<button
+					type="button"
+					onClick={onLogout}
 					style={{
 						color: '#3B82F6',
 						cursor: 'pointer',
+						background: 'none',
+						border: 'none',
+						padding: 0,
+						margin: '1em 0',
+						font: 'inherit',
+						fontSize: '1.17em',
+						fontWeight: 'bold',
+						display: 'block',
+						textAlign: 'left',
 					}}
-					onClick={onLogout}
 				>
 					Logout
-				</h3>
+				</button>
 			)}
 		</div>
 	);

--- a/web/app/src/pages/login.tsx
+++ b/web/app/src/pages/login.tsx
@@ -36,6 +36,20 @@ const HRDForm = styled.form`
 	width: 100%;
 `;
 
+// Visually hidden but still exposed to screen readers (WCAG 3.3.2) — the HRD
+// email field has only a placeholder otherwise, which assistive tech ignores.
+const VisuallyHiddenLabel = styled.label`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`;
+
 const HRDInput = styled.input`
 	width: 100%;
 	padding: 10px;
@@ -151,7 +165,9 @@ export default function Login({ urlProps }: { urlProps: Record<string, any> }) {
 			<Fragment>
 				<h1 style={{ textAlign: 'center' }}>Login</h1>
 				<HRDForm onSubmit={handleHRDSubmit}>
+					<VisuallyHiddenLabel htmlFor="hrd-email">Email</VisuallyHiddenLabel>
 					<HRDInput
+						id="hrd-email"
 						type="email"
 						placeholder="Enter your email"
 						value={hrdEmail}

--- a/web/dashboard/src/components/InputField.test.tsx
+++ b/web/dashboard/src/components/InputField.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import InputField from './InputField';
+import { ArrayInputType, MultiSelectInputType } from '../constants';
+
+// Regression coverage for two runtime crashes InputField used to hit despite
+// TypeScript considering the code "safe":
+//  1. A `fieldVisibility!` non-null assertion threw when a caller passed only
+//     setFieldVisibility (the two props are independently optional).
+//  2. `variables[inputType] as string[]` .map()'d an undefined array when the
+//     field's value was never initialized.
+describe('InputField', () => {
+	it('does not throw when setFieldVisibility is passed without fieldVisibility', () => {
+		const setFieldVisibility = vi.fn();
+		const { container } = render(
+			<InputField
+				inputType="CLIENT_SECRET"
+				variables={{ CLIENT_SECRET: 'shhh' }}
+				setVariables={() => {}}
+				setFieldVisibility={setFieldVisibility}
+			/>,
+		);
+		// The first button is the show/hide (eye) toggle. Clicking it used to
+		// throw on `fieldVisibility!`; the guard now degrades gracefully.
+		const toggle = container.querySelector('button');
+		expect(toggle).not.toBeNull();
+		expect(() => fireEvent.click(toggle!)).not.toThrow();
+		expect(setFieldVisibility).not.toHaveBeenCalled();
+	});
+
+	it('renders an empty ArrayInputType list (no crash) when the array is undefined', () => {
+		expect(() =>
+			render(
+				<InputField
+					inputType={ArrayInputType.ROLES}
+					variables={{}}
+					setVariables={() => {}}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	it('renders an empty MultiSelectInputType list (no crash) when the array is undefined', () => {
+		expect(() =>
+			render(
+				<InputField
+					inputType={MultiSelectInputType.USER_ROLES}
+					variables={{}}
+					setVariables={() => {}}
+					availableRoles={['admin']}
+				/>,
+			),
+		).not.toThrow();
+	});
+});

--- a/web/dashboard/src/components/InputField.tsx
+++ b/web/dashboard/src/components/InputField.tsx
@@ -130,12 +130,13 @@ const InputField = ({
 					<button
 						type="button"
 						className="text-gray-400 hover:text-gray-600"
-						onClick={() =>
-							setFieldVisibility?.({
-								...fieldVisibility!,
-								[inputType]: !fieldVisibility![inputType],
-							})
-						}
+						onClick={() => {
+							if (!fieldVisibility || !setFieldVisibility) return;
+							setFieldVisibility({
+								...fieldVisibility,
+								[inputType]: !fieldVisibility[inputType],
+							});
+						}}
 					>
 						{fieldVisibility?.[inputType] ? (
 							<EyeOff className="h-3.5 w-3.5" />
@@ -158,12 +159,12 @@ const InputField = ({
 	}
 
 	if (Object.values(ArrayInputType).includes(inputType)) {
-		const items = variables[inputType] as string[];
+		const items = (variables[inputType] as string[]) ?? [];
 		return (
 			<div className="flex w-full items-center gap-1 rounded-md border border-gray-300 px-2 py-1 overflow-x-auto">
-				{items.map((role: string, index: number) => (
+				{items.map((role: string) => (
 					<span
-						key={index}
+						key={role}
 						className="group inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-0.5 text-xs whitespace-nowrap"
 					>
 						{role}
@@ -233,14 +234,14 @@ const InputField = ({
 	}
 
 	if (Object.values(MultiSelectInputType).includes(inputType)) {
-		const selectedRoles = variables[inputType] as string[];
+		const selectedRoles = (variables[inputType] as string[]) ?? [];
 		return (
 			<div className="relative w-full">
 				<div className="flex w-full items-center justify-between rounded-md border border-gray-300 px-2 py-1 min-h-[32px]">
 					<div className="flex flex-wrap gap-1">
-						{selectedRoles.map((role: string, index: number) => (
+						{selectedRoles.map((role: string) => (
 							<span
-								key={index}
+								key={role}
 								className="group inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-0.5 text-xs"
 							>
 								{role}

--- a/web/dashboard/src/components/InviteMembersModal.tsx
+++ b/web/dashboard/src/components/InviteMembersModal.tsx
@@ -125,9 +125,13 @@ const InviteMembersModal = ({ updateUserList }: InviteMembersModalProps) => {
 	};
 
 	const onDrop = useCallback(async (acceptedFiles: File[]) => {
-		const result = await parseCSV(acceptedFiles[0], ',');
-		setEmails(result);
-		setTabIndex(0);
+		try {
+			const result = await parseCSV(acceptedFiles[0], ',');
+			setEmails(result);
+			setTabIndex(0);
+		} catch (error) {
+			toast.error(getGraphQLErrorMessage(error));
+		}
 	}, []);
 
 	const setRedirectURIHandler = (value: string) => {

--- a/web/dashboard/src/utils/parseCSV.test.ts
+++ b/web/dashboard/src/utils/parseCSV.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import parseCSV from './parseCSV';
+
+// parseCSV wraps a FileReader in a Promise. The regression it guards against:
+// a FileReader error (locked / unreadable file) used to leave the promise
+// pending forever, so the "Import users" UI hung with no error surfaced.
+describe('parseCSV', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('resolves with parsed, validity-tagged entries on success', async () => {
+		const file = new File(['a@b.com,not-an-email'], 'users.csv', {
+			type: 'text/csv',
+		});
+		const result = await parseCSV(file, ',');
+		expect(result).toEqual([
+			{ value: 'a@b.com', isInvalid: false },
+			{ value: 'not-an-email', isInvalid: true },
+		]);
+	});
+
+	it('rejects (does not hang) when the FileReader errors', async () => {
+		// Stub FileReader so readAsText drives the error path deterministically.
+		class ErroringFileReader {
+			onerror: (() => void) | null = null;
+			onload: (() => void) | null = null;
+			abort() {}
+			readAsText() {
+				this.onerror?.();
+			}
+		}
+		vi.stubGlobal('FileReader', ErroringFileReader);
+
+		const file = new File(['whatever'], 'users.csv', { type: 'text/csv' });
+		await expect(parseCSV(file, ',')).rejects.toThrow(
+			'Failed to read the selected file',
+		);
+	});
+});

--- a/web/dashboard/src/utils/parseCSV.ts
+++ b/web/dashboard/src/utils/parseCSV.ts
@@ -7,8 +7,13 @@ interface DataTypes {
 }
 
 const parseCSV = (file: File, delimiter: string): Promise<DataTypes[]> => {
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		const reader = new FileReader();
+
+		reader.onerror = () => {
+			reader.abort();
+			reject(new Error('Failed to read the selected file'));
+		};
 
 		reader.onload = (e: ProgressEvent<FileReader>) => {
 			const lines = (e.target?.result as string).split('\n');


### PR DESCRIPTION
## Why
`parseCSV` had no `FileReader.onerror`, so a bad file left the import UI
hung forever with no error. `InputField` used a non-null assertion that
could throw when only one of an independently-optional prop pair was set,
plus an unguarded array access and index-as-key on a removable list. In
`web/app`, logout was a non-interactive `<h3>` with no error handling
(keyboard-unreachable, could strand the UI on "Processing…."), and the HRD
email input had no associated label (WCAG 3.3.2).

## What
- `parseCSV.ts`: `reader.onerror` now rejects the promise; caller surfaces it via toast.
- `InputField.tsx`: guarded `fieldVisibility`/`setFieldVisibility` instead of
  asserting; `?? []` fallback for the Array/MultiSelect variable read;
  `key={role}` instead of index on the removable list.
- `dashboard.tsx` (web/app): logout wrapped in try/finally; the control is now
  a real `<button>`, restyled to match the previous look.
- `login.tsx` (web/app): visually-hidden `<label htmlFor>` added for the HRD
  email input.

## Test plan
- [x] `web/dashboard`: new vitest cases (parseCSV error path, InputField guards) — 5 passed
- [x] `web/dashboard`: full suite — 37 passed, no regressions
- [x] `tsc --noEmit` clean on both apps; `vite build` clean on web/app
- [x] Prettier `--check` clean on both apps
- [ ] `web/app` has no test runner configured — the two fixes there were made
      structurally safe (try/finally, static markup) rather than covered by a
      new test framework; verified by typecheck + build only