### PR TITLE
feat(scim): filter operators, provisioning webhooks, full user PATCH

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -636,6 +636,7 @@ func runRoot(c *cobra.Command, args []string) {
 		StorageProvider:     storageProvider,
 		MemoryStoreProvider: memoryStoreProvider,
 		AuthzEngine:         authzEngine,
+		EventsProvider:      eventsProvider,
 	})
 	scimHandler := scimhttp.New(&scimhttp.Dependencies{
 		Log:     &log,

--- a/internal/constants/webhook_event_scim.go
+++ b/internal/constants/webhook_event_scim.go
@@ -1,0 +1,23 @@
+package constants
+
+// SCIM provisioning-lifecycle webhook events (RFC 7644 directory sync). Fired
+// by the inbound SCIM server so a customer's own audit/automation pipeline can
+// react to IdP-driven changes. User events carry a `user` payload; group events
+// carry a `group` payload (see events.RegisterScimGroupEvent).
+const (
+	// UserProvisionedWebhookEvent fires when an IdP creates a user via SCIM.
+	UserProvisionedWebhookEvent = `user.provisioned`
+	// UserDeprovisionedWebhookEvent fires when an IdP deactivates a user via SCIM
+	// (active:false PATCH/PUT or DELETE).
+	UserDeprovisionedWebhookEvent = `user.deprovisioned`
+	// UserScimUpdatedWebhookEvent fires when an IdP changes a user's attributes
+	// via SCIM (name/email/phone/externalId, or reactivation).
+	UserScimUpdatedWebhookEvent = `user.scim_updated`
+	// GroupCreatedWebhookEvent fires when an IdP creates a group via SCIM.
+	GroupCreatedWebhookEvent = `group.created`
+	// GroupUpdatedWebhookEvent fires when an IdP changes a group via SCIM
+	// (displayName/externalId or membership).
+	GroupUpdatedWebhookEvent = `group.updated`
+	// GroupDeletedWebhookEvent fires when an IdP deletes a group via SCIM.
+	GroupDeletedWebhookEvent = `group.deleted`
+)

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -31,6 +32,10 @@ type Dependencies struct {
 type Provider interface {
 	// RegisterEvent to register event and add webhook logs
 	RegisterEvent(ctx context.Context, eventName string, authRecipe string, user *schemas.User) error
+	// RegisterScimGroupEvent fires a SCIM group-lifecycle webhook. Unlike
+	// RegisterEvent the payload carries a `group` object (not a `user`), so it
+	// can dispatch group.created/updated/deleted for the SCIM provisioning flow.
+	RegisterScimGroupEvent(ctx context.Context, eventName string, group *schemas.ScimGroup) error
 }
 
 type provider struct {
@@ -54,119 +59,152 @@ func (p *provider) RegisterEvent(ctx context.Context, eventName string, authReci
 		log.Debug().Err(err).Msg("error getting webhook")
 		return err
 	}
+	userBytes, err := json.Marshal(user.AsAPIUser())
+	if err != nil {
+		log.Debug().Err(err).Msg("error marshalling user obj")
+		return err
+	}
+	userMap := map[string]interface{}{}
+	if err := json.Unmarshal(userBytes, &userMap); err != nil {
+		log.Debug().Err(err).Msg("error un-marshalling user obj")
+		return err
+	}
 	for _, webhook := range webhooks {
 		if !webhook.Enabled {
 			continue
 		}
-		userBytes, err := json.Marshal(user.AsAPIUser())
-		if err != nil {
-			log.Debug().Err(err).Msg("error marshalling user obj")
-			continue
-		}
-		userMap := map[string]interface{}{}
-		err = json.Unmarshal(userBytes, &userMap)
-		if err != nil {
-			log.Debug().Err(err).Msg("error un-marshalling user obj")
-			continue
-		}
-
 		reqBody := map[string]interface{}{
 			"webhook_id":        webhook.ID,
 			"event_name":        eventName,
 			"event_description": webhook.EventDescription,
 			"user":              userMap,
 		}
-
 		if eventName == constants.UserLoginWebhookEvent || eventName == constants.UserSignUpWebhookEvent {
 			reqBody["auth_recipe"] = authRecipe
 		}
-
-		requestBody, err := json.Marshal(reqBody)
-		if err != nil {
-			log.Debug().Err(err).Msg("error marshalling requestBody obj")
-			continue
-		}
-
-		// don't trigger webhook call in case of test
-		if p.config.Env == constants.TestEnv {
-			_, err := p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
-				HttpStatus: 200,
-				Request:    string(requestBody),
-				Response:   string(`{"message": "test"}`),
-				WebhookID:  webhook.ID,
-			})
-			if err != nil {
-				log.Debug().Err(err).Msg("error saving webhook log")
-			}
-			continue
-		}
-
-		// SSRF protection: resolve the host once and pin the dialer to the
-		// validated IP so http.Client cannot be tricked into re-resolving
-		// (DNS rebinding TOCTOU).
-		client, err := validators.SafeHTTPClient(ctx, webhook.EndPoint, time.Second*30)
-		if err != nil {
-			log.Debug().Err(err).Str("endpoint", webhook.EndPoint).Msg("webhook endpoint rejected by SSRF filter")
-			_, _ = p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
-				HttpStatus: 0,
-				Request:    string(requestBody),
-				Response:   fmt.Sprintf(`{"error": "SSRF validation failed: %s"}`, err.Error()),
-				WebhookID:  webhook.ID,
-			})
-			continue
-		}
-
-		// Compute HMAC-SHA256 signature for payload authenticity
-		mac := hmac.New(sha256.New, []byte(p.config.ClientSecret))
-		mac.Write(requestBody)
-		signature := hex.EncodeToString(mac.Sum(nil))
-
-		requestBytesBuffer := bytes.NewBuffer(requestBody)
-		req, err := http.NewRequest("POST", webhook.EndPoint, requestBytesBuffer)
-		if err != nil {
-			log.Debug().Err(err).Msg("error creating request")
-			continue
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Authorizer-Signature", signature)
-		headersMap := make(map[string]interface{})
-		err = json.Unmarshal([]byte(webhook.Headers), &headersMap)
-		if err != nil {
-			log.Debug().Err(err).Msg("error un-marshalling headers")
-		}
-		for key, val := range headersMap {
-			// Header values come from admin-configured JSON (a Map scalar), so a
-			// value may be a number/bool/object; coerce instead of asserting to
-			// avoid panicking this bare goroutine (which would crash the process).
-			req.Header.Set(key, headerValueString(val))
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			log.Debug().Err(err).Msg("error making request")
-			continue
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		responseBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
-		if err != nil {
-			log.Debug().Err(err).Msg("error reading response")
-			continue
-		}
-
-		statusCode := int64(resp.StatusCode)
-		_, err = p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
-			HttpStatus: statusCode,
-			Request:    string(requestBody),
-			Response:   string(responseBytes),
-			WebhookID:  webhook.ID,
-		})
-		if err != nil {
-			log.Debug().Err(err).Msg("error saving webhook log")
-			continue
-		}
+		p.deliver(ctx, &log, webhook, reqBody)
 	}
 	return nil
+}
+
+// RegisterScimGroupEvent fires a SCIM group-lifecycle webhook. The payload
+// carries a `group` object (id, org, displayName, de-namespaced externalId)
+// instead of a `user`, sharing the same delivery path (SSRF pin, HMAC, log).
+func (p *provider) RegisterScimGroupEvent(ctx context.Context, eventName string, group *schemas.ScimGroup) error {
+	log := p.deps.Log.With().Str("func", "RegisterScimGroupEvent").Str("event", eventName).Logger()
+	webhooks, err := p.deps.StorageProvider.GetWebhookByEventName(ctx, eventName)
+	if err != nil {
+		log.Debug().Err(err).Msg("error getting webhook")
+		return err
+	}
+	groupMap := map[string]interface{}{
+		"id":           group.ID,
+		"org_id":       group.OrgID,
+		"display_name": group.DisplayName,
+	}
+	if group.ExternalID != nil {
+		// De-namespace back to the raw IdP value ("<orgID>:<raw>") for the consumer.
+		groupMap["external_id"] = strings.TrimPrefix(*group.ExternalID, group.OrgID+":")
+	}
+	for _, webhook := range webhooks {
+		if !webhook.Enabled {
+			continue
+		}
+		reqBody := map[string]interface{}{
+			"webhook_id":        webhook.ID,
+			"event_name":        eventName,
+			"event_description": webhook.EventDescription,
+			"group":             groupMap,
+		}
+		p.deliver(ctx, &log, webhook, reqBody)
+	}
+	return nil
+}
+
+// deliver marshals reqBody and POSTs it to one webhook endpoint, logging the
+// outcome. It centralises the security-sensitive delivery mechanics (SSRF pin,
+// HMAC signature, TestEnv short-circuit, response log) shared by every event
+// type. Errors are logged and swallowed per-webhook — one bad endpoint never
+// aborts delivery to the others.
+func (p *provider) deliver(ctx context.Context, log *zerolog.Logger, webhook *schemas.Webhook, reqBody map[string]interface{}) {
+	requestBody, err := json.Marshal(reqBody)
+	if err != nil {
+		log.Debug().Err(err).Msg("error marshalling requestBody obj")
+		return
+	}
+
+	// don't trigger webhook call in case of test
+	if p.config.Env == constants.TestEnv {
+		if _, err := p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
+			HttpStatus: 200,
+			Request:    string(requestBody),
+			Response:   string(`{"message": "test"}`),
+			WebhookID:  webhook.ID,
+		}); err != nil {
+			log.Debug().Err(err).Msg("error saving webhook log")
+		}
+		return
+	}
+
+	// SSRF protection: resolve the host once and pin the dialer to the
+	// validated IP so http.Client cannot be tricked into re-resolving
+	// (DNS rebinding TOCTOU).
+	client, err := validators.SafeHTTPClient(ctx, webhook.EndPoint, time.Second*30)
+	if err != nil {
+		log.Debug().Err(err).Str("endpoint", webhook.EndPoint).Msg("webhook endpoint rejected by SSRF filter")
+		_, _ = p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
+			HttpStatus: 0,
+			Request:    string(requestBody),
+			Response:   fmt.Sprintf(`{"error": "SSRF validation failed: %s"}`, err.Error()),
+			WebhookID:  webhook.ID,
+		})
+		return
+	}
+
+	// Compute HMAC-SHA256 signature for payload authenticity
+	mac := hmac.New(sha256.New, []byte(p.config.ClientSecret))
+	mac.Write(requestBody)
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	req, err := http.NewRequest("POST", webhook.EndPoint, bytes.NewBuffer(requestBody))
+	if err != nil {
+		log.Debug().Err(err).Msg("error creating request")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Authorizer-Signature", signature)
+	headersMap := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(webhook.Headers), &headersMap); err != nil {
+		log.Debug().Err(err).Msg("error un-marshalling headers")
+	}
+	for key, val := range headersMap {
+		// Header values come from admin-configured JSON (a Map scalar), so a
+		// value may be a number/bool/object; coerce instead of asserting to
+		// avoid panicking this bare goroutine (which would crash the process).
+		req.Header.Set(key, headerValueString(val))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Debug().Err(err).Msg("error making request")
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	responseBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		log.Debug().Err(err).Msg("error reading response")
+		return
+	}
+
+	if _, err := p.deps.StorageProvider.AddWebhookLog(ctx, &schemas.WebhookLog{
+		HttpStatus: int64(resp.StatusCode),
+		Request:    string(requestBody),
+		Response:   string(responseBytes),
+		WebhookID:  webhook.ID,
+	}); err != nil {
+		log.Debug().Err(err).Msg("error saving webhook log")
+	}
 }
 
 // headerValueString coerces a free-form JSON header value to a string without

--- a/internal/http_handlers/scim/discovery.go
+++ b/internal/http_handlers/scim/discovery.go
@@ -7,15 +7,15 @@ import (
 )
 
 // serviceProviderConfig advertises which SCIM features this server supports so
-// an IdP knows to use PATCH (deprovisioning), no bulk, no filtering beyond the
-// single `userName eq` probe, and bearer auth (RFC 7644 §5).
+// an IdP knows to use PATCH (deprovisioning), no bulk, single-term filtering
+// (eq/ne/co/sw/pr over the core User attributes), and bearer auth (RFC 7644 §5).
 func (h *Handler) serviceProviderConfig(c *gin.Context) {
 	cfg := gin.H{
 		"schemas":          []string{schemaSPConfig},
 		"documentationUri": "https://docs.authorizer.dev",
 		"patch":            gin.H{"supported": true},
 		"bulk":             gin.H{"supported": false, "maxOperations": 0, "maxPayloadSize": 0},
-		"filter":           gin.H{"supported": true, "maxResults": 1},
+		"filter":           gin.H{"supported": true, "maxResults": 1000},
 		"changePassword":   gin.H{"supported": false},
 		"sort":             gin.H{"supported": false},
 		"etag":             gin.H{"supported": false},

--- a/internal/http_handlers/scim/scim_test.go
+++ b/internal/http_handlers/scim/scim_test.go
@@ -32,6 +32,11 @@ type fakeService struct {
 	groupErr     error
 	groupMembers []string
 	lastGroup    string
+
+	listResult []*schemas.User
+	listErr    error
+	lastFilter svcscim.UserFilter
+	lastPatch  svcscim.UserPatch
 }
 
 func (f *fakeService) Authenticate(_ context.Context, bearer string) (string, error) {
@@ -53,6 +58,19 @@ func (f *fakeService) GetUser(_ context.Context, orgID, userID string) (*schemas
 }
 func (f *fakeService) FindByUserName(_ context.Context, orgID, _ string) (*schemas.User, error) {
 	f.lastOrg = orgID
+	return f.created, nil
+}
+func (f *fakeService) ListUsers(_ context.Context, orgID string, filter svcscim.UserFilter) ([]*schemas.User, error) {
+	f.lastOrg = orgID
+	f.lastFilter = filter
+	return f.listResult, f.listErr
+}
+func (f *fakeService) PatchUser(_ context.Context, orgID, userID string, patch svcscim.UserPatch) (*schemas.User, error) {
+	f.lastOrg, f.lastUser = orgID, userID
+	f.lastPatch = patch
+	if f.setErr != nil {
+		return nil, f.setErr
+	}
 	return f.created, nil
 }
 func (f *fakeService) ReplaceUser(_ context.Context, orgID, userID string, _ svcscim.User) (*schemas.User, error) {
@@ -200,13 +218,145 @@ func TestDeleteReturns204(t *testing.T) {
 
 func TestListUserNameFilter(t *testing.T) {
 	svc := &fakeService{authOrg: "org-a",
-		created: &schemas.User{ID: "u1", Email: strptr("bob@acme.com"), IsActive: true}}
+		listResult: []*schemas.User{{ID: "u1", Email: strptr("bob@acme.com"), IsActive: true}}}
 	r := newTestServer(svc)
 	w := do(r, http.MethodGet, `/scim/v2/Users?filter=userName+eq+%22bob@acme.com%22`, "ep.secret", "")
 	require.Equal(t, http.StatusOK, w.Code)
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.EqualValues(t, 1, body["totalResults"])
+	// The parsed filter must reach the service canonicalised.
+	assert.Equal(t, svcscim.UserFilter{Attribute: "userName", Operator: "eq", Value: "bob@acme.com"}, svc.lastFilter)
+}
+
+// TestListUsersFilterParsing checks the handler canonicalises every supported
+// operator/attribute and 400s on unsupported filter shapes.
+func TestListUsersFilterParsing(t *testing.T) {
+	ok := []struct {
+		query string
+		want  svcscim.UserFilter
+	}{
+		{`filter=userName+eq+%22a@b.com%22`, svcscim.UserFilter{Attribute: "userName", Operator: "eq", Value: "a@b.com"}},
+		{`filter=emails.value+eq+%22a@b.com%22`, svcscim.UserFilter{Attribute: "emails.value", Operator: "eq", Value: "a@b.com"}},
+		{`filter=name.familyName+co+%22Doe%22`, svcscim.UserFilter{Attribute: "name.familyName", Operator: "co", Value: "Doe"}},
+		{`filter=name.givenName+sw+%22Jo%22`, svcscim.UserFilter{Attribute: "name.givenName", Operator: "sw", Value: "Jo"}},
+		{`filter=active+eq+true`, svcscim.UserFilter{Attribute: "active", Operator: "eq", Value: "true"}},
+		{`filter=externalId+pr`, svcscim.UserFilter{Attribute: "externalId", Operator: "pr"}},
+	}
+	for _, tc := range ok {
+		t.Run(tc.query, func(t *testing.T) {
+			svc := &fakeService{authOrg: "org-a"}
+			r := newTestServer(svc)
+			w := do(r, http.MethodGet, "/scim/v2/Users?"+tc.query, "ep.secret", "")
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tc.want, svc.lastFilter)
+		})
+	}
+
+	bad := []string{
+		`filter=userName+eq+%22a%22+and+active+eq+true`,          // compound
+		`filter=emails%5Btype+eq+%22work%22%5D.value+eq+%22a%22`, // value-path
+		`filter=displayName+eq+%22x%22`,                          // unsupported attribute
+		`filter=userName+gt+%22a%22`,                             // unsupported operator
+		`filter=active+co+%22tr%22`,                              // co on boolean
+	}
+	for _, q := range bad {
+		t.Run("bad/"+q, func(t *testing.T) {
+			svc := &fakeService{authOrg: "org-a"}
+			r := newTestServer(svc)
+			w := do(r, http.MethodGet, "/scim/v2/Users?"+q, "ep.secret", "")
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// TestListUsersPagination checks startIndex/count slicing over the result set.
+func TestListUsersPagination(t *testing.T) {
+	svc := &fakeService{authOrg: "org-a", listResult: []*schemas.User{
+		{ID: "u1", Email: strptr("a@x.com"), IsActive: true},
+		{ID: "u2", Email: strptr("b@x.com"), IsActive: true},
+		{ID: "u3", Email: strptr("c@x.com"), IsActive: true},
+	}}
+	r := newTestServer(svc)
+	w := do(r, http.MethodGet, `/scim/v2/Users?filter=active+eq+true&startIndex=2&count=1`, "ep.secret", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.EqualValues(t, 3, body["totalResults"])
+	assert.EqualValues(t, 2, body["startIndex"])
+	assert.EqualValues(t, 1, body["itemsPerPage"])
+	res, _ := body["Resources"].([]any)
+	require.Len(t, res, 1)
+}
+
+// TestPatchUserShapes proves both the path-qualified and no-path attribute-map
+// shapes reach the service as the same parsed UserPatch, and that the existing
+// active-only PATCH still works.
+func TestPatchUserShapes(t *testing.T) {
+	t.Run("active regression (both shapes)", func(t *testing.T) {
+		for _, body := range []string{
+			`{"Operations":[{"op":"replace","path":"active","value":false}]}`,
+			`{"Operations":[{"op":"Replace","value":{"active":false}}]}`,
+		} {
+			svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: false}}
+			r := newTestServer(svc)
+			w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret", body)
+			require.Equal(t, http.StatusOK, w.Code)
+			require.NotNil(t, svc.lastPatch.Active)
+			assert.False(t, *svc.lastPatch.Active)
+		}
+	})
+
+	t.Run("path-qualified name.givenName", func(t *testing.T) {
+		svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: true}}
+		r := newTestServer(svc)
+		w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret",
+			`{"Operations":[{"op":"replace","path":"name.givenName","value":"Jonathan"}]}`)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, svc.lastPatch.GivenName)
+		assert.Equal(t, "Jonathan", *svc.lastPatch.GivenName)
+	})
+
+	t.Run("no-path attribute map", func(t *testing.T) {
+		svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: true}}
+		r := newTestServer(svc)
+		w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret",
+			`{"Operations":[{"op":"replace","value":{"name":{"givenName":"Jonathan","familyName":"Doe"},"externalId":"okta-9"}}]}`)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, svc.lastPatch.GivenName)
+		assert.Equal(t, "Jonathan", *svc.lastPatch.GivenName)
+		require.NotNil(t, svc.lastPatch.FamilyName)
+		assert.Equal(t, "Doe", *svc.lastPatch.FamilyName)
+		require.NotNil(t, svc.lastPatch.ExternalID)
+		assert.Equal(t, "okta-9", *svc.lastPatch.ExternalID)
+	})
+
+	t.Run("emails path-qualified and array", func(t *testing.T) {
+		svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: true}}
+		r := newTestServer(svc)
+		w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret",
+			`{"Operations":[{"op":"replace","path":"emails[type eq \"work\"].value","value":"new@acme.com"}]}`)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, svc.lastPatch.Email)
+		assert.Equal(t, "new@acme.com", *svc.lastPatch.Email)
+
+		svc2 := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: true}}
+		r2 := newTestServer(svc2)
+		w2 := do(r2, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret",
+			`{"Operations":[{"op":"replace","path":"emails","value":[{"value":"primary@acme.com","primary":true},{"value":"alt@acme.com"}]}]}`)
+		require.Equal(t, http.StatusOK, w2.Code)
+		require.NotNil(t, svc2.lastPatch.Email)
+		assert.Equal(t, "primary@acme.com", *svc2.lastPatch.Email, "primary email must win")
+	})
+
+	t.Run("unmodelled path is ignored not 400", func(t *testing.T) {
+		svc := &fakeService{authOrg: "org-a", created: &schemas.User{ID: "u1", IsActive: true}}
+		r := newTestServer(svc)
+		w := do(r, http.MethodPatch, "/scim/v2/Users/u1", "ep.secret",
+			`{"Operations":[{"op":"replace","path":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department","value":"Eng"}]}`)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Nil(t, svc.lastPatch.GivenName)
+	})
 }
 
 func TestDiscoveryEndpointsServed(t *testing.T) {

--- a/internal/http_handlers/scim/users.go
+++ b/internal/http_handlers/scim/users.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -144,26 +145,77 @@ func (h *Handler) getUser(c *gin.Context) {
 	writeUser(c, http.StatusOK, h.orgID(c), user)
 }
 
-// listUsers supports only the `userName eq "..."` filter (the IdP dedup probe).
-// An unfiltered list returns an empty set — full org enumeration is out of scope.
+// listUsers evaluates a single-term SCIM filter (RFC 7644 §3.4.2.2) — operators
+// eq/ne/co/sw/pr over userName, emails.value, name.givenName, name.familyName,
+// active, externalId — against the org's members, honouring startIndex/count
+// pagination. An unfiltered list returns an empty set (full org enumeration is
+// out of scope); a filter the parser does not recognize is a 400 invalidFilter
+// (never an empty 200, which a connector reads as "no such user" and duplicates).
 func (h *Handler) listUsers(c *gin.Context) {
 	orgID := h.orgID(c)
-	filter := c.Query("filter")
 	resp := scimListResponse{
-		Schemas:      []string{schemaListResp},
-		StartIndex:   1,
-		ItemsPerPage: 0,
-		Resources:    []scimUserResource{},
+		Schemas:    []string{schemaListResp},
+		StartIndex: 1,
+		Resources:  []scimUserResource{},
 	}
-	if userName, ok := parseUserNameEq(filter); ok {
-		if user, err := h.Service.FindByUserName(c.Request.Context(), orgID, userName); err == nil && user != nil {
-			resp.Resources = append(resp.Resources, toResource(orgID, user))
-		}
+	filter := strings.TrimSpace(c.Query("filter"))
+	if filter == "" {
+		resp.ItemsPerPage = 0
+		c.Header("Content-Type", contentType)
+		c.JSON(http.StatusOK, resp)
+		return
 	}
-	resp.TotalResults = len(resp.Resources)
+	f, ok := parseUserFilter(filter)
+	if !ok {
+		writeError(c, http.StatusBadRequest, "invalidFilter", "unsupported filter expression")
+		return
+	}
+	users, err := h.Service.ListUsers(c.Request.Context(), orgID, f)
+	if err != nil {
+		mapServiceError(c, err)
+		return
+	}
+	all := make([]scimUserResource, 0, len(users))
+	for _, u := range users {
+		all = append(all, toResource(orgID, u))
+	}
+	// RFC 7644 §3.4.2.4 pagination: startIndex is 1-based, count caps the page.
+	startIndex := queryInt(c, "startIndex", 1)
+	if startIndex < 1 {
+		startIndex = 1
+	}
+	count := queryInt(c, "count", len(all))
+	if count < 0 {
+		count = 0
+	}
+	from := startIndex - 1
+	if from > len(all) {
+		from = len(all)
+	}
+	to := from + count
+	if to > len(all) {
+		to = len(all)
+	}
+	resp.TotalResults = len(all)
+	resp.StartIndex = startIndex
+	resp.Resources = all[from:to]
 	resp.ItemsPerPage = len(resp.Resources)
 	c.Header("Content-Type", contentType)
 	c.JSON(http.StatusOK, resp)
+}
+
+// queryInt reads a non-negative integer query param, returning def when absent
+// or unparseable.
+func queryInt(c *gin.Context, key string, def int) int {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return def
+	}
+	return n
 }
 
 func (h *Handler) replaceUser(c *gin.Context) {
@@ -180,26 +232,20 @@ func (h *Handler) replaceUser(c *gin.Context) {
 	writeUser(c, http.StatusOK, h.orgID(c), user)
 }
 
-// patchUser applies a SCIM PatchOp. ponytail: only the `active` attribute is
-// honoured (the deprovision path Okta/Entra drive); other paths are accepted
-// and ignored. Full attribute PATCH is a follow-up — use PUT for profile edits.
+// patchUser applies a SCIM PatchOp (RFC 7644 §3.5.2). It honours replace/add on
+// active, name.givenName, name.familyName, userName/emails (→ email),
+// phoneNumbers (→ phone), and externalId, in both the path-qualified and the
+// no-path attribute-map shapes. Paths the server does not model (e.g. enterprise
+// extension attributes) are ignored rather than 400'd, so a connector that also
+// syncs manager/department does not fail the whole request. An empty patch
+// returns the current resource unchanged (no event).
 func (h *Handler) patchUser(c *gin.Context) {
-	active, hasActive, ok := parseActivePatch(c)
+	patch, ok := parseUserPatch(c)
 	if !ok {
-		writeError(c, http.StatusBadRequest, "invalidValue", "invalid PatchOp body")
+		writeError(c, http.StatusBadRequest, "invalidSyntax", "invalid PatchOp body")
 		return
 	}
-	if !hasActive {
-		// Nothing we act on — return the current resource unchanged.
-		user, err := h.Service.GetUser(c.Request.Context(), h.orgID(c), c.Param("id"))
-		if err != nil {
-			mapServiceError(c, err)
-			return
-		}
-		writeUser(c, http.StatusOK, h.orgID(c), user)
-		return
-	}
-	user, err := h.Service.SetActive(c.Request.Context(), h.orgID(c), c.Param("id"), active)
+	user, err := h.Service.PatchUser(c.Request.Context(), h.orgID(c), c.Param("id"), patch)
 	if err != nil {
 		mapServiceError(c, err)
 		return
@@ -223,29 +269,82 @@ func writeUser(c *gin.Context, status int, orgID string, user *schemas.User) {
 	c.JSON(status, toResource(orgID, user))
 }
 
-// parseUserNameEq extracts X from `userName eq "X"` (case-insensitive operator).
-func parseUserNameEq(filter string) (string, bool) {
-	f := strings.TrimSpace(filter)
-	lower := strings.ToLower(f)
-	if !strings.HasPrefix(lower, "username eq ") {
-		return "", false
-	}
-	val := strings.TrimSpace(f[len("username eq "):])
-	val = strings.Trim(val, `"`)
-	if val == "" {
-		return "", false
-	}
-	return val, true
+// userFilterAttrs maps a lower-cased SCIM attribute path to its canonical name
+// (the form svcscim.UserFilter / the service expect). Only the attributes SCIM
+// directory sync actually filters on are supported.
+var userFilterAttrs = map[string]string{
+	"username":        "userName",
+	"emails.value":    "emails.value",
+	"name.givenname":  "name.givenName",
+	"name.familyname": "name.familyName",
+	"active":          "active",
+	"externalid":      "externalId",
 }
 
-// parseActivePatch reads a SCIM PatchOp and returns the requested active value.
-// It tolerates the two shapes IdPs send:
+// parseUserFilter parses a single-term SCIM filter `attribute op [value]` (RFC
+// 7644 §3.4.2.2) into a svcscim.UserFilter. Supported operators: eq, ne, co, sw,
+// pr. Compound filters (and/or/not), value-path filters (emails[type eq ...]),
+// and ordering operators (gt/lt/…) are deliberately unsupported — real user
+// directory-sync filters are single-term — and return ok=false so the handler
+// answers 400 invalidFilter rather than silently matching nothing.
+func parseUserFilter(filter string) (svcscim.UserFilter, bool) {
+	f := strings.TrimSpace(filter)
+	// Reject compound expressions outright.
+	if lf := strings.ToLower(f); strings.Contains(lf, " and ") || strings.Contains(lf, " or ") || strings.HasPrefix(lf, "not ") || strings.ContainsAny(f, "()[]") {
+		return svcscim.UserFilter{}, false
+	}
+	attrTok, rest, ok := strings.Cut(f, " ")
+	if !ok {
+		return svcscim.UserFilter{}, false
+	}
+	attr, ok := userFilterAttrs[strings.ToLower(strings.TrimSpace(attrTok))]
+	if !ok {
+		return svcscim.UserFilter{}, false
+	}
+	rest = strings.TrimSpace(rest)
+	opTok, valTok, hasVal := strings.Cut(rest, " ")
+	op := strings.ToLower(strings.TrimSpace(opTok))
+
+	switch op {
+	case "pr":
+		// present takes no value.
+		if strings.TrimSpace(valTok) != "" {
+			return svcscim.UserFilter{}, false
+		}
+		return svcscim.UserFilter{Attribute: attr, Operator: "pr"}, true
+	case "eq", "ne", "co", "sw":
+		if !hasVal {
+			return svcscim.UserFilter{}, false
+		}
+		// co/sw are meaningless on the boolean `active` attribute.
+		if attr == "active" && (op == "co" || op == "sw") {
+			return svcscim.UserFilter{}, false
+		}
+		val := unquoteFilterValue(valTok)
+		if val == "" {
+			return svcscim.UserFilter{}, false
+		}
+		return svcscim.UserFilter{Attribute: attr, Operator: op, Value: val}, true
+	default:
+		return svcscim.UserFilter{}, false
+	}
+}
+
+// parseUserPatch reads a SCIM User PatchOp into a svcscim.UserPatch. It handles
+// replace/add ops (single-valued attributes treat add ≡ replace) in both the
+// path-qualified shape:
 //
+//	{"op":"replace","path":"name.givenName","value":"Jonathan"}
 //	{"op":"replace","path":"active","value":false}
-//	{"op":"replace","value":{"active":false}}
+//	{"op":"replace","path":"emails[type eq \"work\"].value","value":"a@b.com"}
 //
-// op case is ignored; value may be a bool or the string "true"/"false".
-func parseActivePatch(c *gin.Context) (active bool, hasActive bool, ok bool) {
+// and the no-path attribute-map shape:
+//
+//	{"op":"replace","value":{"name":{"givenName":"Jonathan"},"active":false}}
+//
+// op case is ignored. remove ops and unmodelled paths are silently skipped.
+// ok=false only for a malformed body.
+func parseUserPatch(c *gin.Context) (svcscim.UserPatch, bool) {
 	body := struct {
 		Operations []struct {
 			Op    string          `json:"op"`
@@ -254,31 +353,178 @@ func parseActivePatch(c *gin.Context) (active bool, hasActive bool, ok bool) {
 		} `json:"Operations"`
 	}{}
 	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
-		return false, false, false
+		return svcscim.UserPatch{}, false
 	}
+	var patch svcscim.UserPatch
 	for _, op := range body.Operations {
-		path := strings.ToLower(strings.TrimSpace(op.Path))
-		if path == "active" {
-			if v, valOK := parseBoolValue(op.Value); valOK {
-				active, hasActive = v, true
-			}
+		verb := strings.ToLower(strings.TrimSpace(op.Op))
+		if verb != "replace" && verb != "add" {
 			continue
 		}
-		if path == "" {
-			// Value is an attribute map, e.g. {"active": false}.
-			m := map[string]json.RawMessage{}
-			if err := json.Unmarshal(op.Value, &m); err == nil {
-				for k, raw := range m {
-					if strings.EqualFold(k, "active") {
-						if v, valOK := parseBoolValue(raw); valOK {
-							active, hasActive = v, true
-						}
-					}
-				}
+		lpath := strings.ToLower(strings.TrimSpace(op.Path))
+		switch {
+		case lpath == "active":
+			if v, ok := parseBoolValue(op.Value); ok {
+				patch.Active = &v
+			}
+		case lpath == "name.givenname":
+			setStrPatch(&patch.GivenName, op.Value)
+		case lpath == "name.familyname":
+			setStrPatch(&patch.FamilyName, op.Value)
+		case lpath == "username":
+			setStrPatch(&patch.Email, op.Value)
+		case lpath == "externalid":
+			setStrPatch(&patch.ExternalID, op.Value)
+		case lpath == "emails", strings.HasPrefix(lpath, "emails["):
+			if email, ok := emailFromValue(op.Value); ok {
+				patch.Email = &email
+			}
+		case lpath == "phonenumber", lpath == "phonenumbers", strings.HasPrefix(lpath, "phonenumbers["):
+			if phone, ok := phoneFromValue(op.Value); ok {
+				patch.PhoneNumber = &phone
+			}
+		case lpath == "":
+			applyNoPathUserPatch(&patch, op.Value)
+		default:
+			// Unmodelled path (e.g. enterprise extension) — ignore, don't 400.
+		}
+	}
+	return patch, true
+}
+
+// applyNoPathUserPatch reads the no-path attribute-map value into the patch.
+func applyNoPathUserPatch(patch *svcscim.UserPatch, raw json.RawMessage) {
+	body := struct {
+		UserName   *string         `json:"userName"`
+		ExternalID *string         `json:"externalId"`
+		Active     json.RawMessage `json:"active"`
+		Name       *struct {
+			GivenName  *string `json:"givenName"`
+			FamilyName *string `json:"familyName"`
+		} `json:"name"`
+		Emails       json.RawMessage `json:"emails"`
+		PhoneNumbers json.RawMessage `json:"phoneNumbers"`
+	}{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return
+	}
+	if body.Name != nil {
+		if body.Name.GivenName != nil {
+			gn := strings.TrimSpace(*body.Name.GivenName)
+			patch.GivenName = &gn
+		}
+		if body.Name.FamilyName != nil {
+			fn := strings.TrimSpace(*body.Name.FamilyName)
+			patch.FamilyName = &fn
+		}
+	}
+	if body.UserName != nil {
+		un := strings.TrimSpace(*body.UserName)
+		patch.Email = &un
+	}
+	if len(body.Emails) > 0 {
+		if email, ok := emailFromValue(body.Emails); ok {
+			patch.Email = &email
+		}
+	}
+	if len(body.PhoneNumbers) > 0 {
+		if phone, ok := phoneFromValue(body.PhoneNumbers); ok {
+			patch.PhoneNumber = &phone
+		}
+	}
+	if body.ExternalID != nil {
+		ext := strings.TrimSpace(*body.ExternalID)
+		patch.ExternalID = &ext
+	}
+	if len(body.Active) > 0 {
+		if v, ok := parseBoolValue(body.Active); ok {
+			patch.Active = &v
+		}
+	}
+}
+
+// setStrPatch decodes a JSON string value and, if non-empty after trim, points
+// dst at it.
+func setStrPatch(dst **string, raw json.RawMessage) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return
+	}
+	s = strings.TrimSpace(s)
+	*dst = &s
+}
+
+// emailFromValue extracts the primary email from a SCIM `emails` PATCH value,
+// tolerating a plain string, an array of {value,type,primary}, or a single such
+// object. Prefers primary:true, then type=="work", then the first non-empty.
+func emailFromValue(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if s = strings.TrimSpace(s); s != "" {
+			return s, true
+		}
+		return "", false
+	}
+	pick := func(emails []scimEmail) (string, bool) {
+		first := ""
+		for _, e := range emails {
+			v := strings.TrimSpace(e.Value)
+			if v == "" {
+				continue
+			}
+			if e.Primary {
+				return v, true
+			}
+			if first == "" {
+				first = v
+			}
+		}
+		if first != "" {
+			return first, true
+		}
+		return "", false
+	}
+	var arr []scimEmail
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return pick(arr)
+	}
+	var one scimEmail
+	if err := json.Unmarshal(raw, &one); err == nil {
+		if v := strings.TrimSpace(one.Value); v != "" {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// phoneFromValue extracts a phone number from a SCIM `phoneNumbers` PATCH value,
+// tolerating a plain string, an array of {value}, or a single {value} object.
+func phoneFromValue(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if s = strings.TrimSpace(s); s != "" {
+			return s, true
+		}
+		return "", false
+	}
+	type phone struct {
+		Value string `json:"value"`
+	}
+	var arr []phone
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		for _, e := range arr {
+			if v := strings.TrimSpace(e.Value); v != "" {
+				return v, true
 			}
 		}
 	}
-	return active, hasActive, true
+	var one phone
+	if err := json.Unmarshal(raw, &one); err == nil {
+		if v := strings.TrimSpace(one.Value); v != "" {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 // parseBoolValue accepts a JSON bool or a quoted "true"/"false" string.

--- a/internal/service/scim/groups.go
+++ b/internal/service/scim/groups.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
@@ -152,6 +153,7 @@ func (p *provider) CreateGroup(ctx context.Context, orgID string, in Group) (*sc
 	if err := p.syncMembers(ctx, orgID, created.ID, in.Members, nil); err != nil {
 		return nil, false, err
 	}
+	p.fireGroupEvent(ctx, constants.GroupCreatedWebhookEvent, created)
 	return created, false, nil
 }
 
@@ -207,6 +209,7 @@ func (p *provider) ReplaceGroup(ctx context.Context, orgID, groupID string, in G
 	if err := p.replaceMembers(ctx, orgID, groupID, in.Members); err != nil {
 		return nil, err
 	}
+	p.fireGroupEvent(ctx, constants.GroupUpdatedWebhookEvent, group)
 	return group, nil
 }
 
@@ -267,6 +270,7 @@ func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displa
 			}
 		}
 	}
+	p.fireGroupEvent(ctx, constants.GroupUpdatedWebhookEvent, group)
 	return group, nil
 }
 
@@ -293,7 +297,11 @@ func (p *provider) DeleteGroup(ctx context.Context, orgID, groupID string) error
 			_ = p.AuthzEngine.DeleteTuples(ctx, tuples)
 		}
 	}
-	return p.StorageProvider.DeleteScimGroup(ctx, group)
+	if err := p.StorageProvider.DeleteScimGroup(ctx, group); err != nil {
+		return err
+	}
+	p.fireGroupEvent(ctx, constants.GroupDeletedWebhookEvent, group)
+	return nil
 }
 
 // GroupMembers returns the direct member user ids of an org's group.

--- a/internal/service/scim/scim.go
+++ b/internal/service/scim/scim.go
@@ -22,8 +22,13 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/authorizerdev/authorizer/internal/asyncutil"
 	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/events"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/memory_store"
+	"github.com/authorizerdev/authorizer/internal/refs"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
@@ -88,6 +93,40 @@ type Dependencies struct {
 	// relationship tuples (not a DB column), so the Group ops require it. Nil
 	// when FGA is not configured — Group ops then return ErrGroupsUnavailable.
 	AuthzEngine engine.AuthorizationEngine
+	// EventsProvider dispatches provisioning-lifecycle webhooks
+	// (user.provisioned/deprovisioned/scim_updated, group.created/updated/deleted).
+	// Nil when webhooks are not wired — event firing is then a no-op.
+	EventsProvider events.Provider
+}
+
+// maxFilterScan bounds the org-member scan a non-indexed SCIM filter performs
+// (see ListUsers). ponytail: bounded in-Go scan; the upgrade path for very
+// large orgs is a per-backend native attribute query, not a bigger cap.
+const maxFilterScan = 1000
+
+// filterScanPage is the page size used to walk org memberships during a scan.
+const filterScanPage = 100
+
+// UserFilter is a parsed single-term SCIM filter (RFC 7644 §3.4.2.2). Attribute
+// is one of the canonical names ListUsers understands (userName, emails.value,
+// name.givenName, name.familyName, active, externalId); Operator is one of
+// eq/ne/co/sw/pr; Value is empty for pr.
+type UserFilter struct {
+	Attribute string
+	Operator  string
+	Value     string
+}
+
+// UserPatch is a parsed SCIM User PatchOp (RFC 7644 §3.5.2). Every field is a
+// pointer so "attribute absent from the patch" is distinguishable from "set to
+// empty": only non-nil fields are applied.
+type UserPatch struct {
+	GivenName   *string
+	FamilyName  *string
+	Email       *string
+	PhoneNumber *string
+	ExternalID  *string
+	Active      *bool
 }
 
 // Provider is the org-bounded SCIM operation surface. Every method takes the
@@ -107,12 +146,22 @@ type Provider interface {
 	// FindByUserName returns the org member with the given userName, or nil when
 	// none (the IdP's pre-create dedup probe). Never leaks another org's user.
 	FindByUserName(ctx context.Context, orgID, userName string) (*schemas.User, error)
+	// ListUsers evaluates a parsed single-term SCIM filter against the org's
+	// members and returns the matches (org-scoped — never another org's users).
+	// eq on userName/emails.value/externalId is an indexed lookup; other
+	// operators/attributes scan the org's memberships (bounded).
+	ListUsers(ctx context.Context, orgID string, filter UserFilter) ([]*schemas.User, error)
 	// ReplaceUser (PUT) overwrites the mutable profile + active flag of an org
 	// member. A true→false active transition revokes the user's sessions.
 	ReplaceUser(ctx context.Context, orgID, userID string, in User) (*schemas.User, error)
 	// SetActive (PATCH active / DELETE) flips the active flag. Deactivation
 	// synchronously revokes the user's sessions + refresh tokens.
 	SetActive(ctx context.Context, orgID, userID string, active bool) (*schemas.User, error)
+	// PatchUser applies a parsed SCIM User PatchOp: any non-nil field in patch is
+	// updated. Email/phone changes are uniqueness-checked (ErrConflict on a
+	// collision with another user); an active:true→false transition revokes the
+	// user's sessions. Returns the user unchanged (no event) when nothing changed.
+	PatchUser(ctx context.Context, orgID, userID string, patch UserPatch) (*schemas.User, error)
 
 	// --- SCIM Group provisioning (RFC 7643 §4.2 / RFC 7644 §3.5.2). Membership
 	// is stored as FGA tuples, never on the Group row. ---
@@ -312,6 +361,7 @@ func (p *provider) CreateUser(ctx context.Context, orgID string, in User) (*sche
 		log.Debug().Err(err).Msg("failed to add org membership for scim user")
 		return nil, false, err
 	}
+	p.fireUserEvent(ctx, constants.UserProvisionedWebhookEvent, created)
 	return created, false, nil
 }
 
@@ -352,13 +402,21 @@ func (p *provider) ReplaceUser(ctx context.Context, orgID, userID string, in Use
 	}
 	user.IsActive = in.Active
 	if wasActive && !in.Active {
-		return p.deactivate(ctx, user)
+		updated, err := p.deactivate(ctx, user)
+		if err == nil {
+			p.fireUserEvent(ctx, constants.UserDeprovisionedWebhookEvent, updated)
+		}
+		return updated, err
 	}
 	if !wasActive && in.Active {
 		user.RevokedTimestamp = nil
 	}
 	user.UpdatedAt = time.Now().Unix()
-	return p.StorageProvider.UpdateUser(ctx, user)
+	updated, err := p.StorageProvider.UpdateUser(ctx, user)
+	if err == nil {
+		p.fireUserEvent(ctx, constants.UserScimUpdatedWebhookEvent, updated)
+	}
+	return updated, err
 }
 
 func (p *provider) SetActive(ctx context.Context, orgID, userID string, active bool) (*schemas.User, error) {
@@ -368,16 +426,29 @@ func (p *provider) SetActive(ctx context.Context, orgID, userID string, active b
 	}
 	if !active {
 		if !user.IsActive {
+			// Already deprovisioned — idempotent no-op, no event.
 			return user, nil
 		}
 		user.IsActive = false
-		return p.deactivate(ctx, user)
+		updated, err := p.deactivate(ctx, user)
+		if err == nil {
+			p.fireUserEvent(ctx, constants.UserDeprovisionedWebhookEvent, updated)
+		}
+		return updated, err
 	}
 	// Reactivation: clear the revocation marker.
+	if user.IsActive {
+		// Already active — idempotent no-op, no event.
+		return user, nil
+	}
 	user.IsActive = true
 	user.RevokedTimestamp = nil
 	user.UpdatedAt = time.Now().Unix()
-	return p.StorageProvider.UpdateUser(ctx, user)
+	updated, err := p.StorageProvider.UpdateUser(ctx, user)
+	if err == nil {
+		p.fireUserEvent(ctx, constants.UserScimUpdatedWebhookEvent, updated)
+	}
+	return updated, err
 }
 
 // deactivate is the enterprise-offboarding path: mark the user inactive+revoked
@@ -406,4 +477,251 @@ func (p *provider) deactivate(ctx context.Context, user *schemas.User) (*schemas
 		log.Debug().Err(err).Msg("failed to delete session tokens from storage")
 	}
 	return updated, nil
+}
+
+// ListUsers evaluates a parsed single-term SCIM filter against the org's
+// members. The common dedup-probe shapes (eq on userName/emails.value/
+// externalId) are indexed O(1) lookups; every other operator/attribute falls
+// back to a bounded scan of the org's memberships with the predicate applied in
+// Go (ponytail: bounded scan, upgrade path = per-backend native attribute
+// query). Results are always org-scoped: a user who is not a member of orgID is
+// never returned (H6).
+func (p *provider) ListUsers(ctx context.Context, orgID string, f UserFilter) ([]*schemas.User, error) {
+	// Indexed fast paths for the pre-create dedup probe.
+	if f.Operator == "eq" {
+		switch f.Attribute {
+		case "userName", "emails.value":
+			user, err := p.FindByUserName(ctx, orgID, f.Value)
+			if err != nil || user == nil {
+				return nil, err
+			}
+			return []*schemas.User{user}, nil
+		case "externalId":
+			user, err := p.StorageProvider.GetUserByExternalID(ctx, orgID, f.Value)
+			if err != nil || user == nil {
+				return nil, nil
+			}
+			if _, err := p.StorageProvider.GetOrgMembership(ctx, orgID, user.ID); err != nil {
+				return nil, nil
+			}
+			return []*schemas.User{user}, nil
+		}
+	}
+
+	// General path: scan the org's members and apply the predicate in Go.
+	var matches []*schemas.User
+	scanned := 0
+	page := int64(1)
+	for scanned < maxFilterScan {
+		memberships, _, err := p.StorageProvider.ListOrgMembershipsByOrg(ctx, orgID, &model.Pagination{
+			Limit:  filterScanPage,
+			Page:   page,
+			Offset: (page - 1) * filterScanPage,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(memberships) == 0 {
+			break
+		}
+		for _, m := range memberships {
+			scanned++
+			user, err := p.StorageProvider.GetUserByID(ctx, m.UserID)
+			if err != nil || user == nil {
+				continue
+			}
+			if matchesFilter(orgID, user, f) {
+				matches = append(matches, user)
+			}
+		}
+		if len(memberships) < filterScanPage {
+			break
+		}
+		page++
+	}
+	return matches, nil
+}
+
+// matchesFilter applies a single-term SCIM filter predicate to a user. String
+// comparisons are case-insensitive (RFC 7644 default for these attributes);
+// externalId is compared against the de-namespaced (raw IdP) value.
+func matchesFilter(orgID string, u *schemas.User, f UserFilter) bool {
+	// active is boolean-valued; only eq/ne are meaningful.
+	if f.Attribute == "active" {
+		want := strings.EqualFold(strings.TrimSpace(f.Value), "true")
+		switch f.Operator {
+		case "eq":
+			return u.IsActive == want
+		case "ne":
+			return u.IsActive != want
+		case "pr":
+			return true // a boolean is always present
+		default:
+			return false
+		}
+	}
+
+	attr := userAttrValue(orgID, u, f.Attribute)
+	if f.Operator == "pr" {
+		return attr != ""
+	}
+	val := f.Value
+	la, lv := strings.ToLower(attr), strings.ToLower(val)
+	switch f.Operator {
+	case "eq":
+		return la == lv
+	case "ne":
+		return la != lv
+	case "co":
+		return strings.Contains(la, lv)
+	case "sw":
+		return strings.HasPrefix(la, lv)
+	default:
+		return false
+	}
+}
+
+// userAttrValue maps a canonical SCIM attribute name to the user's stored value.
+func userAttrValue(orgID string, u *schemas.User, attr string) string {
+	switch attr {
+	case "userName", "emails.value":
+		return refs.StringValue(u.Email)
+	case "name.givenName":
+		return refs.StringValue(u.GivenName)
+	case "name.familyName":
+		return refs.StringValue(u.FamilyName)
+	case "externalId":
+		if u.ExternalID == nil {
+			return ""
+		}
+		return strings.TrimPrefix(refs.StringValue(u.ExternalID), orgID+":")
+	default:
+		return ""
+	}
+}
+
+// PatchUser applies a parsed SCIM User PatchOp. Only non-nil fields are touched;
+// email/phone changes are uniqueness-checked (global uniqueness, mirroring
+// AddUser/GetUserByEmail); an active:true→false transition revokes sessions. It
+// returns the user unchanged with no event when the patch is a no-op.
+func (p *provider) PatchUser(ctx context.Context, orgID, userID string, patch UserPatch) (*schemas.User, error) {
+	user, err := p.requireMember(ctx, orgID, userID)
+	if err != nil {
+		return nil, err
+	}
+	changed := false
+	if patch.GivenName != nil {
+		gn := strings.TrimSpace(*patch.GivenName)
+		if gn != refs.StringValue(user.GivenName) {
+			user.GivenName = &gn
+			changed = true
+		}
+	}
+	if patch.FamilyName != nil {
+		fn := strings.TrimSpace(*patch.FamilyName)
+		if fn != refs.StringValue(user.FamilyName) {
+			user.FamilyName = &fn
+			changed = true
+		}
+	}
+	if patch.Email != nil {
+		email := strings.ToLower(strings.TrimSpace(*patch.Email))
+		if email == "" {
+			return nil, ErrInvalid
+		}
+		if email != refs.StringValue(user.Email) {
+			// Global email uniqueness: a PATCH must not set an email another user
+			// already holds (same guard AddUser/CreateUser rely on).
+			if existing, err := p.StorageProvider.GetUserByEmail(ctx, email); err == nil && existing != nil && existing.ID != user.ID {
+				return nil, ErrConflict
+			}
+			user.Email = &email
+			changed = true
+		}
+	}
+	if patch.PhoneNumber != nil {
+		phone := strings.TrimSpace(*patch.PhoneNumber)
+		if phone == "" {
+			return nil, ErrInvalid
+		}
+		if phone != refs.StringValue(user.PhoneNumber) {
+			if existing, err := p.StorageProvider.GetUserByPhoneNumber(ctx, phone); err == nil && existing != nil && existing.ID != user.ID {
+				return nil, ErrConflict
+			}
+			user.PhoneNumber = &phone
+			changed = true
+		}
+	}
+	if patch.ExternalID != nil {
+		ext := strings.TrimSpace(*patch.ExternalID)
+		if ext != "" {
+			nsExt := namespacedExternalID(orgID, ext)
+			if user.ExternalID == nil || *user.ExternalID != nsExt {
+				user.ExternalID = &nsExt
+				changed = true
+			}
+		}
+	}
+
+	deactivating := false
+	if patch.Active != nil {
+		if user.IsActive && !*patch.Active {
+			deactivating = true
+			changed = true
+		} else if !user.IsActive && *patch.Active {
+			// Reactivation — clear the revocation marker; reported as an attribute
+			// change (scim_updated), not a distinct event.
+			user.IsActive = true
+			user.RevokedTimestamp = nil
+			changed = true
+		}
+	}
+
+	if !changed {
+		// Idempotent replay that changes nothing — no write, no event.
+		return user, nil
+	}
+
+	if deactivating {
+		user.IsActive = false
+		updated, err := p.deactivate(ctx, user)
+		if err != nil {
+			return nil, err
+		}
+		p.fireUserEvent(ctx, constants.UserDeprovisionedWebhookEvent, updated)
+		return updated, nil
+	}
+
+	user.UpdatedAt = time.Now().Unix()
+	updated, err := p.StorageProvider.UpdateUser(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	p.fireUserEvent(ctx, constants.UserScimUpdatedWebhookEvent, updated)
+	return updated, nil
+}
+
+// fireUserEvent dispatches a user provisioning-lifecycle webhook off the request
+// path (asyncutil.Go: tracked for graceful-shutdown drain, panic-recovered). A
+// nil EventsProvider (webhooks not wired) is a no-op.
+func (p *provider) fireUserEvent(ctx context.Context, eventName string, user *schemas.User) {
+	if p.EventsProvider == nil || user == nil {
+		return
+	}
+	asyncutil.Go(p.Log, func() {
+		ctx := context.WithoutCancel(ctx)
+		_ = p.EventsProvider.RegisterEvent(ctx, eventName, "", user)
+	})
+}
+
+// fireGroupEvent dispatches a SCIM group provisioning-lifecycle webhook off the
+// request path. A nil EventsProvider is a no-op.
+func (p *provider) fireGroupEvent(ctx context.Context, eventName string, group *schemas.ScimGroup) {
+	if p.EventsProvider == nil || group == nil {
+		return
+	}
+	asyncutil.Go(p.Log, func() {
+		ctx := context.WithoutCancel(ctx)
+		_ = p.EventsProvider.RegisterScimGroupEvent(ctx, eventName, group)
+	})
 }

--- a/internal/service/scim/scim_test.go
+++ b/internal/service/scim/scim_test.go
@@ -3,6 +3,9 @@ package scim
 import (
 	"context"
 	"errors"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -10,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/authorizerdev/authorizer/internal/asyncutil"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
 	"github.com/authorizerdev/authorizer/internal/memory_store"
 	"github.com/authorizerdev/authorizer/internal/storage"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
@@ -95,6 +100,75 @@ func (f *fakeStore) AddOrgMembership(_ context.Context, m *schemas.OrgMembership
 func (f *fakeStore) DeleteAllSessionTokensByUserID(_ context.Context, userID string) error {
 	f.deletedTok = append(f.deletedTok, userID)
 	return nil
+}
+
+func (f *fakeStore) GetUserByPhoneNumber(_ context.Context, phone string) (*schemas.User, error) {
+	for _, u := range f.users {
+		if u.PhoneNumber != nil && *u.PhoneNumber == phone {
+			return u, nil
+		}
+	}
+	return nil, errNotFound
+}
+
+// ListOrgMembershipsByOrg returns the org's memberships in a stable order,
+// honouring the pagination offset/limit (enough for the ListUsers scan tests).
+func (f *fakeStore) ListOrgMembershipsByOrg(_ context.Context, orgID string, p *model.Pagination) ([]*schemas.OrgMembership, *model.Pagination, error) {
+	var keys []string
+	for k, ok := range f.memberships {
+		if ok && strings.HasPrefix(k, orgID+"|") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	total := int64(len(keys))
+	from := int(p.Offset)
+	if from > len(keys) {
+		from = len(keys)
+	}
+	to := from + int(p.Limit)
+	if to > len(keys) {
+		to = len(keys)
+	}
+	var out []*schemas.OrgMembership
+	for _, k := range keys[from:to] {
+		out = append(out, &schemas.OrgMembership{OrgID: orgID, UserID: strings.SplitN(k, "|", 2)[1]})
+	}
+	return out, &model.Pagination{Limit: p.Limit, Page: p.Page, Offset: p.Offset, Total: total}, nil
+}
+
+// spyEvents records the provisioning-lifecycle events the service fires. Because
+// events go through asyncutil.Go, tests must asyncutil.Wait before asserting.
+type spyEvents struct {
+	mu          sync.Mutex
+	userEvents  []string
+	groupEvents []string
+}
+
+func (s *spyEvents) RegisterEvent(_ context.Context, eventName string, _ string, _ *schemas.User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.userEvents = append(s.userEvents, eventName)
+	return nil
+}
+
+func (s *spyEvents) RegisterScimGroupEvent(_ context.Context, eventName string, _ *schemas.ScimGroup) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.groupEvents = append(s.groupEvents, eventName)
+	return nil
+}
+
+func (s *spyEvents) users() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.userEvents...)
+}
+
+func (s *spyEvents) groups() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.groupEvents...)
 }
 
 // fakeMem records the user ids whose sessions were dropped.
@@ -279,6 +353,195 @@ func TestDelete_MapsToDeactivate(t *testing.T) {
 	_, err = p.SetActive(ctx, "org-a", u.ID, false)
 	require.NoError(t, err)
 	assert.Contains(t, mem.deleted, u.ID)
+}
+
+// seedUser inserts a user into the fake store and binds them to org.
+func seedUser(store *fakeStore, org, id, email, given, family, ext string, active bool) {
+	u := &schemas.User{ID: id, IsActive: active}
+	if email != "" {
+		u.Email = &email
+	}
+	if given != "" {
+		u.GivenName = &given
+	}
+	if family != "" {
+		u.FamilyName = &family
+	}
+	if ext != "" {
+		ns := org + ":" + ext
+		u.ExternalID = &ns
+	}
+	store.users[id] = u
+	store.memberships[org+"|"+id] = true
+}
+
+func ids(users []*schemas.User) []string {
+	out := make([]string, 0, len(users))
+	for _, u := range users {
+		out = append(out, u.ID)
+	}
+	return out
+}
+
+// TestListUsers_Filters exercises every supported operator against every
+// supported attribute, plus a negative (matches-nothing) case and cross-org
+// isolation.
+func TestListUsers_Filters(t *testing.T) {
+	p, store, _ := newSvc(t)
+	ctx := context.Background()
+	const org = "org-a"
+	seedUser(store, org, "u1", "bob@acme.com", "Bob", "Doe", "okta-1", true)
+	seedUser(store, org, "u2", "alice@acme.com", "Alice", "Smith", "", false)
+	// A member of a different org with a colliding givenName — must never surface.
+	seedUser(store, "org-b", "b1", "bob@other.com", "Bob", "Doe", "okta-b", true)
+
+	cases := []struct {
+		name string
+		f    UserFilter
+		want []string
+	}{
+		{"eq userName (indexed)", UserFilter{"userName", "eq", "bob@acme.com"}, []string{"u1"}},
+		{"eq emails.value (indexed)", UserFilter{"emails.value", "eq", "alice@acme.com"}, []string{"u2"}},
+		{"eq externalId (indexed)", UserFilter{"externalId", "eq", "okta-1"}, []string{"u1"}},
+		{"eq userName no match", UserFilter{"userName", "eq", "nobody@acme.com"}, nil},
+		{"ne givenName", UserFilter{"name.givenName", "ne", "bob"}, []string{"u2"}},
+		{"co familyName", UserFilter{"name.familyName", "co", "oe"}, []string{"u1"}},
+		{"sw givenName", UserFilter{"name.givenName", "sw", "al"}, []string{"u2"}},
+		{"pr externalId", UserFilter{"externalId", "pr", ""}, []string{"u1"}},
+		{"active eq true", UserFilter{"active", "eq", "true"}, []string{"u1"}},
+		{"active eq false", UserFilter{"active", "eq", "false"}, []string{"u2"}},
+		{"active ne true", UserFilter{"active", "ne", "true"}, []string{"u2"}},
+		{"co familyName matches nothing", UserFilter{"name.familyName", "co", "zzz"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := p.ListUsers(ctx, org, tc.f)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, ids(got))
+		})
+	}
+}
+
+// drainEvents waits for asyncutil.Go-dispatched webhook goroutines to finish so
+// the spy's recorded events are visible.
+func drainEvents() { asyncutil.Wait(zerolog.Nop()) }
+
+func newSvcWithEvents(t *testing.T) (*provider, *fakeStore, *spyEvents) {
+	t.Helper()
+	p, store, _ := newSvc(t)
+	spy := &spyEvents{}
+	p.EventsProvider = spy
+	return p, store, spy
+}
+
+// TestScimUserWebhookEvents proves each user lifecycle event fires exactly once
+// on its triggering operation (and not on idempotent no-ops).
+func TestScimUserWebhookEvents(t *testing.T) {
+	p, _, spy := newSvcWithEvents(t)
+	ctx := context.Background()
+	const org = "org-a"
+
+	// Create → user.provisioned.
+	u, _, err := p.CreateUser(ctx, org, User{ExternalID: "e1", UserName: "bob@acme.com", Active: true})
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"user.provisioned"}, spy.users())
+
+	// Attribute change via PATCH → user.scim_updated.
+	gn := "Robert"
+	_, err = p.PatchUser(ctx, org, u.ID, UserPatch{GivenName: &gn})
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"user.provisioned", "user.scim_updated"}, spy.users())
+
+	// Deactivate via SetActive(false) → user.deprovisioned.
+	_, err = p.SetActive(ctx, org, u.ID, false)
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"user.provisioned", "user.scim_updated", "user.deprovisioned"}, spy.users())
+
+	// Idempotent SetActive(false) again → no new event.
+	_, err = p.SetActive(ctx, org, u.ID, false)
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"user.provisioned", "user.scim_updated", "user.deprovisioned"}, spy.users(),
+		"a no-op deactivate must not re-fire")
+}
+
+// TestScimGroupWebhookEvents proves the three group events fire on create,
+// update (membership), and delete.
+func TestScimGroupWebhookEvents(t *testing.T) {
+	p, store := newGroupSvc(t)
+	spy := &spyEvents{}
+	p.EventsProvider = spy
+	ctx := context.Background()
+	const org = "org-a"
+	store.memberships[org+"|u1"] = true
+
+	g, _, err := p.CreateGroup(ctx, org, Group{DisplayName: "Engineers", ExternalID: "ext-1"})
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"group.created"}, spy.groups())
+
+	_, err = p.PatchGroup(ctx, org, g.ID, nil, nil, []MemberOp{{Op: "add", Members: []string{"u1"}}})
+	require.NoError(t, err)
+	drainEvents()
+	assert.Equal(t, []string{"group.created", "group.updated"}, spy.groups())
+
+	require.NoError(t, p.DeleteGroup(ctx, org, g.ID))
+	drainEvents()
+	assert.Equal(t, []string{"group.created", "group.updated", "group.deleted"}, spy.groups())
+}
+
+// TestPatchUser_Attributes covers each PATCH-able attribute, the duplicate-email
+// rejection, and the no-op (nothing changed) case.
+func TestPatchUser_Attributes(t *testing.T) {
+	p, store, _ := newSvc(t)
+	ctx := context.Background()
+	const org = "org-a"
+	u, _, err := p.CreateUser(ctx, org, User{ExternalID: "e1", UserName: "bob@acme.com", GivenName: "Bob", Active: true})
+	require.NoError(t, err)
+
+	t.Run("name/phone/externalId", func(t *testing.T) {
+		gn, fn, phone, ext := "Robert", "Doe", "+15551234567", "okta-new"
+		got, err := p.PatchUser(ctx, org, u.ID, UserPatch{GivenName: &gn, FamilyName: &fn, PhoneNumber: &phone, ExternalID: &ext})
+		require.NoError(t, err)
+		assert.Equal(t, "Robert", *got.GivenName)
+		assert.Equal(t, "Doe", *got.FamilyName)
+		assert.Equal(t, "+15551234567", *got.PhoneNumber)
+		assert.Equal(t, "org-a:okta-new", *got.ExternalID, "externalId must be re-namespaced")
+	})
+
+	t.Run("email change", func(t *testing.T) {
+		email := "robert@acme.com"
+		got, err := p.PatchUser(ctx, org, u.ID, UserPatch{Email: &email})
+		require.NoError(t, err)
+		assert.Equal(t, "robert@acme.com", *got.Email)
+	})
+
+	t.Run("duplicate email rejected", func(t *testing.T) {
+		// Another user owns this email.
+		seedUser(store, org, "u2", "taken@acme.com", "", "", "", true)
+		email := "taken@acme.com"
+		_, err := p.PatchUser(ctx, org, u.ID, UserPatch{Email: &email})
+		assert.ErrorIs(t, err, ErrConflict, "a PATCH must not set an email another user holds")
+	})
+
+	t.Run("no-op patch changes nothing", func(t *testing.T) {
+		gn := "Robert" // already set to Robert above
+		before := *store.users[u.ID]
+		got, err := p.PatchUser(ctx, org, u.ID, UserPatch{GivenName: &gn})
+		require.NoError(t, err)
+		assert.Equal(t, before.UpdatedAt, got.UpdatedAt, "an idempotent patch must not bump updated_at")
+	})
+
+	t.Run("active:false deactivates and revokes", func(t *testing.T) {
+		active := false
+		got, err := p.PatchUser(ctx, org, u.ID, UserPatch{Active: &active})
+		require.NoError(t, err)
+		assert.False(t, got.IsActive)
+		require.NotNil(t, got.RevokedTimestamp)
+	})
 }
 
 func TestFindByUserName_OrgScoped(t *testing.T) {


### PR DESCRIPTION
## Why
Closes the 3 gaps identified against issue #513's RFC while auditing what
actually shipped in PRs #692/#694: SCIM `filter` only ever supported
`userName eq "..."`, no webhook events fired on SCIM-driven user/group
lifecycle changes, and User `PATCH` only recognized the `active` attribute.

## What
- **Filtering** (RFC 7644 §3.4.2.2 subset): `eq`/`ne`/`co`/`sw`/`pr` over
  `userName`, `emails.value`, `name.givenName`, `name.familyName`, `active`,
  `externalId`. `eq` on userName/email/externalId is an indexed lookup;
  everything else is a bounded (cap 1000) in-Go scan over org membership.
  Compound filters (`and`/`or`/`not`), value-path filters, and ordering
  operators are deliberately unsupported — real directory-sync filters are
  single-term — and return `400 invalidFilter` rather than a silent empty
  200 (which connectors misread as "no such user" and duplicate).
- **Provisioning webhooks**: `user.provisioned`, `user.deprovisioned`,
  `user.scim_updated`, `group.created`, `group.updated`, `group.deleted`,
  fired via `asyncutil.Go` (tracked, panic-recovered) so SCIM responses
  aren't blocked on webhook delivery. No-op replays don't fire.
- **User PATCH**: extended beyond `active` to `name.givenName`,
  `name.familyName`, email, phone, `externalId` — both the path-qualified
  and no-path attribute-map shapes IdPs actually send. Email/phone changes
  go through the same uniqueness guard `AddUser` uses (409 on conflict).
  Paths the server doesn't model (enterprise extension attributes) are
  ignored rather than 400'd, so a connector syncing manager/department
  doesn't fail the whole request.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` — 0 issues
- [x] Every operator × attribute combination, incl. a matches-nothing
      negative and cross-org isolation
- [x] Each event fires exactly once; no-op doesn't refire
- [x] Both PATCH shapes per attribute; active-only regression retained;
      duplicate-email PATCH rejected
- [x] `make test` — full SQLite suite green (independently re-verified,
      not just the implementing agent's self-report)