### PR TITLE
feat(dashboard): add verified org domains UI

### DIFF
--- a/web/dashboard/src/components/OrgDomains.test.tsx
+++ b/web/dashboard/src/components/OrgDomains.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+	render,
+	screen,
+	fireEvent,
+	waitFor,
+	cleanup,
+} from '@testing-library/react';
+import OrgDomains from './OrgDomains';
+import {
+	RequestOrgDomain,
+	VerifyOrgDomain,
+	DeleteOrgDomain,
+} from '../graphql/mutation';
+
+// urql's useClient is the only external dependency OrgDomains.tsx needs — mock
+// it so query()/mutation() responses are controlled per-call by the test.
+vi.mock('urql', () => ({
+	useClient: () => mockClient,
+}));
+
+let mockClient: {
+	query: ReturnType<typeof vi.fn>;
+	mutation: ReturnType<typeof vi.fn>;
+};
+
+// The _org_domains list response, mutated in-place so a mutation handler can
+// make the post-action refetch observe the new state.
+let listResponse: { data: { _org_domains: { org_domains: unknown[] } } };
+
+const challenge = {
+	domain: 'acme.com',
+	record_type: 'TXT',
+	record_name: '_authorizer-challenge.acme.com',
+	record_value: 'authorizer-domain-verification=tok123',
+};
+
+const verifiedDomain = {
+	domain: 'acme.com',
+	org_id: 'org1',
+	verified_at: 1700000000,
+	created_at: 1700000000,
+	updated_at: 1700000000,
+};
+
+// vitest.config.ts does not set test.globals, so @testing-library/react's
+// automatic afterEach(cleanup) never registers — clean up Radix portals by hand.
+afterEach(cleanup);
+
+beforeEach(() => {
+	listResponse = { data: { _org_domains: { org_domains: [] } } };
+	mockClient = {
+		query: vi.fn(() => ({
+			toPromise: () => Promise.resolve(listResponse),
+		})),
+		mutation: vi.fn(),
+	};
+});
+
+describe('OrgDomains', () => {
+	it('renders the list of verified domains', async () => {
+		listResponse = {
+			data: { _org_domains: { org_domains: [verifiedDomain] } },
+		};
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		expect(await screen.findByText('acme.com')).toBeTruthy();
+	});
+
+	it('runs the DNS challenge flow: request → shows TXT → verify → verified', async () => {
+		mockClient.mutation.mockImplementation((doc: unknown) => {
+			if (doc === RequestOrgDomain) {
+				return {
+					toPromise: () =>
+						Promise.resolve({ data: { _request_org_domain: challenge } }),
+				};
+			}
+			// Verify succeeds; make the subsequent refetch observe the new row.
+			listResponse = {
+				data: { _org_domains: { org_domains: [verifiedDomain] } },
+			};
+			return {
+				toPromise: () =>
+					Promise.resolve({ data: { _verify_org_domain: verifiedDomain } }),
+			};
+		});
+
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		await screen.findByText('No verified domains yet.');
+
+		fireEvent.click(screen.getByRole('button', { name: /Add Domain/ }));
+		fireEvent.change(screen.getByPlaceholderText('acme.com'), {
+			target: { value: 'acme.com' },
+		});
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Request DNS Challenge' }),
+		);
+
+		// The TXT record to publish is shown.
+		expect(
+			await screen.findByText('_authorizer-challenge.acme.com'),
+		).toBeTruthy();
+		expect(
+			screen.getByText('authorizer-domain-verification=tok123'),
+		).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: /Verify/ }));
+
+		// Dialog closes (TXT gone) and the domain now shows in the verified table.
+		await waitFor(() =>
+			expect(
+				screen.queryByText('authorizer-domain-verification=tok123'),
+			).toBeNull(),
+		);
+		expect(await screen.findByText('acme.com')).toBeTruthy();
+	});
+
+	it('keeps the challenge dialog open on a retryable "not verified yet" error', async () => {
+		mockClient.mutation.mockImplementation((doc: unknown) => {
+			if (doc === RequestOrgDomain) {
+				return {
+					toPromise: () =>
+						Promise.resolve({ data: { _request_org_domain: challenge } }),
+				};
+			}
+			// Verify fails because DNS hasn't propagated — resolver leaves the
+			// challenge in place.
+			return {
+				toPromise: () =>
+					Promise.resolve({
+						error: {
+							message:
+								'dns verification failed: challenge TXT record not found or does not match',
+						},
+					}),
+			};
+		});
+
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		await screen.findByText('No verified domains yet.');
+
+		fireEvent.click(screen.getByRole('button', { name: /Add Domain/ }));
+		fireEvent.change(screen.getByPlaceholderText('acme.com'), {
+			target: { value: 'acme.com' },
+		});
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Request DNS Challenge' }),
+		);
+		await screen.findByText('_authorizer-challenge.acme.com');
+
+		fireEvent.click(screen.getByRole('button', { name: /Verify/ }));
+
+		// Retryable hint appears and the TXT record is still on screen.
+		expect(
+			await screen.findByText(/DNS changes can take a few minutes/),
+		).toBeTruthy();
+		expect(
+			screen.getByText('authorizer-domain-verification=tok123'),
+		).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Verify/ })).toBeTruthy();
+	});
+
+	it('deletes a domain after confirmation', async () => {
+		listResponse = {
+			data: { _org_domains: { org_domains: [verifiedDomain] } },
+		};
+		mockClient.mutation.mockImplementation(() => {
+			listResponse = { data: { _org_domains: { org_domains: [] } } };
+			return {
+				toPromise: () =>
+					Promise.resolve({ data: { _delete_org_domain: { message: 'ok' } } }),
+			};
+		});
+
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		await screen.findByText('acme.com');
+
+		// Row delete opens the confirm dialog; the mutation has NOT fired yet.
+		fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+		expect(await screen.findByText('Delete Verified Domain')).toBeTruthy();
+		expect(mockClient.mutation).not.toHaveBeenCalled();
+
+		// Confirm: two "Delete" buttons now (row + dialog) — click the dialog's.
+		const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+		fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+		await waitFor(() =>
+			expect(mockClient.mutation).toHaveBeenCalledWith(
+				DeleteOrgDomain,
+				expect.objectContaining({ params: { domain: 'acme.com' } }),
+			),
+		);
+		await waitFor(() => expect(screen.queryByText('acme.com')).toBeNull());
+	});
+});

--- a/web/dashboard/src/components/OrgDomains.test.tsx
+++ b/web/dashboard/src/components/OrgDomains.test.tsx
@@ -60,6 +60,24 @@ beforeEach(() => {
 });
 
 describe('OrgDomains', () => {
+	it('shows a loading state before the initial fetch resolves', async () => {
+		let resolveQuery: (value: typeof listResponse) => void = () => {};
+		mockClient.query = vi.fn(() => ({
+			toPromise: () =>
+				new Promise<typeof listResponse>((resolve) => {
+					resolveQuery = resolve;
+				}),
+		}));
+
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		expect(screen.getByText('Loading verified domains…')).toBeTruthy();
+		expect(screen.queryByText('No verified domains yet.')).toBeNull();
+
+		resolveQuery({ data: { _org_domains: { org_domains: [] } } });
+		await screen.findByText('No verified domains yet.');
+		expect(screen.queryByText('Loading verified domains…')).toBeNull();
+	});
+
 	it('renders the list of verified domains', async () => {
 		listResponse = {
 			data: { _org_domains: { org_domains: [verifiedDomain] } },

--- a/web/dashboard/src/components/OrgDomains.tsx
+++ b/web/dashboard/src/components/OrgDomains.tsx
@@ -1,0 +1,398 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'urql';
+import { toast } from 'sonner';
+import { Plus, Copy, Check, ShieldCheck } from 'lucide-react';
+import dayjs from 'dayjs';
+import {
+	capitalizeFirstLetter,
+	copyTextToClipboard,
+	getGraphQLErrorMessage,
+} from '../utils';
+import { OrgDomainsQuery } from '../graphql/queries';
+import {
+	RequestOrgDomain,
+	VerifyOrgDomain,
+	AddVerifiedOrgDomain,
+	DeleteOrgDomain,
+} from '../graphql/mutation';
+import type { OrgDomain, OrgDomainChallenge } from '../types';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { Input } from './ui/input';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from './ui/card';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from './ui/dialog';
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+} from './ui/table';
+
+interface OrgDomainsProps {
+	orgId: string;
+	// orgSlug is the display name of the org, shown in copy for context.
+	orgSlug: string;
+}
+
+// CopyField renders a read-only value with a copy-to-clipboard affordance,
+// mirroring the inline copy control in ClientSecretDialog.
+const CopyField = ({ label, value }: { label: string; value: string }) => {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		await copyTextToClipboard(value);
+		setCopied(true);
+		toast.success(`${label} copied`);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<div>
+			<p className="text-xs font-medium text-gray-500">{label}</p>
+			<div className="mt-1 flex items-center gap-2 rounded-md bg-gray-100 p-3">
+				<code className="flex-1 break-all font-mono text-sm">{value}</code>
+				<button
+					type="button"
+					onClick={handleCopy}
+					className="text-gray-400 hover:text-gray-600"
+					aria-label={`Copy ${label.toLowerCase()}`}
+				>
+					{copied ? (
+						<Check className="h-4 w-4 text-green-500" />
+					) : (
+						<Copy className="h-4 w-4" />
+					)}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
+	const client = useClient();
+
+	const [domains, setDomains] = useState<OrgDomain[]>([]);
+
+	// Add-domain dialog. `challenge` null => domain-entry step; set => DNS step.
+	const [addOpen, setAddOpen] = useState(false);
+	const [domainInput, setDomainInput] = useState('');
+	const [challenge, setChallenge] = useState<OrgDomainChallenge | null>(null);
+	const [requesting, setRequesting] = useState(false);
+	const [verifying, setVerifying] = useState(false);
+	const [addingVerified, setAddingVerified] = useState(false);
+	// Retryable "DNS not propagated yet" hint shown inline without discarding
+	// the challenge so the tenant can retry after the record propagates.
+	const [notVerifiedHint, setNotVerifiedHint] = useState(false);
+
+	const [domainToDelete, setDomainToDelete] = useState<OrgDomain | null>(null);
+
+	const fetchDomains = async () => {
+		if (!orgId) return;
+		const res = await client
+			.query<{ _org_domains: { org_domains: OrgDomain[] } }>(OrgDomainsQuery, {
+				params: { org_id: orgId },
+			})
+			.toPromise();
+		setDomains(res.data?._org_domains?.org_domains || []);
+	};
+
+	useEffect(() => {
+		fetchDomains();
+	}, [orgId]);
+
+	const resetAddDialog = () => {
+		setDomainInput('');
+		setChallenge(null);
+		setNotVerifiedHint(false);
+	};
+
+	const requestChallengeHandler = async () => {
+		if (!domainInput.trim()) return;
+		setRequesting(true);
+		const res = await client
+			.mutation<{ _request_org_domain: OrgDomainChallenge }>(RequestOrgDomain, {
+				params: { org_id: orgId, domain: domainInput.trim() },
+			})
+			.toPromise();
+		setRequesting(false);
+		if (res.error || !res.data?._request_org_domain) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(
+						res.error,
+						'Failed to request domain challenge',
+					),
+				),
+			);
+			return;
+		}
+		setChallenge(res.data._request_org_domain);
+		setNotVerifiedHint(false);
+	};
+
+	const verifyHandler = async () => {
+		if (!challenge) return;
+		setVerifying(true);
+		const res = await client
+			.mutation<{ _verify_org_domain: OrgDomain }>(VerifyOrgDomain, {
+				params: { org_id: orgId, domain: challenge.domain },
+			})
+			.toPromise();
+		setVerifying(false);
+		if (res.error) {
+			const msg = getGraphQLErrorMessage(res.error, 'Verification failed');
+			// The resolver leaves the challenge in place when the TXT record isn't
+			// resolvable yet ("dns verification failed: ..."). Surface it as a
+			// retryable hint and keep the dialog + record on screen.
+			if (/dns verification failed/i.test(msg)) {
+				setNotVerifiedHint(true);
+			} else {
+				toast.error(capitalizeFirstLetter(msg));
+			}
+			return;
+		}
+		toast.success('Domain verified');
+		setAddOpen(false);
+		resetAddDialog();
+		fetchDomains();
+	};
+
+	const quickAddHandler = async () => {
+		if (!domainInput.trim()) return;
+		setAddingVerified(true);
+		const res = await client
+			.mutation<{ _add_verified_org_domain: OrgDomain }>(AddVerifiedOrgDomain, {
+				params: { org_id: orgId, domain: domainInput.trim() },
+			})
+			.toPromise();
+		setAddingVerified(false);
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to add verified domain'),
+				),
+			);
+			return;
+		}
+		toast.success('Domain added');
+		setAddOpen(false);
+		resetAddDialog();
+		fetchDomains();
+	};
+
+	const deleteHandler = async () => {
+		if (!domainToDelete) return;
+		const res = await client
+			.mutation(DeleteOrgDomain, {
+				params: { domain: domainToDelete.domain },
+			})
+			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to delete domain'),
+				),
+			);
+			return;
+		}
+		toast.success('Domain deleted');
+		setDomainToDelete(null);
+		fetchDomains();
+	};
+
+	return (
+		<>
+			<Card>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle>Verified Domains</CardTitle>
+							<CardDescription>
+								Email domains verified for {orgSlug || 'this organization'}. A
+								login from a verified domain is routed to this org's SSO
+								(home-realm discovery).
+							</CardDescription>
+						</div>
+						<Button
+							size="sm"
+							onClick={() => {
+								resetAddDialog();
+								setAddOpen(true);
+							}}
+						>
+							<Plus className="mr-2 h-4 w-4" />
+							Add Domain
+						</Button>
+					</div>
+				</CardHeader>
+				<CardContent>
+					{domains.length > 0 ? (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Domain</TableHead>
+									<TableHead>Verified</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{domains.map((d) => (
+									<TableRow key={d.domain}>
+										<TableCell className="font-mono text-xs">
+											{d.domain}
+										</TableCell>
+										<TableCell>
+											{d.verified_at ? (
+												<Badge variant="success">
+													{dayjs.unix(d.verified_at).format('MMM D, YYYY')}
+												</Badge>
+											) : (
+												<span className="text-sm text-gray-400">—</span>
+											)}
+										</TableCell>
+										<TableCell className="text-right">
+											<Button
+												variant="destructive"
+												size="sm"
+												onClick={() => setDomainToDelete(d)}
+											>
+												Delete
+											</Button>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					) : (
+						<p className="text-sm text-gray-400">No verified domains yet.</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* Add domain: DNS challenge flow (primary) + quick verify (super-admin) */}
+			<Dialog
+				open={addOpen}
+				onOpenChange={(isOpen) => {
+					setAddOpen(isOpen);
+					if (!isOpen) resetAddDialog();
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Add Verified Domain</DialogTitle>
+						<DialogDescription>
+							{challenge
+								? 'Publish this DNS TXT record, then verify.'
+								: 'Prove control of a domain by publishing a DNS TXT record.'}
+						</DialogDescription>
+					</DialogHeader>
+
+					{challenge ? (
+						<div className="space-y-4">
+							<div className="rounded-md border border-blue-200 bg-blue-50 p-4">
+								<p className="text-sm text-blue-800">
+									Create the following <strong>{challenge.record_type}</strong>{' '}
+									record for <strong>{challenge.domain}</strong>, then click
+									Verify.
+								</p>
+							</div>
+							<CopyField label="Record name" value={challenge.record_name} />
+							<CopyField label="Record value" value={challenge.record_value} />
+							{notVerifiedHint && (
+								<div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+									<p className="text-sm text-yellow-800">
+										Not verified yet. DNS changes can take a few minutes to
+										propagate — leave the record in place and try again shortly.
+									</p>
+								</div>
+							)}
+						</div>
+					) : (
+						<div className="space-y-3">
+							<div>
+								<label className="text-sm font-medium">Domain</label>
+								<Input
+									placeholder="acme.com"
+									value={domainInput}
+									onChange={(e) => setDomainInput(e.currentTarget.value)}
+								/>
+							</div>
+							<button
+								type="button"
+								onClick={quickAddHandler}
+								disabled={addingVerified || !domainInput.trim()}
+								className="inline-flex items-center text-sm text-blue-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+							>
+								<ShieldCheck className="mr-1 h-4 w-4" />
+								Add without DNS verification (super-admin)
+							</button>
+						</div>
+					)}
+
+					<DialogFooter>
+						{challenge ? (
+							<Button
+								onClick={verifyHandler}
+								isLoading={verifying}
+								disabled={verifying}
+							>
+								I've published this record — Verify
+							</Button>
+						) : (
+							<Button
+								onClick={requestChallengeHandler}
+								isLoading={requesting}
+								disabled={requesting || !domainInput.trim()}
+							>
+								Request DNS Challenge
+							</Button>
+						)}
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Confirm: delete domain */}
+			<Dialog
+				open={!!domainToDelete}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) setDomainToDelete(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Verified Domain</DialogTitle>
+						<DialogDescription>Are you sure?</DialogDescription>
+					</DialogHeader>
+					<div className="rounded-md border border-red-300 bg-red-50 p-4">
+						<p className="text-sm">
+							Domain <strong>{domainToDelete?.domain}</strong> will be removed.
+							Logins from it will no longer route to this organization's SSO.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button variant="destructive" onClick={deleteHandler}>
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+};
+
+export default OrgDomains;

--- a/web/dashboard/src/components/OrgDomains.tsx
+++ b/web/dashboard/src/components/OrgDomains.tsx
@@ -87,6 +87,7 @@ const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
 	const client = useClient();
 
 	const [domains, setDomains] = useState<OrgDomain[]>([]);
+	const [domainsLoading, setDomainsLoading] = useState(true);
 
 	// Add-domain dialog. `challenge` null => domain-entry step; set => DNS step.
 	const [addOpen, setAddOpen] = useState(false);
@@ -103,12 +104,17 @@ const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
 
 	const fetchDomains = async () => {
 		if (!orgId) return;
+		setDomainsLoading(true);
 		const res = await client
 			.query<{ _org_domains: { org_domains: OrgDomain[] } }>(OrgDomainsQuery, {
-				params: { org_id: orgId },
+				// Verified domains per org are expected to be a handful at most; a
+				// generous single-page limit avoids silently truncating at the
+				// backend's default of 10 without needing full pagination UI.
+				params: { org_id: orgId, pagination: { limit: 100 } },
 			})
 			.toPromise();
 		setDomains(res.data?._org_domains?.org_domains || []);
+		setDomainsLoading(false);
 	};
 
 	useEffect(() => {
@@ -241,7 +247,9 @@ const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
 					</div>
 				</CardHeader>
 				<CardContent>
-					{domains.length > 0 ? (
+					{domainsLoading ? (
+						<p className="text-sm text-gray-400">Loading verified domains…</p>
+					) : domains.length > 0 ? (
 						<Table>
 							<TableHeader>
 								<TableRow>
@@ -325,8 +333,14 @@ const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
 					) : (
 						<div className="space-y-3">
 							<div>
-								<label className="text-sm font-medium">Domain</label>
+								<label
+									htmlFor="org-domain-input"
+									className="text-sm font-medium"
+								>
+									Domain
+								</label>
 								<Input
+									id="org-domain-input"
 									placeholder="acme.com"
 									value={domainInput}
 									onChange={(e) => setDomainInput(e.currentTarget.value)}

--- a/web/dashboard/src/graphql/mutation/index.ts
+++ b/web/dashboard/src/graphql/mutation/index.ts
@@ -410,3 +410,46 @@ export const ImportSAMLSPMetadata = `
     }
   }
 `;
+
+export const RequestOrgDomain = `
+  mutation requestOrgDomain($params: RequestOrgDomainRequest!) {
+    _request_org_domain(params: $params) {
+      domain
+      record_type
+      record_name
+      record_value
+    }
+  }
+`;
+
+export const VerifyOrgDomain = `
+  mutation verifyOrgDomain($params: VerifyOrgDomainRequest!) {
+    _verify_org_domain(params: $params) {
+      domain
+      org_id
+      verified_at
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export const AddVerifiedOrgDomain = `
+  mutation addVerifiedOrgDomain($params: AddVerifiedOrgDomainRequest!) {
+    _add_verified_org_domain(params: $params) {
+      domain
+      org_id
+      verified_at
+      created_at
+      updated_at
+    }
+  }
+`;
+
+export const DeleteOrgDomain = `
+  mutation deleteOrgDomain($params: DeleteOrgDomainRequest!) {
+    _delete_org_domain(params: $params) {
+      message
+    }
+  }
+`;

--- a/web/dashboard/src/graphql/queries/index.ts
+++ b/web/dashboard/src/graphql/queries/index.ts
@@ -404,3 +404,20 @@ export const ListSAMLIDPKeysQuery = `
     }
   }
 `;
+
+export const OrgDomainsQuery = `
+  query listOrgDomains($params: ListOrgDomainsRequest!) {
+    _org_domains(params: $params) {
+      pagination {
+        total
+      }
+      org_domains {
+        domain
+        org_id
+        verified_at
+        created_at
+        updated_at
+      }
+    }
+  }
+`;

--- a/web/dashboard/src/pages/OrganizationDetail.tsx
+++ b/web/dashboard/src/pages/OrganizationDetail.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner';
 import UpdateOrgOIDCConnectionModal from '../components/UpdateOrgOIDCConnectionModal';
 import UpdateOrgSAMLConnectionModal from '../components/UpdateOrgSAMLConnectionModal';
 import SAMLServiceProviders from '../components/SAMLServiceProviders';
+import OrgDomains from '../components/OrgDomains';
 import ClientSecretDialog from '../components/ClientSecretDialog';
 import { UpdateModalViews } from '../constants';
 import { capitalizeFirstLetter, getGraphQLErrorMessage } from '../utils';
@@ -816,6 +817,9 @@ const OrganizationDetail = () => {
 					)}
 				</CardContent>
 			</Card>
+
+			{/* Verified domains (home-realm discovery) */}
+			<OrgDomains orgId={orgId} orgSlug={org?.name || ''} />
 
 			{/* Confirm dialogs */}
 			<ConfirmDialog

--- a/web/dashboard/src/types.ts
+++ b/web/dashboard/src/types.ts
@@ -364,3 +364,25 @@ export interface CreateScimEndpointResponse {
 	// Returned exactly once at creation/rotation; never retrievable again.
 	token: string;
 }
+
+// OrgDomain is a VERIFIED DNS domain -> organization mapping used for
+// home-realm discovery (routing a login to the correct tenant IdP). A row
+// exists only once the domain is verified.
+export interface OrgDomain {
+	domain: string;
+	org_id: string;
+	verified_at?: number | null;
+	created_at?: number | null;
+	updated_at?: number | null;
+}
+
+// OrgDomainChallenge is the DNS TXT record a tenant publishes to prove control
+// of a domain. Returned by _request_org_domain; no durable row exists until the
+// domain is verified.
+export interface OrgDomainChallenge {
+	domain: string;
+	// record_type is always "TXT".
+	record_type: string;
+	record_name: string;
+	record_value: string;
+}


### PR DESCRIPTION
## Why
The backend fully implements per-org verified email domains for home-realm
discovery (DNS TXT challenge/verify, super-admin trusted-assert, list,
delete) but had zero dashboard UI — the only piece of the Enterprise SSO
story an admin couldn't configure without calling the GraphQL API directly.

## What
New `OrgDomains` card (structural clone of `SAMLServiceProviders.tsx`),
mounted on the organization detail page:
- Lists verified domains with verified-date badge and delete
- "Add Domain" → DNS challenge flow: request → shows the TXT record name/value
  with copy-to-clipboard → Verify. A DNS-not-propagated-yet response keeps the
  dialog and record on screen with a retry hint instead of discarding the flow
- Secondary "Add without DNS verification (super-admin)" trusted-assert path —
  no client-side role gating invented (none exists elsewhere in this
  dashboard); a non-super-admin caller gets the backend's real permission
  error via the existing toast path

## Test plan
- [x] New vitest suite (4 tests): list render, full challenge→verify happy
      path, retryable DNS-failure keeps dialog+record, delete-with-confirm
- [x] Full dashboard suite: 8 files / 41 tests passed, no regressions
- [x] `tsc --noEmit` clean, prettier clean