### PR TITLE
fix(app): add breathing room between login title and social/passkey button

### DIFF
--- a/web/app/src/index.css
+++ b/web/app/src/index.css
@@ -136,7 +136,7 @@ textarea {
 }
 
 .au-page-title {
-	margin: 0 0 4px;
+	margin: 0 0 20px;
 	text-align: center;
 	font-size: 20px;
 	font-weight: 600;


### PR DESCRIPTION
## Why
\`.au-page-title\` had only a 4px bottom margin, so "Login" sat almost flush
against the passkey/social login buttons directly below it — visually cramped.

## What
Bumped the title's bottom margin from 4px to 20px. Applies to all three
pages using this class (Login, Signup, Forgot Password) for consistency.

## Test plan
- [x] \`npm run build\` — clean
- [x] Visually verified in a live \`make dev\`-equivalent run (screenshot below) —
      comfortable, proportionate gap; not excessive
- [x] prettier clean