### PR TITLE
security(observability): instrument silent auth/FGA/OAuth-hardening rejection paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -440,6 +440,7 @@ func runRoot(c *cobra.Command, args []string) {
 	// the host-header-injection account-takeover class (CWE-640). Empty keeps
 	// the legacy header-based derivation.
 	parsers.SetTrustedURL(rootArgs.config.AuthorizerURL)
+	parsers.SetLogger(&log)
 
 	// Storage provider
 	storageProvider, err := storage.New(&rootArgs.config, &storage.Dependencies{

--- a/internal/asyncutil/asyncutil.go
+++ b/internal/asyncutil/asyncutil.go
@@ -5,24 +5,31 @@
 package asyncutil
 
 import (
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/authorizerdev/authorizer/internal/metrics"
 )
 
 var counter atomic.Int64
 
 // Go runs fn in a new goroutine, tracking it so Wait can block until it
 // finishes and recovering any panic fn raises. log may be nil, in which
-// case a recovered panic is dropped (all current call sites pass a logger).
+// case a recovered panic is only counted, not logged (all current call
+// sites pass a logger).
 func Go(log *zerolog.Logger, fn func()) {
 	counter.Add(1)
 	go func() {
 		defer counter.Add(-1)
 		defer func() {
-			if r := recover(); r != nil && log != nil {
-				log.Error().Interface("panic", r).Msg("recovered panic in background goroutine")
+			if r := recover(); r != nil {
+				metrics.RecordPanicRecovered()
+				if log != nil {
+					log.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("recovered panic in background goroutine")
+				}
 			}
 		}()
 		fn()

--- a/internal/authorization/engine/openfga/openfga.go
+++ b/internal/authorization/engine/openfga/openfga.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 )
 
 // Store kinds for the embedded datastore.
@@ -235,6 +236,7 @@ func (e *engineImpl) Reset(ctx context.Context) error {
 	defer e.mu.Unlock()
 	if e.storeID != "" {
 		if _, err := e.srv.DeleteStore(ctx, &openfgav1.DeleteStoreRequest{StoreId: e.storeID}); err != nil {
+			metrics.RecordFgaOperation(metrics.FgaOpReset, metrics.FgaResultError)
 			return fmt.Errorf("openfga.Reset: DeleteStore: %w", err)
 		}
 	}
@@ -242,10 +244,12 @@ func (e *engineImpl) Reset(ctx context.Context) error {
 		Name: storeNameOrDefault(e.storeName),
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpReset, metrics.FgaResultError)
 		return fmt.Errorf("openfga.Reset: CreateStore: %w", err)
 	}
 	e.storeID = store.GetId()
 	e.modelID = ""
+	metrics.RecordFgaOperation(metrics.FgaOpReset, metrics.FgaResultSuccess)
 	e.log.Info().Str("store_id", e.storeID).Msg("FGA store reset; new empty store created")
 	return nil
 }

--- a/internal/authorization/engine/openfga/operations.go
+++ b/internal/authorization/engine/openfga/operations.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/authorizerdev/authorizer/internal/authorization/engine"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 )
 
 // Check reports whether user is related to object via relation. It is
@@ -132,8 +133,11 @@ func (e *engineImpl) ListUsers(ctx context.Context, object, relation, userType s
 		UserFilters:          []*openfgav1.UserTypeFilter{{Type: userType}},
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpListUsers, metrics.FgaResultError)
+		e.log.Debug().Err(err).Msg("openfga: list users failed")
 		return nil, fmt.Errorf("openfga.ListUsers: %w", err)
 	}
+	metrics.RecordFgaOperation(metrics.FgaOpListUsers, metrics.FgaResultSuccess)
 	users := make([]string, 0, len(res.GetUsers()))
 	for _, u := range res.GetUsers() {
 		users = append(users, string(tuple.UserProtoToString(u)))
@@ -159,12 +163,16 @@ func (e *engineImpl) Expand(ctx context.Context, relation, object string) (strin
 		},
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpExpand, metrics.FgaResultError)
+		e.log.Debug().Err(err).Msg("openfga: expand failed")
 		return "", fmt.Errorf("openfga.Expand: %w", err)
 	}
 	jsonBytes, err := protojson.Marshal(res.GetTree())
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpExpand, metrics.FgaResultError)
 		return "", fmt.Errorf("openfga.Expand: marshal tree: %w", err)
 	}
+	metrics.RecordFgaOperation(metrics.FgaOpExpand, metrics.FgaResultSuccess)
 	return string(jsonBytes), nil
 }
 
@@ -188,8 +196,11 @@ func (e *engineImpl) WriteTuples(ctx context.Context, tuples []engine.TupleKey) 
 		Writes:               &openfgav1.WriteRequestWrites{TupleKeys: keys},
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpWriteTuples, metrics.FgaResultError)
+		e.log.Debug().Err(err).Int("count", len(tuples)).Msg("openfga: write tuples failed")
 		return fmt.Errorf("openfga.WriteTuples: %w", err)
 	}
+	metrics.RecordFgaOperation(metrics.FgaOpWriteTuples, metrics.FgaResultSuccess)
 	return nil
 }
 
@@ -213,8 +224,11 @@ func (e *engineImpl) DeleteTuples(ctx context.Context, tuples []engine.TupleKey)
 		Deletes:              &openfgav1.WriteRequestDeletes{TupleKeys: keys},
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpDeleteTuples, metrics.FgaResultError)
+		e.log.Debug().Err(err).Int("count", len(tuples)).Msg("openfga: delete tuples failed")
 		return fmt.Errorf("openfga.DeleteTuples: %w", err)
 	}
+	metrics.RecordFgaOperation(metrics.FgaOpDeleteTuples, metrics.FgaResultSuccess)
 	return nil
 }
 
@@ -244,8 +258,11 @@ func (e *engineImpl) ReadTuples(ctx context.Context, filter engine.ReadTuplesFil
 
 	res, err := e.srv.Read(ctx, req)
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpReadTuples, metrics.FgaResultError)
+		e.log.Debug().Err(err).Msg("openfga: read tuples failed")
 		return nil, fmt.Errorf("openfga.ReadTuples: %w", err)
 	}
+	metrics.RecordFgaOperation(metrics.FgaOpReadTuples, metrics.FgaResultSuccess)
 
 	out := &engine.ReadTuplesResult{
 		ContinuationToken: res.GetContinuationToken(),
@@ -279,6 +296,8 @@ func (e *engineImpl) WriteModel(ctx context.Context, dsl string) (string, error)
 		Conditions:      parsed.GetConditions(),
 	})
 	if err != nil {
+		metrics.RecordFgaOperation(metrics.FgaOpWriteModel, metrics.FgaResultError)
+		e.log.Debug().Err(err).Msg("openfga: write model failed")
 		return "", fmt.Errorf("openfga.WriteModel: %w", err)
 	}
 	modelID := wm.GetAuthorizationModelId()
@@ -287,6 +306,7 @@ func (e *engineImpl) WriteModel(ctx context.Context, dsl string) (string, error)
 	e.modelID = modelID
 	e.mu.Unlock()
 
+	metrics.RecordFgaOperation(metrics.FgaOpWriteModel, metrics.FgaResultSuccess)
 	e.log.Info().Str("model_id", modelID).Msg("wrote OpenFGA authorization model; persist this ID")
 	return modelID, nil
 }

--- a/internal/grpcsrv/interceptors/auth.go
+++ b/internal/grpcsrv/interceptors/auth.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,6 +18,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/authctx"
 	"github.com/authorizerdev/authorizer/internal/cookie"
 	"github.com/authorizerdev/authorizer/internal/grpcsrv/transport"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/token"
 )
 
@@ -42,7 +44,8 @@ var infrastructureServices = map[string]struct{}{
 var methodDescCache sync.Map // map[string]protoreflect.MethodDescriptor
 
 // Auth returns a unary interceptor that enforces proto-declared auth policy.
-func Auth(tp token.Provider) grpc.UnaryServerInterceptor {
+// log may be nil (rejections are then only counted, not logged).
+func Auth(tp token.Provider, log *zerolog.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		methodDesc, ok := methodDescriptor(info.FullMethod)
 		if !ok {
@@ -77,6 +80,18 @@ func Auth(tp token.Provider) grpc.UnaryServerInterceptor {
 
 		if serviceName == adminServiceName {
 			if !tp.IsSuperAdmin(gc) {
+				if isPublicMethod(methodDesc) {
+					// This method carries the `public` proto annotation but isn't
+					// AdminLogin, so the bypass above deliberately did not honor it —
+					// it fell through here and is still being blocked. That is a
+					// mis-annotated admin RPC (a real footgun: it means someone marked
+					// a sensitive admin method public by mistake), worth alerting on
+					// distinctly from an ordinary unauthenticated caller.
+					metrics.RecordSecurityEvent("admin_public_bypass_blocked", "grpc_auth")
+					if log != nil {
+						log.Warn().Str("method", string(methodDesc.Name())).Msg("admin RPC marked public but is not AdminLogin — bypass denied, super-admin still required")
+					}
+				}
 				return nil, status.Error(codes.Unauthenticated, "unauthorized")
 			}
 			ctx = authctx.WithPrincipal(ctx, &authctx.Principal{IsSuperAdmin: true})

--- a/internal/grpcsrv/interceptors/auth_test.go
+++ b/internal/grpcsrv/interceptors/auth_test.go
@@ -60,7 +60,7 @@ func (s *stubTokenProvider) ValidateBrowserSession(_ *gin.Context, encryptedSess
 
 func TestAuth_PublicMethodPassesThrough(t *testing.T) {
 	stub := &stubTokenProvider{}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 
 	called := false
 	_, err := mw(context.Background(), &authorizerv1.MetaRequest{}, info(authorizerv1.AuthorizerService_Meta_FullMethodName), func(ctx context.Context, _ any) (any, error) {
@@ -79,7 +79,7 @@ func TestAuth_PublicMethodPassesThrough(t *testing.T) {
 func TestAuth_AdminMethodRequiresSuperAdmin(t *testing.T) {
 	t.Run("rejects missing admin auth", func(t *testing.T) {
 		stub := &stubTokenProvider{superAdmin: false}
-		mw := Auth(stub)
+		mw := Auth(stub, nil)
 		called := false
 		_, err := mw(context.Background(), &authorizerv1.AdminMetaRequest{}, info(authorizerv1.AuthorizerAdminService_AdminMeta_FullMethodName), func(_ context.Context, _ any) (any, error) {
 			called = true
@@ -94,7 +94,7 @@ func TestAuth_AdminMethodRequiresSuperAdmin(t *testing.T) {
 
 	t.Run("attaches admin principal when authorized", func(t *testing.T) {
 		stub := &stubTokenProvider{superAdmin: true}
-		mw := Auth(stub)
+		mw := Auth(stub, nil)
 		called := false
 		_, err := mw(context.Background(), &authorizerv1.AdminMetaRequest{}, info(authorizerv1.AuthorizerAdminService_AdminMeta_FullMethodName), func(ctx context.Context, _ any) (any, error) {
 			called = true
@@ -115,7 +115,7 @@ func TestAuth_AdminMethodRequiresSuperAdmin(t *testing.T) {
 func TestAuth_PrivatePublicServiceMethodRequiresUser(t *testing.T) {
 	t.Run("rejects unauthenticated user", func(t *testing.T) {
 		stub := &stubTokenProvider{tokenErr: status.Error(codes.Unauthenticated, "bad token")}
-		mw := Auth(stub)
+		mw := Auth(stub, nil)
 		called := false
 		_, err := mw(context.Background(), &authorizerv1.ProfileRequest{}, info(authorizerv1.AuthorizerService_Profile_FullMethodName), func(_ context.Context, _ any) (any, error) {
 			called = true
@@ -136,7 +136,7 @@ func TestAuth_PrivatePublicServiceMethodRequiresUser(t *testing.T) {
 				Nonce:       "nonce-1",
 			},
 		}
-		mw := Auth(stub)
+		mw := Auth(stub, nil)
 		called := false
 		_, err := mw(context.Background(), &authorizerv1.ProfileRequest{}, info(authorizerv1.AuthorizerService_Profile_FullMethodName), func(ctx context.Context, _ any) (any, error) {
 			called = true
@@ -158,7 +158,7 @@ func TestAuth_PrivatePublicServiceMethodRequiresUser(t *testing.T) {
 
 func TestAuth_InfrastructureServiceSkipsAuth(t *testing.T) {
 	stub := &stubTokenProvider{}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	called := false
 	_, err := mw(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}, func(_ context.Context, _ any) (any, error) {
 		called = true
@@ -174,7 +174,7 @@ func TestAuth_SessionRequiresCookieRejectsBearer(t *testing.T) {
 	stub := &stubTokenProvider{
 		tokenData: &token.SessionOrAccessTokenData{UserID: "user-1"},
 	}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		"authorization", "Bearer access-token",
 	))
@@ -198,7 +198,7 @@ func TestAuth_SessionAcceptsCookie(t *testing.T) {
 			Nonce:       "nonce-1",
 		},
 	}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	cookieName := constants.AppCookieName + "_session"
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		"cookie", cookieName+"=sess-token",
@@ -219,7 +219,7 @@ func TestAuth_SessionAcceptsCookie(t *testing.T) {
 
 func TestAuth_LogoutRequiresAuth(t *testing.T) {
 	stub := &stubTokenProvider{tokenErr: status.Error(codes.Unauthenticated, "bad token")}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	called := false
 	_, err := mw(context.Background(), &authorizerv1.LogoutRequest{}, info(authorizerv1.AuthorizerService_Logout_FullMethodName), func(_ context.Context, _ any) (any, error) {
 		called = true
@@ -235,7 +235,7 @@ func TestAuth_LogoutRequiresAuth(t *testing.T) {
 // it. Regression guard that scoping the `public` bypass did not lock admins out.
 func TestAuth_AdminLoginRemainsPublic(t *testing.T) {
 	stub := &stubTokenProvider{superAdmin: false}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	called := false
 	_, err := mw(context.Background(), &authorizerv1.AdminLoginRequest{}, info(authorizerv1.AuthorizerAdminService_AdminLogin_FullMethodName), func(ctx context.Context, _ any) (any, error) {
 		called = true
@@ -282,7 +282,7 @@ func TestShouldRejectUnlistedService(t *testing.T) {
 // TestAuth_NilTokenProviderFailsClosed asserts the interceptor fails closed when
 // no TokenProvider is wired (e.g. during early startup).
 func TestAuth_NilTokenProviderFailsClosed(t *testing.T) {
-	mw := Auth(nil)
+	mw := Auth(nil, nil)
 	called := false
 	_, err := mw(context.Background(), &authorizerv1.ProfileRequest{}, info(authorizerv1.AuthorizerService_Profile_FullMethodName), func(_ context.Context, _ any) (any, error) {
 		called = true
@@ -301,7 +301,7 @@ func TestAuth_SessionOnlyAcceptsPublicService(t *testing.T) {
 	stub := &stubTokenProvider{
 		sessionData: &token.SessionData{Subject: "user-1", LoginMethod: "basic_auth", Nonce: "n"},
 	}
-	mw := Auth(stub)
+	mw := Auth(stub, nil)
 	cookieName := constants.AppCookieName + "_session"
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("cookie", cookieName+"=tok"))
 	_, err := mw(ctx, &authorizerv1.SessionRequest{}, info(authorizerv1.AuthorizerService_Session_FullMethodName), func(ctx context.Context, _ any) (any, error) {

--- a/internal/grpcsrv/server.go
+++ b/internal/grpcsrv/server.go
@@ -54,7 +54,7 @@ func New(addr string, deps *Dependencies) (*Server, error) {
 			// Records authorizer_api_operations_total{protocol,operation,status}
 			// for every RPC (covers both gRPC and REST-via-gateway).
 			interceptors.Metrics(),
-			interceptors.Auth(deps.TokenProvider),
+			interceptors.Auth(deps.TokenProvider, deps.Log),
 			validate,
 			// Innermost: wraps the handler directly so it can translate typed
 			// service.Error values into proper gRPC status codes. Must stay

--- a/internal/http_handlers/authorize.go
+++ b/internal/http_handlers/authorize.go
@@ -50,6 +50,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/cookie"
 	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/parsers"
 	"github.com/authorizerdev/authorizer/internal/token"
 	"github.com/authorizerdev/authorizer/internal/validators"
@@ -185,7 +186,10 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 
 		// RFC 8707: reject a repeated resource parameter (single audience only).
 		// redirect_uri is validated above, so redirectErrorToRP is safe here.
+		// Debug only, no security-event metric: a routine malformed request,
+		// not evidence of an attack (keeps SecurityEventsTotal signal clean).
 		if vals := gc.Request.Form["resource"]; len(vals) > 1 {
+			log.Debug().Str("client_id", clientID).Msg("rejected: repeated resource parameter")
 			redirectErrorToRP(gc, responseMode, redirectURI, state, "invalid_request", "only one resource parameter is supported")
 			return
 		}
@@ -194,6 +198,7 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 		// NOT include a fragment component. The RFC-conventional error code for
 		// a rejected resource is invalid_target.
 		if resource != "" && !isValidResourceIndicator(resource) {
+			log.Debug().Str("client_id", clientID).Str("resource", resource).Msg("rejected: invalid resource indicator")
 			redirectErrorToRP(gc, responseMode, redirectURI, state, "invalid_target", "resource must be an absolute URI without a fragment")
 			return
 		}
@@ -211,6 +216,7 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 				errCode = "request_uri_not_supported"
 				errDesc = "the request_uri parameter is not supported"
 			}
+			log.Debug().Str("client_id", clientID).Str("error", errCode).Msg("rejected: request/request_uri (JAR) not supported")
 			redirectErrorToRP(gc, responseMode, redirectURI, state, errCode, errDesc)
 			return
 		}
@@ -220,6 +226,7 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 		// here — reject rather than silently defaulting to an implicit-flow
 		// token grant the client never asked for.
 		if responseType == "" {
+			log.Debug().Str("client_id", clientID).Msg("rejected: response_type is required")
 			redirectErrorToRP(gc, responseMode, redirectURI, state, "invalid_request", "response_type is required")
 			return
 		}
@@ -244,8 +251,13 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 			})
 			return
 		}
-		// OAuth 2.1 strict mode: PKCE "plain" is removed — S256 only.
+		// OAuth 2.1 strict mode: PKCE "plain" is removed — S256 only. Recorded
+		// as a security event (not just logged): a client presenting "plain"
+		// while strict mode is on is attempting the exact downgrade this
+		// setting exists to block.
 		if h.Config.OAuth21Strict && codeChallengeMethod == "plain" && codeChallenge != "" {
+			metrics.RecordSecurityEvent("pkce_plain_rejected_strict", "authorize_endpoint")
+			log.Warn().Str("client_id", clientID).Msg("rejected: PKCE plain method not allowed under OAuth 2.1 strict mode")
 			gc.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_request",
 				"error_description": "code_challenge_method=plain is not allowed; use S256",
@@ -302,6 +314,8 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 		// The check is component-exact (not a substring) so "id_token" — which
 		// contains "token" only as a substring — is NOT matched.
 		if h.Config.OAuth21Strict && responseTypeHasBareToken(responseType) {
+			metrics.RecordSecurityEvent("bare_token_response_type_rejected_strict", "authorize_endpoint")
+			log.Warn().Str("client_id", clientID).Str("response_type", responseType).Msg("rejected: implicit/bare-token response_type not allowed under OAuth 2.1 strict mode")
 			redirectErrorToRP(gc, responseMode, redirectURI, state, "unsupported_response_type", "response_type="+responseType+" is not supported")
 			return
 		}

--- a/internal/http_handlers/authorize.go
+++ b/internal/http_handlers/authorize.go
@@ -75,8 +75,13 @@ const (
 // code_challenge = to prevent CSRF attack
 // code_challenge_method = to prevent CSRF attack [only sh256 is supported]
 func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
-	log := h.Log.With().Str("func", "AuthorizeHandler").Logger()
 	return func(gc *gin.Context) {
+		// log is request-scoped (declared inside the closure, not captured from
+		// the enclosing func) so concurrent requests each mutate their own
+		// value when reassigning below (e.g. attaching client_id) — a logger
+		// declared outside the closure and reassigned here would be shared,
+		// mutable state race-read/written by every concurrent request.
+		log := h.Log.With().Str("func", "AuthorizeHandler").Logger()
 		// RFC 6749 §3.1 / OIDC Core §3.1.2.1: the authorization endpoint
 		// MUST support GET and MAY support POST (form-urlencoded body).
 		// FormValue reads the POST body first, falling back to the query

--- a/internal/http_handlers/org_group_roles.go
+++ b/internal/http_handlers/org_group_roles.go
@@ -3,9 +3,11 @@ package http_handlers
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 
+	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
@@ -41,12 +43,16 @@ func (h *httpProvider) orgGroupDerivedRoles(ctx context.Context, orgID string, u
 		return nil
 	}
 	l := log.With().Str("func", "orgGroupDerivedRoles").Logger()
+	start := time.Now()
 	objects, err := h.AuthzEngine.ListObjects(ctx, "user:"+user.ID, "assignee", "role")
+	metrics.ObserveFgaCheckDuration(metrics.FgaOpDerivedRoles, time.Since(start).Seconds())
 	if err != nil {
 		// No model, no role type/relation, engine down — derive nothing.
+		metrics.RecordFgaCheck(metrics.FgaOpDerivedRoles, metrics.FgaResultError)
 		l.Debug().Err(err).Msg("role lookup failed, deriving no roles")
 		return nil
 	}
+	metrics.RecordFgaCheck(metrics.FgaOpDerivedRoles, metrics.FgaResultSuccess)
 	prefix := "role:" + orgID + "/"
 	seen := map[string]bool{}
 	var names []string

--- a/internal/http_handlers/saml_idp.go
+++ b/internal/http_handlers/saml_idp.go
@@ -525,12 +525,16 @@ func (h *httpProvider) assertedGroupsForOrg(ctx context.Context, orgID string, u
 	if h.AuthzEngine == nil {
 		return nil
 	}
+	start := time.Now()
 	objects, err := h.AuthzEngine.ListObjects(ctx, "user:"+user.ID, "member", "group")
+	metrics.ObserveFgaCheckDuration(metrics.FgaOpDerivedRoles, time.Since(start).Seconds())
 	if err != nil {
 		// No model yet, engine down, etc. — emit no groups (fail-closed).
+		metrics.RecordFgaCheck(metrics.FgaOpDerivedRoles, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("saml idp: group lookup failed, emitting no groups")
 		return nil
 	}
+	metrics.RecordFgaCheck(metrics.FgaOpDerivedRoles, metrics.FgaResultSuccess)
 	prefix := "group:" + orgID + "/"
 	seen := map[string]bool{}
 	var names []string

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -377,6 +377,11 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			if resource != "" {
 				requestResources := gc.PostFormArray("resource")
 				if len(requestResources) != 1 || strings.TrimSpace(requestResources[0]) != resource {
+					// A mismatched resource here is more than a client bug: it's the
+					// shape of an audience-confusion / token-substitution attempt
+					// against the exact binding RFC 8707 exists to enforce.
+					metrics.RecordSecurityEvent("token_exchange_resource_mismatch", "token_endpoint")
+					log.Warn().Str("client_id", strings.TrimSpace(reqBody.ClientID)).Msg("rejected: resource parameter does not match the authorization request")
 					gc.JSON(http.StatusBadRequest, gin.H{
 						"error":             "invalid_grant",
 						"error_description": "The resource parameter does not match the authorization request",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -189,6 +189,18 @@ var (
 		},
 		[]string{"operation", "result"},
 	)
+
+	// PanicsRecoveredTotal counts panics recovered from fire-and-forget
+	// background goroutines (internal/asyncutil.Go). Any nonzero rate means a
+	// background side-effect (email/SMS send, webhook, audit log) hit a bug
+	// that would otherwise have crashed the whole process — always worth
+	// alerting on.
+	PanicsRecoveredTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "authorizer_panics_recovered_total",
+			Help: "Total panics recovered from fire-and-forget background goroutines",
+		},
+	)
 )
 
 // staticAssetPathSuffixes are path suffixes (after lowercasing) treated as static files
@@ -275,6 +287,7 @@ func Init() {
 		prometheus.MustRegister(FgaChecksTotal)
 		prometheus.MustRegister(FgaCheckDuration)
 		prometheus.MustRegister(FgaOperationsTotal)
+		prometheus.MustRegister(PanicsRecoveredTotal)
 	})
 }
 
@@ -353,6 +366,13 @@ const (
 	FgaOpListUsers        = "list_users"
 	FgaOpExpand           = "expand"
 	FgaOpReset            = "reset"
+	// FgaOpRequiredRelations is the session/token-validation-time gate
+	// (enforceRequiredRelations) — a Check call, decision-family like
+	// check_permissions/list_permissions.
+	FgaOpRequiredRelations = "required_relations"
+	// FgaOpDerivedRoles is the login/SSO-time claim-derivation lookup shared by
+	// SAML group assertion and JWT role derivation (both ListObjects calls).
+	FgaOpDerivedRoles = "derived_roles"
 )
 
 // FGA result labels.
@@ -391,4 +411,10 @@ func ObserveFgaCheckDuration(operation string, seconds float64) {
 // FgaResultError.
 func RecordFgaOperation(operation, result string) {
 	FgaOperationsTotal.WithLabelValues(operation, result).Inc()
+}
+
+// RecordPanicRecovered records a panic recovered from a fire-and-forget
+// background goroutine.
+func RecordPanicRecovered() {
+	PanicsRecoveredTotal.Inc()
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -154,24 +154,35 @@ var (
 	)
 
 	// FgaChecksTotal is the headline fine-grained-authorization access-decision
-	// counter: every check_permissions decision by outcome. Use it for FGA
-	// adoption tracking and denial/error alerting.
-	// operation: check_permissions. result: allowed | denied | error.
+	// counter: every access-decision check by outcome, across every decision
+	// surface (client-facing checks, session/token required-relations gating,
+	// and login/SSO-time claim derivation). Use it for FGA adoption tracking
+	// and denial/error alerting.
+	// operation: check_permissions | list_permissions | required_relations |
+	// derived_roles. result: allowed | denied | error.
+	// NOTE: required_relations runs on the session/JWT-validation hot path and
+	// derived_roles on every login/SSO claim derivation — both are far
+	// higher-QPS than the admin-triggered check_permissions/list_permissions
+	// calls. A PromQL query that aggregates this family WITHOUT filtering by
+	// `operation` will be dominated by these two series.
 	FgaChecksTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "authorizer_fga_checks_total",
-			Help: "Total fine-grained authorization access decisions. operation=check_permissions, result=allowed|denied|error",
+			Help: "Total fine-grained authorization access decisions. operation=check_permissions|list_permissions|required_relations|derived_roles, result=allowed|denied|error",
 		},
 		[]string{"operation", "result"},
 	)
 
-	// FgaCheckDuration tracks the latency of the client-facing FGA read
-	// operations (the OpenFGA engine call), in seconds.
-	// operation: check_permissions | list_permissions.
+	// FgaCheckDuration tracks the latency of FGA access-decision calls (the
+	// OpenFGA engine Check/ListObjects call), in seconds, across every
+	// decision surface — see FgaChecksTotal's doc comment for the QPS caveat
+	// on required_relations/derived_roles.
+	// operation: check_permissions | list_permissions | required_relations |
+	// derived_roles.
 	FgaCheckDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "authorizer_fga_check_duration_seconds",
-			Help:    "Fine-grained authorization engine call duration in seconds. operation=check_permissions|list_permissions",
+			Help:    "Fine-grained authorization engine call duration in seconds. operation=check_permissions|list_permissions|required_relations|derived_roles",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"operation"},
@@ -360,18 +371,23 @@ const (
 	FgaOpListPermissions  = "list_permissions"
 	FgaOpGetModel         = "get_model"
 	FgaOpWriteModel       = "write_model"
-	FgaOpReadTuples       = "read_tuples"
-	FgaOpWriteTuples      = "write_tuples"
-	FgaOpDeleteTuples     = "delete_tuples"
-	FgaOpListUsers        = "list_users"
-	FgaOpExpand           = "expand"
-	FgaOpReset            = "reset"
+	// FgaOpReadTuples is recorded once per engine-level page read, not once per
+	// logical caller request — a caller that paginates internally (e.g. SCIM's
+	// group-membership listing) increments this once per page.
+	FgaOpReadTuples   = "read_tuples"
+	FgaOpWriteTuples  = "write_tuples"
+	FgaOpDeleteTuples = "delete_tuples"
+	FgaOpListUsers    = "list_users"
+	FgaOpExpand       = "expand"
+	FgaOpReset        = "reset"
 	// FgaOpRequiredRelations is the session/token-validation-time gate
 	// (enforceRequiredRelations) — a Check call, decision-family like
 	// check_permissions/list_permissions.
 	FgaOpRequiredRelations = "required_relations"
 	// FgaOpDerivedRoles is the login/SSO-time claim-derivation lookup shared by
 	// SAML group assertion and JWT role derivation (both ListObjects calls).
+	// The two call sites share this one label — the series does not
+	// distinguish which of the two triggered a given sample.
 	FgaOpDerivedRoles = "derived_roles"
 )
 

--- a/internal/parsers/url.go
+++ b/internal/parsers/url.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 )
 
 // GetHost returns the authorizer host URL from the gin request context.
@@ -27,6 +28,12 @@ func GetHost(c *gin.Context) string {
 // ever reconfigured this at runtime, which we don't.
 var trustedURL string
 
+// pkgLog is an optional logger for host-header rejection events, set once at
+// startup via SetLogger. Same set-once-before-any-listener convention as
+// trustedURL above — no lock needed. Nil (the default, e.g. in tests) simply
+// means rejections aren't logged.
+var pkgLog *zerolog.Logger
+
 // SetTrustedURL records the operator-configured canonical base URL. Called once
 // from cmd/root at startup. The value is normalized to scheme+host (path,
 // query, fragment, userinfo and trailing slash stripped) so it is a valid,
@@ -34,6 +41,12 @@ var trustedURL string
 // the legacy header-based behavior rather than emitting a broken host.
 func SetTrustedURL(u string) {
 	trustedURL = sanitizeAuthorizerURL(strings.TrimSpace(u))
+}
+
+// SetLogger records the logger used to report rejected X-Authorizer-URL
+// header values. Called once from cmd/root at startup, alongside SetTrustedURL.
+func SetLogger(log *zerolog.Logger) {
+	pkgLog = log
 }
 
 // GetHostFromRequest returns the authorizer host URL from a raw *http.Request.
@@ -50,7 +63,12 @@ func GetHostFromRequest(r *http.Request) string {
 		if sanitized := sanitizeAuthorizerURL(authorizerURL); sanitized != "" {
 			return sanitized
 		}
-		// Invalid header value — fall through to standard host detection
+		// Invalid header value — fall through to standard host detection.
+		// Worth logging: a malformed/rejected X-Authorizer-URL is either a
+		// misconfigured proxy or a host-header-injection probe.
+		if pkgLog != nil {
+			pkgLog.Warn().Str("header", authorizerURL).Msg("rejected X-Authorizer-URL header — falling back to standard host detection")
+		}
 	}
 
 	scheme := r.Header.Get("X-Forwarded-Proto")

--- a/internal/service/admin_fga.go
+++ b/internal/service/admin_fga.go
@@ -68,13 +68,12 @@ func (p *provider) FgaWriteModel(ctx context.Context, meta RequestMetadata, para
 	if params == nil || strings.TrimSpace(params.Dsl) == "" {
 		return nil, nil, InvalidArgument("dsl is required")
 	}
+	// Outcome metric is recorded by the engine (WriteModel) itself.
 	modelID, err := p.AuthzEngine.WriteModel(ctx, params.Dsl)
 	if err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpWriteModel, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to write authorization model")
 		return nil, nil, err
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpWriteModel, metrics.FgaResultSuccess)
 	p.AuditProvider.LogEvent(audit.Event{
 		Action:   constants.AuditAdminFgaModelWrittenEvent,
 		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
@@ -103,12 +102,11 @@ func (p *provider) FgaWriteTuples(ctx context.Context, meta RequestMetadata, par
 	if err != nil {
 		return nil, nil, err
 	}
+	// Outcome metric is recorded by the engine (WriteTuples) itself.
 	if err := p.AuthzEngine.WriteTuples(ctx, tuples); err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpWriteTuples, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to write tuples")
 		return nil, nil, friendlyTupleError(err)
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpWriteTuples, metrics.FgaResultSuccess)
 	p.AuditProvider.LogEvent(audit.Event{
 		Action:   constants.AuditAdminFgaTuplesWrittenEvent,
 		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
@@ -137,12 +135,11 @@ func (p *provider) FgaDeleteTuples(ctx context.Context, meta RequestMetadata, pa
 	if err != nil {
 		return nil, nil, err
 	}
+	// Outcome metric is recorded by the engine (DeleteTuples) itself.
 	if err := p.AuthzEngine.DeleteTuples(ctx, tuples); err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpDeleteTuples, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to delete tuples")
 		return nil, nil, friendlyTupleError(err)
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpDeleteTuples, metrics.FgaResultSuccess)
 	p.AuditProvider.LogEvent(audit.Event{
 		Action:   constants.AuditAdminFgaTuplesDeletedEvent,
 		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,
@@ -185,13 +182,12 @@ func (p *provider) FgaReadTuples(ctx context.Context, meta RequestMetadata, para
 	if filter.PageSize == 0 {
 		filter.PageSize = maxFgaReadPageSize
 	}
+	// Outcome metric is recorded by the engine (ReadTuples) itself.
 	res, err := p.AuthzEngine.ReadTuples(ctx, filter)
 	if err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpReadTuples, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to read tuples")
 		return nil, nil, err
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpReadTuples, metrics.FgaResultSuccess)
 	out := &model.FgaTuples{Tuples: make([]*model.FgaTuple, 0, len(res.Tuples))}
 	for _, t := range res.Tuples {
 		out.Tuples = append(out.Tuples, &model.FgaTuple{User: t.User, Relation: t.Relation, Object: t.Object})
@@ -219,13 +215,12 @@ func (p *provider) FgaListUsers(ctx context.Context, meta RequestMetadata, param
 	if params == nil || strings.TrimSpace(params.Object) == "" || strings.TrimSpace(params.Relation) == "" || strings.TrimSpace(params.UserType) == "" {
 		return nil, nil, InvalidArgument("object, relation and user_type are required")
 	}
+	// Outcome metric is recorded by the engine (ListUsers) itself.
 	users, err := p.AuthzEngine.ListUsers(ctx, params.Object, params.Relation, params.UserType)
 	if err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpListUsers, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to list users")
 		return nil, nil, err
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpListUsers, metrics.FgaResultSuccess)
 	// Cap the result set; ListUsers is an expensive enumeration surface.
 	if len(users) > maxFgaListResults {
 		users = users[:maxFgaListResults]
@@ -250,13 +245,12 @@ func (p *provider) FgaExpand(ctx context.Context, meta RequestMetadata, params *
 	if params == nil || strings.TrimSpace(params.Relation) == "" || strings.TrimSpace(params.Object) == "" {
 		return nil, nil, InvalidArgument("relation and object are required")
 	}
+	// Outcome metric is recorded by the engine (Expand) itself.
 	tree, err := p.AuthzEngine.Expand(ctx, params.Relation, params.Object)
 	if err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpExpand, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to expand")
 		return nil, nil, err
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpExpand, metrics.FgaResultSuccess)
 	return &model.FgaExpandResponse{Tree: tree}, nil, nil
 }
 
@@ -288,12 +282,11 @@ func (p *provider) FgaReset(ctx context.Context, meta RequestMetadata) (*model.R
 	if existing != nil && len(existing.Tuples) > 0 {
 		return nil, nil, FailedPrecondition("remove all relationship tuples before resetting the authorization model")
 	}
+	// Outcome metric is recorded by the engine (Reset) itself.
 	if err := p.AuthzEngine.Reset(ctx); err != nil {
-		metrics.RecordFgaOperation(metrics.FgaOpReset, metrics.FgaResultError)
 		log.Debug().Err(err).Msg("Failed to reset authorization store")
 		return nil, nil, err
 	}
-	metrics.RecordFgaOperation(metrics.FgaOpReset, metrics.FgaResultSuccess)
 	p.AuditProvider.LogEvent(audit.Event{
 		Action:   constants.AuditAdminFgaResetEvent,
 		Protocol: meta.Protocol, ActorType: constants.AuditActorTypeAdmin,

--- a/internal/service/fga.go
+++ b/internal/service/fga.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
@@ -12,6 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/authorization/engine"
 	"github.com/authorizerdev/authorizer/internal/constants"
 	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 )
 
 // ErrFgaNotEnabled is returned by every fine-grained-authorization (FGA)
@@ -257,12 +259,16 @@ func (p *provider) enforceRequiredRelations(ctx context.Context, log zerolog.Log
 		if r == nil || strings.TrimSpace(r.Relation) == "" || strings.TrimSpace(r.Object) == "" {
 			return InvalidArgument("each required relation needs relation and object")
 		}
+		start := time.Now()
 		allowed, err := p.AuthzEngine.Check(ctx, subject, r.Relation, r.Object)
+		metrics.ObserveFgaCheckDuration(metrics.FgaOpRequiredRelations, time.Since(start).Seconds())
 		if err != nil {
 			// Fail closed.
+			metrics.RecordFgaCheck(metrics.FgaOpRequiredRelations, metrics.FgaResultError)
 			log.Debug().Err(err).Str("relation", r.Relation).Str("object", r.Object).Msg("required relation check errored")
 			return PermissionDenied("unauthorized")
 		}
+		metrics.RecordFgaCheckResult(metrics.FgaOpRequiredRelations, allowed)
 		if !allowed {
 			log.Debug().Str("relation", r.Relation).Str("object", r.Object).Msg("required relation denied")
 			return PermissionDenied("unauthorized")

--- a/internal/service/scim/groups.go
+++ b/internal/service/scim/groups.go
@@ -275,6 +275,7 @@ func (p *provider) PatchGroup(ctx context.Context, orgID, groupID string, displa
 }
 
 func (p *provider) DeleteGroup(ctx context.Context, orgID, groupID string) error {
+	log := p.Log.With().Str("func", "scim.DeleteGroup").Str("org_id", orgID).Str("group_id", groupID).Logger()
 	group, err := p.requireGroup(ctx, orgID, groupID)
 	if err != nil {
 		return err
@@ -294,7 +295,14 @@ func (p *provider) DeleteGroup(ctx context.Context, orgID, groupID string) error
 			for _, subj := range members {
 				tuples = append(tuples, engine.TupleKey{User: subj, Relation: groupMemberRelation, Object: groupObject(orgID, groupID)})
 			}
-			_ = p.AuthzEngine.DeleteTuples(ctx, tuples)
+			// Not fatal to the delete (the group row is still removed below — a
+			// stuck tuple write here does not block deprovisioning), but MUST be
+			// logged: a failure leaves membership tuples pointing at a
+			// soon-to-be-gone group, which is exactly the kind of authorization
+			// drift that needs an operator's attention rather than silent loss.
+			if err := p.AuthzEngine.DeleteTuples(ctx, tuples); err != nil {
+				log.Warn().Err(err).Int("member_count", len(tuples)).Msg("failed to delete group membership tuples on group delete — tuples may be orphaned")
+			}
 		}
 	}
 	if err := p.StorageProvider.DeleteScimGroup(ctx, group); err != nil {
@@ -366,11 +374,13 @@ func (p *provider) syncMembers(ctx context.Context, orgID, groupID string, add, 
 	}
 	if len(writes) > 0 {
 		if err := p.AuthzEngine.WriteTuples(ctx, writes); err != nil {
+			log.Warn().Err(err).Str("group_id", groupID).Int("count", len(writes)).Msg("failed to write group membership tuples")
 			return err
 		}
 	}
 	if len(deletes) > 0 {
 		if err := p.AuthzEngine.DeleteTuples(ctx, deletes); err != nil {
+			log.Warn().Err(err).Str("group_id", groupID).Int("count", len(deletes)).Msg("failed to delete group membership tuples")
 			return err
 		}
 	}

--- a/internal/service/verify_otp.go
+++ b/internal/service/verify_otp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/authorizerdev/authorizer/internal/cookie"
 	"github.com/authorizerdev/authorizer/internal/crypto"
 	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/metrics"
 	"github.com/authorizerdev/authorizer/internal/refs"
 	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
@@ -104,6 +105,12 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 		log.Debug().Err(err).Msg("User not found")
 		return nil, nil, NotFound("invalid verification request")
 	}
+	// Rebuild the logger from scratch (not derived from the email/phone_number
+	// context above) now that user.ID is known: every remaining log line in
+	// this function — including the lockout Warn below, which is enabled by
+	// default in production unlike the Debug lines above — must not carry raw
+	// PII. user_id is an opaque internal identifier, not personal data.
+	log = p.Log.With().Str("func", "VerifyOTP").Str("user_id", user.ID).Logger()
 
 	if user.RevokedTimestamp != nil {
 		log.Debug().Msg("User access has been revoked")
@@ -147,7 +154,8 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 			// ValidateRecoveryCode's storage-fault case.
 			log.Debug().Err(incErr).Msg("Failed to increment totp failed-attempt counter")
 		} else if attempts > totpMaxFailedAttempts {
-			log.Debug().Int64("attempts", attempts).Msg("TOTP verification locked: too many failed attempts")
+			metrics.RecordSecurityEvent("totp_verification_locked", "verify_otp")
+			log.Warn().Int64("attempts", attempts).Str("ip", meta.IPAddress).Msg("TOTP verification locked: too many failed attempts")
 			return nil, nil, TooManyRequests(`too many failed attempts, please try again later`)
 		}
 
@@ -192,7 +200,8 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 			// lock out a legitimate user (fail-open, matching the TOTP branch).
 			log.Debug().Err(incErr).Msg("Failed to increment otp failed-attempt counter")
 		} else if attempts > totpMaxFailedAttempts {
-			log.Debug().Int64("attempts", attempts).Msg("OTP verification locked: too many failed attempts")
+			metrics.RecordSecurityEvent("otp_verification_locked", "verify_otp")
+			log.Warn().Int64("attempts", attempts).Str("ip", meta.IPAddress).Msg("OTP verification locked: too many failed attempts")
 			return nil, nil, TooManyRequests(`too many failed attempts, please try again later`)
 		}
 

--- a/internal/storage/db/sql/client.go
+++ b/internal/storage/db/sql/client.go
@@ -51,12 +51,16 @@ func (p *provider) UpdateClient(ctx context.Context, sa *schemas.Client) (*schem
 // TrustedIssuers. Mirrors the webhook cascade-delete pattern. Both deletes run
 // in a single transaction so a failure cannot orphan trusted issuers.
 func (p *provider) DeleteClient(ctx context.Context, sa *schemas.Client) error {
-	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("client_id = ?", sa.ID).Delete(&schemas.TrustedIssuer{}).Error; err != nil {
 			return err
 		}
 		return tx.Delete(sa).Error
 	})
+	if err != nil {
+		p.dependencies.Log.Warn().Err(err).Str("client_id", sa.ID).Msg("DeleteClient: cascade transaction failed, rolled back")
+	}
+	return err
 }
 
 // GetClientByID fetches a service account by primary key.

--- a/internal/storage/db/sql/organization.go
+++ b/internal/storage/db/sql/organization.go
@@ -49,7 +49,7 @@ func (p *provider) UpdateOrganization(ctx context.Context, org *schemas.Organiza
 // single transaction so a mid-cascade failure cannot orphan memberships or
 // domains.
 func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organization) error {
-	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("org_id = ?", org.ID).Delete(&schemas.OrgMembership{}).Error; err != nil {
 			return err
 		}
@@ -60,6 +60,10 @@ func (p *provider) DeleteOrganization(ctx context.Context, org *schemas.Organiza
 		}
 		return tx.Delete(org).Error
 	})
+	if err != nil {
+		p.dependencies.Log.Warn().Err(err).Str("org_id", org.ID).Msg("DeleteOrganization: cascade transaction failed, rolled back")
+	}
+	return err
 }
 
 // GetOrganizationByID fetches an organization by primary key.

--- a/internal/storage/db/sql/user.go
+++ b/internal/storage/db/sql/user.go
@@ -77,12 +77,16 @@ func (p *provider) UpdateUser(ctx context.Context, user *schemas.User) (*schemas
 func (p *provider) DeleteUser(ctx context.Context, user *schemas.User) error {
 	// Delete the user and their sessions atomically so a failure cannot leave
 	// orphaned session rows behind.
-	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("user_id = ?", user.ID).Delete(&schemas.Session{}).Error; err != nil {
 			return err
 		}
 		return tx.Delete(&user).Error
 	})
+	if err != nil {
+		p.dependencies.Log.Warn().Err(err).Str("user_id", user.ID).Msg("DeleteUser: cascade transaction failed, rolled back")
+	}
+	return err
 }
 
 // ListUsers to get list of users from database. When query is non-empty it is

--- a/internal/storage/db/sql/webhook.go
+++ b/internal/storage/db/sql/webhook.go
@@ -87,10 +87,14 @@ func (p *provider) GetWebhookByEventName(ctx context.Context, eventName string) 
 func (p *provider) DeleteWebhook(ctx context.Context, webhook *schemas.Webhook) error {
 	// Delete the webhook and its logs atomically so a failure cannot leave
 	// orphaned webhook_logs rows behind.
-	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Delete(&schemas.Webhook{ID: webhook.ID}).Error; err != nil {
 			return err
 		}
 		return tx.Where("webhook_id = ?", webhook.ID).Delete(&schemas.WebhookLog{}).Error
 	})
+	if err != nil {
+		p.dependencies.Log.Warn().Err(err).Str("webhook_id", webhook.ID).Msg("DeleteWebhook: cascade transaction failed, rolled back")
+	}
+	return err
 }


### PR DESCRIPTION
## Summary
- Adds logging + Prometheus `RecordSecurityEvent` to previously-silent OAuth 2.1/RFC 8707 rejection branches (authorize.go/token.go), SCIM group FGA tuple write/delete failures, the gRPC admin public-bypass tighten, `asyncutil` panic recovery (now with stack trace + counter), and rejected `X-Authorizer-URL` headers.
- Moves FGA engine instrumentation (write/delete/read tuples, list users, expand, write model, reset) down into the `openfga` engine layer itself so every caller — including SCIM, which had none — gets it for free; removes the now-redundant duplicate metric calls in `admin_fga.go` (avoids double-counting), leaving `FgaGetModel`/`ReadModel` untouched since its `ErrNoModel`-is-success special case would be miscounted by generic wrapping. Also instruments three FGA decision call sites found uninstrumented along the way (session `required_relations` gating, SAML group assertion, JWT role derivation).
- Bumps OTP/TOTP lockout logs to `Warn` with a security-event metric, and logs cascade-delete transaction failures (org/client/webhook) that previously rolled back silently. The lockout log lines are rebuilt from a fresh logger carrying `user_id` instead of the ambient `email`/`phone_number` context, since `Warn` (unlike the existing `Debug` lines) actually emits in production and must not leak raw PII.
- Separate commit: fixes a pre-existing data race in `AuthorizeHandler` where the request logger was declared outside the closure and reassigned inside it — shared mutable state across concurrent requests, found while touching this handler.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (SQLite, 36/36 packages pass)
- [x] `make test-mongodb` (cross-DB parity check for the storage-layer logging change)
- [x] `make lint` (Go + TS, 0 issues)
- [x] Independent security-engineer review pass: no auth-decision changes, no secret/PII leakage, no metric double-counting, no concurrency hazards