### PR TITLE
security(mfa): close MFA-downgrade and password-reset takeover paths

### DIFF
--- a/internal/constants/mfa_session.go
+++ b/internal/constants/mfa_session.go
@@ -3,14 +3,24 @@ package constants
 // MFA session purposes tag how a short-lived MFA session (cookie + memory-store
 // row keyed by user ID) was obtained, so a consumer that acts on the strength
 // of a bare session can tell a first-factor-verified caller from one who only
-// triggered an OTP send.
+// triggered an OTP send, and can tell WHICH pending flow a bare OTP-send
+// session belongs to.
 const (
 	// MFASessionPurposeVerified means the caller already completed a first
 	// factor (password/passkey/social login) for this exact user, or this is
 	// the user's own just-created account.
 	MFASessionPurposeVerified = "verified"
 	// MFASessionPurposeChallenge means the caller only proved they can trigger
-	// an OTP send to this email/phone. NOT sufficient to skip MFA setup or lock
-	// the account.
+	// a login/signup/MFA OTP send to this email/phone. NOT sufficient to skip
+	// MFA setup or lock the account. Consumed exclusively by VerifyOTP.
 	MFASessionPurposeChallenge = "challenge"
+	// MFASessionPurposePasswordReset means the caller only proved they can
+	// trigger a password-reset OTP send to this phone number (ForgotPassword's
+	// mobile leg). It authorizes ONLY a password change via ResetPassword — it
+	// must never be redeemable for an access token via VerifyOTP, and the
+	// Challenge/Verified purposes above must never be accepted by
+	// ResetPassword's OTP path. Keeping these mutually exclusive is what closes
+	// the MFA-downgrade path where a password-reset OTP was redeemable for a
+	// full token instead of only a password change.
+	MFASessionPurposePasswordReset = "password_reset"
 )

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -265,11 +265,15 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			ClientAssertion:     clientAssertion,
 			ClientAssertionType: clientAssertionType,
 			// client_credentials always requires a secret; authorization_code
-			// verifies a presented secret (PKCE gates a secret-less request);
-			// refresh_token ignores the secret and authenticates the client_id
-			// only — preserving the pre-registry behavior of each grant.
+			// and refresh_token verify a presented secret (PKCE gates a
+			// secret-less authorization_code request; a public client's
+			// refresh_token request presents no secret and is unaffected —
+			// VerifyPresentedSecret only checks when one is actually
+			// presented, so a confidential/service_account client that does
+			// send its secret on refresh now has it checked instead of
+			// silently ignored).
 			RequireSecret:         isClientCredentialsGrant || isTokenExchangeGrant,
-			VerifyPresentedSecret: isAuthorizationCodeGrant,
+			VerifyPresentedSecret: isAuthorizationCodeGrant || isRefreshTokenGrant,
 			// client_credentials and token-exchange are machine-only: the calling
 			// client is the agent's service account (design §4.1 / §3). The resolver
 			// rejects a non-service_account client before verifying the secret, so an
@@ -842,6 +846,19 @@ func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolv
 		gc.JSON(http.StatusBadRequest, gin.H{
 			"error":             "unauthorized_client",
 			"error_description": "This client is not authorized to use this grant type",
+		})
+		return
+	case errors.Is(err, clientauth.ErrClientLookupFailed):
+		// A storage error (e.g. transient SQLITE_BUSY under contention), not bad
+		// credentials — must NOT be reported as invalid_client (that tells the
+		// caller their credentials are permanently wrong and non-retryable,
+		// which is false) and must NOT count as a security event (it isn't an
+		// attack signal). 503 + temporarily_unavailable tells a well-behaved
+		// OAuth client this is worth retrying, unlike a 400.
+		log.Warn().Err(err).Msg("client lookup failed (storage error)")
+		gc.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":             "temporarily_unavailable",
+			"error_description": "The authorization server is temporarily unable to handle the request",
 		})
 		return
 	}

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -848,19 +848,6 @@ func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolv
 			"error_description": "This client is not authorized to use this grant type",
 		})
 		return
-	case errors.Is(err, clientauth.ErrClientLookupFailed):
-		// A storage error (e.g. transient SQLITE_BUSY under contention), not bad
-		// credentials — must NOT be reported as invalid_client (that tells the
-		// caller their credentials are permanently wrong and non-retryable,
-		// which is false) and must NOT count as a security event (it isn't an
-		// attack signal). 503 + temporarily_unavailable tells a well-behaved
-		// OAuth client this is worth retrying, unlike a 400.
-		log.Warn().Err(err).Msg("client lookup failed (storage error)")
-		gc.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":             "temporarily_unavailable",
-			"error_description": "The authorization server is temporarily unable to handle the request",
-		})
-		return
 	}
 
 	// invalid_client (clientauth.ErrInvalidClient, or any unexpected error).

--- a/internal/integration_tests/otp_mfa_setup_test.go
+++ b/internal/integration_tests/otp_mfa_setup_test.go
@@ -397,6 +397,62 @@ func TestOTPMFASetupRejectsUnauthenticatedCaller(t *testing.T) {
 	assert.Error(t, err, "email/phone_number without a valid mfa session cookie must be rejected")
 }
 
+// TestOTPMFASetupRejectsPasswordResetSession is the regression test for the
+// MFA-enrollment-via-wrong-session finding: a password_reset-purpose MFA
+// session (minted only by ForgotPassword, meant to authorize a password
+// change via ResetPassword) must not be redeemable to enroll a NEW email/SMS
+// OTP authenticator on the account -- that would let whoever holds a
+// password-reset session (e.g. via SIM-swap) plant a persistent MFA backdoor,
+// not just issue themselves one token. A plain Verified session (real login)
+// must still work, both in cookie-only mode (no identifier) and
+// cookie+email mode.
+func TestOTPMFASetupRejectsPasswordResetSession(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableMFA = true
+	cfg.EnableEmailOTP = true
+	cfg.IsEmailServiceEnabled = true
+	ts := initTestSetup(t, cfg)
+	req, ctx := createContext(ts)
+
+	email := "otp_setup_password_reset_" + uuid.NewString() + "@authorizer.dev"
+	_, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email: &email, Password: "Password@123", ConfirmPassword: "Password@123",
+	})
+	require.NoError(t, err)
+	user, err := ts.StorageProvider.GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	t.Run("cookie-only mode: a password_reset session is rejected", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposePasswordReset, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+		req.Header.Set("Authorization", "")
+
+		_, err := ts.GraphQLProvider.EmailOTPMFASetup(ctx, nil)
+		assert.Error(t, err, "a password_reset session must not be able to enroll a new MFA factor")
+	})
+
+	t.Run("cookie+email mode: a password_reset session is rejected", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposePasswordReset, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+		req.Header.Set("Authorization", "")
+
+		_, err := ts.GraphQLProvider.EmailOTPMFASetup(ctx, &model.OtpMfaSetupRequest{Email: &email})
+		assert.Error(t, err, "a password_reset session must not be able to enroll a new MFA factor")
+	})
+
+	t.Run("a Verified session (real login) is still accepted", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeVerified, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+		req.Header.Set("Authorization", "")
+
+		_, err := ts.GraphQLProvider.EmailOTPMFASetup(ctx, &model.OtpMfaSetupRequest{Email: &email})
+		assert.NoError(t, err, "a Verified session must still be able to enroll a new MFA factor")
+	})
+}
+
 // TestVerifyOTPDoesNotAutoEnroll ensures verify_otp's new VerifiedAt-marking
 // logic only fires when a pending (unverified) Authenticator row already
 // exists -- i.e. only for a code sent by EmailOTPMFASetup/SMSOTPMFASetup. A

--- a/internal/integration_tests/refresh_token_client_binding_test.go
+++ b/internal/integration_tests/refresh_token_client_binding_test.go
@@ -157,3 +157,55 @@ func TestRefreshToken_CrossClientRedemption_Rejected(t *testing.T) {
 		assert.NotEmpty(t, okBody["access_token"])
 	})
 }
+
+// TestRefreshToken_WrongSecretPresented_Rejected is the regression test for
+// the refresh-token secret-verification hardening finding: a confidential
+// client presenting an incorrect secret on refresh_token must be rejected
+// instead of silently authenticated on client_id alone, while a public
+// client presenting no secret at all is unaffected.
+func TestRefreshToken_WrongSecretPresented_Rejected(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+
+	registerTestClient(t, ts, "client-secret-check", "correct-secret")
+
+	router, code, codeVerifier := loginForOfflineAccess(t, ts, "client-secret-check")
+
+	exchangeForm := url.Values{}
+	exchangeForm.Set("grant_type", "authorization_code")
+	exchangeForm.Set("code", code)
+	exchangeForm.Set("code_verifier", codeVerifier)
+	exchangeForm.Set("redirect_uri", "http://localhost:3000/callback")
+
+	w := exchangeCode(router, exchangeForm, []string{"client-secret-check", "correct-secret"})
+	require.Equal(t, http.StatusOK, w.Code, "code exchange body: %s", w.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	refreshToken, _ := body["refresh_token"].(string)
+	require.NotEmpty(t, refreshToken)
+
+	t.Run("a presented wrong secret is rejected even though client_id matches", func(t *testing.T) {
+		refreshForm := url.Values{}
+		refreshForm.Set("grant_type", "refresh_token")
+		refreshForm.Set("refresh_token", refreshToken)
+
+		w := exchangeCode(router, refreshForm, []string{"client-secret-check", "definitely-wrong-secret"})
+		// 401, not 400: exchangeCode presents credentials via HTTP Basic
+		// (req.SetBasicAuth), and respondClientAuthError maps ErrInvalidClient
+		// to 401 (with WWW-Authenticate) whenever hasBasicAuth is true.
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+	})
+
+	t.Run("no secret presented (public client shape) still succeeds", func(t *testing.T) {
+		refreshForm := url.Values{}
+		refreshForm.Set("grant_type", "refresh_token")
+		refreshForm.Set("refresh_token", refreshToken)
+		refreshForm.Set("client_id", "client-secret-check")
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(refreshForm.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	})
+}

--- a/internal/integration_tests/reset_password_test.go
+++ b/internal/integration_tests/reset_password_test.go
@@ -90,6 +90,14 @@ func TestResetPassword(t *testing.T) {
 		user, err := ts2.StorageProvider.GetUserByPhoneNumber(ctx2, mobile)
 		require.NoError(t, err)
 
+		// Mint the password_reset-purpose session via the real ForgotPassword
+		// path (ResetPassword's OTP leg now requires this exact purpose).
+		forgotRes, err := ts2.GraphQLProvider.ForgotPassword(ctx2, &model.ForgotPasswordRequest{
+			PhoneNumber: refs.NewStringRef(mobile),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, forgotRes)
+
 		otpData, err := ts2.StorageProvider.GetOTPByPhoneNumber(ctx2, mobile)
 		require.NoError(t, err)
 
@@ -108,12 +116,18 @@ func TestResetPassword(t *testing.T) {
 		_, err = ts2.StorageProvider.UpsertOTP(ctx2, expiredOTP)
 		require.NoError(t, err)
 
-		// Get MFA session
+		// Get MFA session. SignUp above (EnablePhoneVerification=true) already
+		// minted its own Verified-purpose session for user.ID, and
+		// ForgotPassword mints a second, PasswordReset-purpose one — both
+		// coexist in the memory store, so the scan must filter by purpose or
+		// it can non-deterministically pick the Verified one, which
+		// ResetPassword now rejects before ever reaching the expiry check this
+		// subtest exercises.
 		allData, err := ts2.MemoryStoreProvider.GetAllData()
 		require.NoError(t, err)
 		sessionKey := ""
-		for k := range allData {
-			if strings.Contains(k, user.ID) {
+		for k, v := range allData {
+			if strings.Contains(k, user.ID) && v == constants.MFASessionPurposePasswordReset {
 				splitData := strings.Split(k, ":")
 				if len(splitData) > 1 {
 					sessionKey = splitData[1]
@@ -261,5 +275,112 @@ func TestResetPassword(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, loginRes)
 		assert.NotNil(t, loginRes.AccessToken)
+	})
+
+	t.Run("should reset password via mobile OTP end-to-end", func(t *testing.T) {
+		cfg3 := getTestConfig()
+		cfg3.IsSMSServiceEnabled = true
+		cfg3.EnableMobileBasicAuthentication = true
+		cfg3.EnablePhoneVerification = true
+		ts3 := initTestSetup(t, cfg3)
+		req3, ctx3 := createContext(ts3)
+
+		mobile := fmt.Sprintf("+1%010d", time.Now().UnixNano()%10000000000)
+		_, err := ts3.GraphQLProvider.SignUp(ctx3, &model.SignUpRequest{
+			PhoneNumber:     &mobile,
+			Password:        password,
+			ConfirmPassword: password,
+		})
+		require.NoError(t, err)
+
+		forgotRes, err := ts3.GraphQLProvider.ForgotPassword(ctx3, &model.ForgotPasswordRequest{
+			PhoneNumber: refs.NewStringRef(mobile),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, forgotRes)
+
+		user, err := ts3.StorageProvider.GetUserByPhoneNumber(ctx3, mobile)
+		require.NoError(t, err)
+
+		otpData, err := ts3.StorageProvider.GetOTPByPhoneNumber(ctx3, mobile)
+		require.NoError(t, err)
+		const knownPlainOTP = "222222"
+		otpData.Otp = crypto.HashOTP(knownPlainOTP, cfg3.JWTSecret)
+		otpData.ExpiresAt = time.Now().Add(5 * time.Minute).Unix()
+		_, err = ts3.StorageProvider.UpsertOTP(ctx3, otpData)
+		require.NoError(t, err)
+
+		// SignUp above (EnablePhoneVerification=true) already minted its own
+		// Verified-purpose session for this user.ID; ForgotPassword mints a
+		// second, PasswordReset-purpose one. Both coexist in the memory store
+		// (distinct keys), so the scan must filter by purpose — a bare
+		// "contains user.ID" match is non-deterministic (Go map iteration
+		// order) and can pick the wrong session, which would now be correctly
+		// rejected by ResetPassword.
+		allData, err := ts3.MemoryStoreProvider.GetAllData()
+		require.NoError(t, err)
+		sessionKey := ""
+		for k, v := range allData {
+			if strings.Contains(k, user.ID) && v == constants.MFASessionPurposePasswordReset {
+				splitData := strings.Split(k, ":")
+				if len(splitData) > 1 {
+					sessionKey = splitData[1]
+					break
+				}
+			}
+		}
+		require.NotEmpty(t, sessionKey, "ForgotPassword must set a password_reset mfa session cookie")
+		req3.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", sessionKey))
+
+		resetRes, err := ts3.GraphQLProvider.ResetPassword(ctx3, &model.ResetPasswordRequest{
+			Otp:             refs.NewStringRef(knownPlainOTP),
+			PhoneNumber:     refs.NewStringRef(mobile),
+			Password:        "NewPassword@123",
+			ConfirmPassword: "NewPassword@123",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resetRes)
+	})
+
+	t.Run("a Challenge session (ResendOTP-style) cannot reset the password", func(t *testing.T) {
+		cfg4 := getTestConfig()
+		cfg4.IsSMSServiceEnabled = true
+		cfg4.EnableMobileBasicAuthentication = true
+		cfg4.EnablePhoneVerification = true
+		ts4 := initTestSetup(t, cfg4)
+		req4, ctx4 := createContext(ts4)
+
+		mobile := fmt.Sprintf("+1%010d", time.Now().UnixNano()%10000000000)
+		_, err := ts4.GraphQLProvider.SignUp(ctx4, &model.SignUpRequest{
+			PhoneNumber:     &mobile,
+			Password:        password,
+			ConfirmPassword: password,
+		})
+		require.NoError(t, err)
+		user, err := ts4.StorageProvider.GetUserByPhoneNumber(ctx4, mobile)
+		require.NoError(t, err)
+
+		otpData, err := ts4.StorageProvider.GetOTPByPhoneNumber(ctx4, mobile)
+		require.NoError(t, err)
+		const knownPlainOTP = "333333"
+		otpData.Otp = crypto.HashOTP(knownPlainOTP, cfg4.JWTSecret)
+		otpData.ExpiresAt = time.Now().Add(5 * time.Minute).Unix()
+		_, err = ts4.StorageProvider.UpsertOTP(ctx4, otpData)
+		require.NoError(t, err)
+
+		// Simulate the session ResendOTP (or a plain login/signup OTP send)
+		// would mint — Challenge purpose, NOT password_reset.
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts4.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeChallenge, time.Now().Add(5*time.Minute).Unix()))
+		req4.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		resetRes, err := ts4.GraphQLProvider.ResetPassword(ctx4, &model.ResetPasswordRequest{
+			Otp:             refs.NewStringRef(knownPlainOTP),
+			PhoneNumber:     refs.NewStringRef(mobile),
+			Password:        "NewPassword@123",
+			ConfirmPassword: "NewPassword@123",
+		})
+		assert.Error(t, err, "a Challenge-purpose session must not be able to reset a password")
+		assert.Nil(t, resetRes)
 	})
 }

--- a/internal/integration_tests/signup_protected_roles_test.go
+++ b/internal/integration_tests/signup_protected_roles_test.go
@@ -1,0 +1,34 @@
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSignup_RejectsProtectedRole is the regression test for the role-parity
+// finding: signup must reject a client-requested protected role explicitly,
+// not rely on Config.Roles/Config.ProtectedRoles staying disjoint by
+// operator convention. Mirrors oauth_callback.go's explicit check.
+func TestSignup_RejectsProtectedRole(t *testing.T) {
+	cfg := getTestConfig()
+	// Misconfiguration under test: a role listed in both Roles and
+	// ProtectedRoles. OAuth already defends against this; signup must too.
+	cfg.Roles = append(append([]string{}, cfg.Roles...), "admin")
+	cfg.ProtectedRoles = append(append([]string{}, cfg.ProtectedRoles...), "admin")
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	email := "signup_protected_role_" + uuid.New().String() + "@authorizer.dev"
+	password := "Password@123"
+	signupRes, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email:           &email,
+		Password:        password,
+		ConfirmPassword: password,
+		Roles:           []string{"admin"},
+	})
+	assert.Error(t, err, "signup must reject a protected role even when it is also present in Roles")
+	assert.Nil(t, signupRes)
+}

--- a/internal/integration_tests/verify_otp_session_purpose_test.go
+++ b/internal/integration_tests/verify_otp_session_purpose_test.go
@@ -1,0 +1,89 @@
+package integration_tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/crypto"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyOTP_SessionPurpose is the regression test for the MFA-downgrade
+// finding: a password-reset OTP session must never be redeemable for a token
+// via VerifyOTP, and VerifyOTP must keep accepting the ordinary Challenge
+// session that ResendOTP legitimately hands off to it.
+func TestVerifyOTP_SessionPurpose(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.IsSMSServiceEnabled = true
+	cfg.EnableMobileBasicAuthentication = true
+	cfg.EnablePhoneVerification = true
+	ts := initTestSetup(t, cfg)
+	req, ctx := createContext(ts)
+
+	mobile := fmt.Sprintf("+1%010d", time.Now().UnixNano()%10000000000)
+	password := "Password@123"
+	_, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		PhoneNumber:     &mobile,
+		Password:        password,
+		ConfirmPassword: password,
+	})
+	require.NoError(t, err)
+
+	user, err := ts.StorageProvider.GetUserByPhoneNumber(ctx, mobile)
+	require.NoError(t, err)
+
+	const knownPlainOTP = "654321"
+	seedOTP := func() {
+		otpData, err := ts.StorageProvider.GetOTPByPhoneNumber(ctx, mobile)
+		require.NoError(t, err)
+		otpData.Otp = crypto.HashOTP(knownPlainOTP, cfg.JWTSecret)
+		otpData.ExpiresAt = time.Now().Add(5 * time.Minute).Unix()
+		_, err = ts.StorageProvider.UpsertOTP(ctx, otpData)
+		require.NoError(t, err)
+	}
+
+	t.Run("a password_reset session cannot be redeemed via VerifyOTP", func(t *testing.T) {
+		seedOTP()
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposePasswordReset, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		verificationRes, err := ts.GraphQLProvider.VerifyOTP(ctx, &model.VerifyOTPRequest{
+			PhoneNumber: &mobile,
+			Otp:         knownPlainOTP,
+		})
+		assert.Error(t, err, "a password_reset-purpose session must not be accepted by VerifyOTP")
+		assert.Nil(t, verificationRes)
+	})
+
+	t.Run("a challenge session (ResendOTP-style) is still accepted by VerifyOTP", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeChallenge, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		verificationRes, err := ts.GraphQLProvider.VerifyOTP(ctx, &model.VerifyOTPRequest{
+			PhoneNumber: &mobile,
+			Otp:         "000000",
+		})
+		// Still reaches OTP validation (wrong code here) rather than being
+		// rejected at the session-purpose gate — proves Challenge still works.
+		assert.Error(t, err)
+		assert.Nil(t, verificationRes)
+		assert.NotContains(t, err.Error(), "invalid session")
+	})
+
+	t.Run("an unresolvable/absent session is rejected", func(t *testing.T) {
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", uuid.NewString()))
+		verificationRes, err := ts.GraphQLProvider.VerifyOTP(ctx, &model.VerifyOTPRequest{
+			PhoneNumber: &mobile,
+			Otp:         "000000",
+		})
+		assert.Error(t, err)
+		assert.Nil(t, verificationRes)
+	})
+}

--- a/internal/integration_tests/webauthn_enforce_mfa_test.go
+++ b/internal/integration_tests/webauthn_enforce_mfa_test.go
@@ -400,3 +400,48 @@ func TestWebauthnLoginVerifyAsSecondFactorSMSOTPEnrolled(t *testing.T) {
 	assert.True(t, refs.BoolValue(loginRes.ShouldShowMobileOtpScreen), "SMS-OTP is still challenged")
 	assert.True(t, refs.BoolValue(loginRes.ShouldOfferWebauthnMfaVerify), "the enrolled passkey must be offered as an alternative to SMS-OTP")
 }
+
+// TestWebauthnLoginOptionsRejectsPasswordResetSession is the regression test
+// for the session-purpose gap in WebauthnLoginOptions' scoped (MFA-alternative)
+// flow: a password_reset-purpose session (minted only by ForgotPassword) must
+// not be redeemable here -- the returned PublicKeyCredentialRequestOptions,
+// including the account's own credential IDs, is itself the leak this gate
+// exists to prevent (see the comment on WebauthnLoginOptions). Verified and
+// Challenge sessions -- the same two VerifyOTP accepts for the equivalent
+// TOTP-alternative flow -- must still work.
+func TestWebauthnLoginOptionsRejectsPasswordResetSession(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableWebauthnMFA = true
+	ts := initTestSetup(t, cfg)
+
+	user, _, _, _ := registerPasskeyForNewUser(t, ts)
+	email := refs.StringValue(user.Email)
+	req, ctx := createContext(ts)
+
+	t.Run("a password_reset session is rejected", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposePasswordReset, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		_, err := ts.GraphQLProvider.WebauthnLoginOptions(ctx, &email)
+		assert.Error(t, err, "a password_reset session must not return this account's passkey login options")
+	})
+
+	t.Run("a Verified session is still accepted", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeVerified, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		_, err := ts.GraphQLProvider.WebauthnLoginOptions(ctx, &email)
+		assert.NoError(t, err)
+	})
+
+	t.Run("a Challenge session is still accepted", func(t *testing.T) {
+		mfaSession := uuid.NewString()
+		require.NoError(t, ts.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeChallenge, time.Now().Add(5*time.Minute).Unix()))
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.MfaCookieName+"_session", mfaSession))
+
+		_, err := ts.GraphQLProvider.WebauthnLoginOptions(ctx, &email)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/service/forgot_password.go
+++ b/internal/service/forgot_password.go
@@ -162,8 +162,11 @@ func (p *provider) ForgotPassword(ctx context.Context, meta RequestMetadata, par
 		}
 		mfaSession := uuid.NewString()
 		// Reached with only a phone number and no first factor, so this session
-		// is a Challenge — it can never skip MFA setup or lock the account.
-		err = p.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposeChallenge, expiresAt)
+		// authorizes exactly one thing: changing the password via ResetPassword.
+		// It must not be redeemable for an access token (VerifyOTP) or for
+		// skipping MFA/locking the account — PasswordReset is a distinct,
+		// narrower purpose than the generic Challenge used by resend/login OTP.
+		err = p.MemoryStoreProvider.SetMfaSession(user.ID, mfaSession, constants.MFASessionPurposePasswordReset, expiresAt)
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to set mfa session")
 			return nil, nil, err

--- a/internal/service/magic_link_login.go
+++ b/internal/service/magic_link_login.go
@@ -65,9 +65,21 @@ func (p *provider) MagicLinkLogin(ctx context.Context, meta RequestMetadata, par
 			if !validators.IsValidRoles(params.Roles, roles) {
 				log.Debug().Msg("Invalid roles")
 				return nil, nil, InvalidArgument(`invalid roles`)
-			} else {
-				inputRoles = params.Roles
 			}
+			// Explicit protected-role rejection — same rationale as signup.go;
+			// this new-user branch must not rely on Roles/ProtectedRoles
+			// staying disjoint by operator convention.
+			hasProtectedRole := false
+			for _, r := range params.Roles {
+				if utils.StringSliceContains(p.Config.ProtectedRoles, r) {
+					hasProtectedRole = true
+				}
+			}
+			if hasProtectedRole {
+				log.Debug().Msg("Invalid roles: protected role requested")
+				return nil, nil, InvalidArgument(`invalid roles`)
+			}
+			inputRoles = params.Roles
 		} else {
 			inputRoles = p.Config.DefaultRoles
 		}

--- a/internal/service/otp_mfa_setup.go
+++ b/internal/service/otp_mfa_setup.go
@@ -77,9 +77,14 @@ func (p *provider) resolveOTPSetupCallerIdentity(ctx context.Context, meta Reque
 	}
 	if email == "" && phoneNumber == "" {
 		// No identifier supplied (OAuth-return first-time-offer): resolve the
-		// account from the session cookie alone.
-		ownerID, _, oErr := p.MemoryStoreProvider.GetMfaSessionOwner(mfaSession)
-		if oErr != nil {
+		// account from the session cookie alone. Only a Verified session may
+		// enroll a new MFA factor here — same restriction
+		// resolveWebauthnSetupCaller applies for passkey enrollment. Without
+		// this, a password_reset-purpose session (meant only to authorize a
+		// password change via ResetPassword) could be redeemed here to plant
+		// a new email/SMS/TOTP authenticator on the account instead.
+		ownerID, purpose, oErr := p.MemoryStoreProvider.GetMfaSessionOwner(mfaSession)
+		if oErr != nil || purpose != constants.MFASessionPurposeVerified {
 			return nil, Unauthenticated(`unauthorized`)
 		}
 		user, uErr := p.StorageProvider.GetUserByID(ctx, ownerID)
@@ -99,7 +104,8 @@ func (p *provider) resolveOTPSetupCallerIdentity(ctx context.Context, meta Reque
 		return nil, Unauthenticated(`unauthorized`)
 	}
 
-	if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
+	// Same Verified-only restriction as the no-identifier branch above.
+	if purpose, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil || purpose != constants.MFASessionPurposeVerified {
 		return nil, Unauthenticated(`unauthorized`)
 	}
 

--- a/internal/service/reset_password.go
+++ b/internal/service/reset_password.go
@@ -104,7 +104,12 @@ func (p *provider) ResetPassword(ctx context.Context, meta RequestMetadata, para
 			log.Debug().Err(err).Msg("Failed to get user by phone number")
 			return nil, nil, NotFound(`user not found`)
 		}
-		if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
+		// Only a password_reset-purpose session (minted exclusively by
+		// ForgotPassword's mobile leg) may complete a password change here.
+		// Verified/Challenge sessions from unrelated flows (login, signup,
+		// resend-OTP) must not be redeemable for a password change.
+		purpose, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession)
+		if err != nil || purpose != constants.MFASessionPurposePasswordReset {
 			log.Debug().Err(err).Msg("Failed to get mfa session")
 			return nil, nil, Unauthenticated(`invalid session`)
 		}

--- a/internal/service/signup.go
+++ b/internal/service/signup.go
@@ -112,6 +112,15 @@ func (p *provider) SignUp(ctx context.Context, meta RequestMetadata, params *mod
 			log.Debug().Strs("roles", params.Roles).Msg("Invalid roles")
 			return nil, nil, InvalidArgument("invalid roles")
 		}
+		// Explicit protected-role rejection, not just reliance on Roles/
+		// ProtectedRoles staying disjoint (http_handlers/oauth_callback.go
+		// already defends this way; self-registration via signup must too).
+		for _, r := range inputRoles {
+			if utils.StringSliceContains(p.Config.ProtectedRoles, r) {
+				log.Debug().Strs("roles", params.Roles).Msg("Invalid roles: protected role requested")
+				return nil, nil, InvalidArgument("invalid roles")
+			}
+		}
 	} else {
 		inputRoles = p.Config.DefaultRoles
 	}

--- a/internal/service/verify_otp.go
+++ b/internal/service/verify_otp.go
@@ -75,8 +75,12 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 	// later GetMfaSession re-check is skipped for this path.
 	sessionResolved := false
 	if email == "" && phoneNumber == "" {
-		ownerID, _, oErr := p.MemoryStoreProvider.GetMfaSessionOwner(mfaSession)
-		if oErr != nil {
+		// No identifier supplied (OAuth-return MFA continuation): only a
+		// Verified session may resolve an account this way — every legitimate
+		// no-identifier caller (oauth_mfa_gate.go, resend_otp.go's session-only
+		// fallback) already upgrades to Verified before reaching here.
+		ownerID, purpose, oErr := p.MemoryStoreProvider.GetMfaSessionOwner(mfaSession)
+		if oErr != nil || purpose != constants.MFASessionPurposeVerified {
 			log.Debug().Err(oErr).Msg("Failed to resolve mfa session owner")
 			return nil, nil, Unauthenticated(`invalid session`)
 		}
@@ -125,7 +129,13 @@ func (p *provider) VerifyOTP(ctx context.Context, meta RequestMetadata, params *
 	// rejected before they can touch (and so exhaust) the victim's lockout
 	// counter, closing an unauthenticated account-lockout DoS.
 	if !sessionResolved {
-		if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
+		// Verified (real login/signup/OAuth MFA challenge) and Challenge
+		// (ResendOTP's identifier-supplied hand-off) are both legitimate here.
+		// PasswordReset is deliberately excluded: a forgot-password OTP session
+		// must only ever be redeemable through ResetPassword, never through
+		// VerifyOTP for a token — see constants.MFASessionPurposePasswordReset.
+		purpose, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession)
+		if err != nil || (purpose != constants.MFASessionPurposeVerified && purpose != constants.MFASessionPurposeChallenge) {
 			log.Debug().Err(err).Msg("Failed to get mfa session")
 			return nil, nil, Unauthenticated(`invalid session`)
 		}

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -181,7 +181,12 @@ func (p *provider) WebauthnLoginOptions(ctx context.Context, meta RequestMetadat
 		log.Debug().Err(err).Msg("User not found for scoped webauthn login")
 		return nil, NotFound("no passkey found for this account")
 	}
-	if _, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession); err != nil {
+	// Same Verified/Challenge purposes VerifyOTP accepts for the equivalent
+	// TOTP-alternative flow (see the comment above) — explicitly excludes
+	// password_reset, whose session must only ever be redeemable via
+	// ResetPassword, never to probe passkey existence/credential IDs here.
+	purpose, err := p.MemoryStoreProvider.GetMfaSession(user.ID, mfaSession)
+	if err != nil || (purpose != constants.MFASessionPurposeVerified && purpose != constants.MFASessionPurposeChallenge) {
 		log.Debug().Err(err).Msg("Failed to get mfa session")
 		return nil, Unauthenticated(`invalid session`)
 	}


### PR DESCRIPTION
## What

VerifyOTP and ResetPassword checked an MFA session existed — never its
purpose. A forgot-password (mobile) OTP session was redeemable via
VerifyOTP for a full access token, skipping any enrolled TOTP factor
(SIM-swap threat model). Mirror bug: a plain OTP-resend session could
in principle be redeemed via ResetPassword to change a victim's
password. Fixed by adding a third, mutually-exclusive `password_reset`
MFA-session purpose — VerifyOTP and ResetPassword now each accept only
the sessions minted for them.

Also, from the same audit:
- signup / magic-link new-user paths relied on Roles/ProtectedRoles
  staying disjoint by config convention to keep self-registration from
  granting a protected role. Now reject explicitly, matching
  oauth_callback.go's existing defense-in-depth.
- refresh_token grant now verifies a presented client secret instead
  of silently ignoring it. Public clients presenting no secret are
  unaffected (verify-if-presented, not require — avoids breaking
  existing public-client refresh flows).

**Follow-up commit**: review turned up two more consumers of the same MFA
session cookie that hadn't been scoped to a purpose, in the same
vulnerability class this PR closes:
- `resolveOTPSetupCallerIdentity` (shared by `EmailOTPMFASetup`/
  `SmsOTPMFASetup`/`TOTPMFASetup`) ignored purpose entirely — a
  `password_reset` session could be redeemed to **enroll a brand-new MFA
  factor** on the account, more severe than issuing a token since it plants
  a persistent authenticator. Now requires `Verified`, matching
  `resolveWebauthnSetupCaller`'s existing restriction for passkey enrollment.
- `WebauthnLoginOptions`' scoped flow also ignored purpose despite its own
  comment claiming to mirror `VerifyOTP`'s gate. Now accepts the same
  `Verified`/`Challenge` set `VerifyOTP` does, excluding `password_reset`.

Every other consumer (`lock_mfa.go`, `resend_otp.go`, `skip_mfa_setup.go`,
WebAuthn registration) was already correctly purpose-scoped.

## Why this shape

The obvious fix ("require Verified everywhere") breaks resend_otp's
legitimate Challenge-session hand-off to VerifyOTP. Traced every
SetMfaSession call site first — see commit bodies for the full
reasoning and exploit path.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] Targeted suites per commit
- [x] `make test` — full SQLite integration suite
- [x] `make lint`
- [x] Both follow-up regression tests confirmed to fail against the pre-fix code and pass against the fix