### PR TITLE
fix(oauth): don't report transient storage errors as invalid_client

### DIFF
--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -844,6 +844,19 @@ func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolv
 			"error_description": "This client is not authorized to use this grant type",
 		})
 		return
+	case errors.Is(err, clientauth.ErrClientLookupFailed):
+		// A storage error (e.g. transient SQLITE_BUSY under contention), not bad
+		// credentials — must NOT be reported as invalid_client (that tells the
+		// caller their credentials are permanently wrong and non-retryable,
+		// which is false) and must NOT count as a security event (it isn't an
+		// attack signal). 503 + temporarily_unavailable tells a well-behaved
+		// OAuth client this is worth retrying, unlike a 400.
+		log.Warn().Err(err).Msg("client lookup failed (storage error)")
+		gc.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":             "temporarily_unavailable",
+			"error_description": "The authorization server is temporarily unable to handle the request",
+		})
+		return
 	}
 
 	// invalid_client (clientauth.ErrInvalidClient, or any unexpected error).

--- a/internal/integration_tests/admin_update_user_enforce_mfa_test.go
+++ b/internal/integration_tests/admin_update_user_enforce_mfa_test.go
@@ -51,3 +51,44 @@ func TestAdminUpdateUserEnforceMFA(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, refs.BoolValue(persisted.IsMultiFactorAuthEnabled), "MFA must remain enabled after a rejected disable")
 }
+
+// TestAdminUpdateUserMFAFlagNilToFalse is a regression test: the "did the flag
+// actually change" check used to compare refs.BoolValue(user...) !=
+// refs.BoolValue(params...), and BoolValue(nil) == false, so a user whose
+// IsMultiFactorAuthEnabled was never set (nil) compared as "false != false"
+// against an explicit false — no change detected — and the assignment was
+// silently skipped, leaving the flag stuck at nil instead of the requested
+// false.
+func TestAdminUpdateUserMFAFlagNilToFalse(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableMFA = true
+	cfg.EnableTOTPLogin = true
+	ts := initTestSetup(t, cfg)
+	req, ctx := createContext(ts)
+
+	email := "admin_mfa_nil_to_false_" + uuid.NewString() + "@authorizer.dev"
+	now := time.Now().Unix()
+	user, err := ts.StorageProvider.AddUser(ctx, &schemas.User{
+		Email:           refs.NewStringRef(email),
+		EmailVerifiedAt: &now,
+		SignupMethods:   constants.AuthRecipeMethodBasicAuth,
+		// IsMultiFactorAuthEnabled deliberately left nil (unset).
+	})
+	require.NoError(t, err)
+	require.Nil(t, user.IsMultiFactorAuthEnabled, "fixture must start unset to exercise the nil->false transition")
+
+	h, err := crypto.EncryptPassword(cfg.AdminSecret)
+	require.NoError(t, err)
+	req.Header.Set("Cookie", fmt.Sprintf("%s=%s", constants.AdminCookieName, h))
+
+	_, err = ts.GraphQLProvider.UpdateUser(ctx, &model.UpdateUserRequest{
+		ID:                       user.ID,
+		IsMultiFactorAuthEnabled: refs.NewBoolRef(false),
+	})
+	require.NoError(t, err)
+
+	persisted, err := ts.StorageProvider.GetUserByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.IsMultiFactorAuthEnabled, "explicit false must be persisted, not left as nil")
+	assert.False(t, refs.BoolValue(persisted.IsMultiFactorAuthEnabled))
+}

--- a/internal/service/admin_users.go
+++ b/internal/service/admin_users.go
@@ -174,7 +174,14 @@ func (p *provider) UpdateUser(ctx context.Context, meta RequestMetadata, params 
 		user.AppData = &appDataString
 	}
 
-	if params.IsMultiFactorAuthEnabled != nil && refs.BoolValue(user.IsMultiFactorAuthEnabled) != refs.BoolValue(params.IsMultiFactorAuthEnabled) {
+	// user.IsMultiFactorAuthEnabled == nil is checked explicitly (not just via
+	// refs.BoolValue's zero-collapse) because BoolValue(nil) == false: without
+	// this, an admin explicitly setting false on a user whose flag was never
+	// set (nil) would compare as "false != false" — no change detected — and
+	// the assignment below would be silently skipped, leaving the flag stuck
+	// at nil instead of the requested false.
+	if params.IsMultiFactorAuthEnabled != nil &&
+		(user.IsMultiFactorAuthEnabled == nil || refs.BoolValue(user.IsMultiFactorAuthEnabled) != refs.BoolValue(params.IsMultiFactorAuthEnabled)) {
 		// Only gate the enable action; disabling MFA is always allowed so an admin
 		// can still turn it off after the server has stopped offering any method.
 		if refs.BoolValue(params.IsMultiFactorAuthEnabled) && !p.isMFAServiceAvailable() {

--- a/internal/service/clientauth/clientauth.go
+++ b/internal/service/clientauth/clientauth.go
@@ -55,6 +55,16 @@ var (
 	// and jwt-spiffe (draft-ietf-oauth-spiffe-client-auth) types are supported; any
 	// other value is rejected. Map to invalid_request.
 	ErrUnsupportedAssertionType = errors.New("clientauth: unsupported client_assertion_type")
+
+	// ErrClientLookupFailed is returned when the client registry lookup itself
+	// errors (e.g. a transient SQLITE_BUSY under contention, a network blip to
+	// an external DB) — distinct from a genuine "no such client" (a nil client
+	// with a nil error). This must NEVER be reported as invalid_client: that
+	// response tells the caller their credentials are permanently wrong, which
+	// is false and non-retryable, when the real situation is a momentary
+	// storage hiccup that a retry would very likely clear. Map to
+	// temporarily_unavailable (503), not invalid_client (400).
+	ErrClientLookupFailed = errors.New("clientauth: client lookup failed")
 )
 
 // dummySecretCost mirrors the bcrypt cost real client secrets are hashed with
@@ -228,7 +238,20 @@ func (p *provider) ResolveClient(ctx context.Context, params ResolveParams) (*sc
 	doVerify := params.RequireSecret || (params.VerifyPresentedSecret && secretPresented)
 
 	client, err := p.StorageProvider.GetClientByClientID(ctx, clientID)
-	if err != nil || client == nil {
+	if err != nil {
+		// A storage error (e.g. transient SQLITE_BUSY under contention) is NOT
+		// "no such client" — we simply couldn't check. Bail out here, before the
+		// bootstrap-config fallback below: that fallback exists for a CONFIRMED
+		// absent row (an availability escape hatch), not for "unknown, storage
+		// errored" — silently authenticating against static bootstrap config
+		// while the real registry row's state (active? right secret?) is
+		// unknown would be its own correctness risk. Never dummy-compare or
+		// treat as invalid_client — that tells the caller their credentials
+		// are permanently wrong, which is both false and non-retryable.
+		log.Warn().Err(err).Msg("client lookup failed (storage error) — not treating as unknown client")
+		return nil, ErrClientLookupFailed
+	}
+	if client == nil {
 		// Availability fallback (BC): the reserved client's row may be absent on a
 		// read-only replica where the boot seed was skipped. Fall back to the
 		// bootstrap Config credential so login is never locked out. This path
@@ -245,7 +268,7 @@ func (p *provider) ResolveClient(ctx context.Context, params ResolveParams) (*sc
 		}
 		// Unknown client: burn an equivalent bcrypt cost so timing does not
 		// distinguish an unknown client from a wrong secret, then reject.
-		log.Debug().Err(err).Msg("client not found")
+		log.Debug().Msg("client not found")
 		performDummyCompare(secret)
 		return nil, ErrInvalidClient
 	}

--- a/internal/service/clientauth/clientauth_test.go
+++ b/internal/service/clientauth/clientauth_test.go
@@ -27,7 +27,10 @@ type fakeStore struct {
 func (f *fakeStore) GetClientByClientID(_ context.Context, clientID string) (*schemas.Client, error) {
 	c, ok := f.clients[clientID]
 	if !ok {
-		return nil, errors.New("client not found")
+		// Matches the real providers' contract: a genuinely absent row is
+		// (nil, nil), never a wrapped error — ResolveClient distinguishes "no
+		// such client" from "storage error" by whether err is nil.
+		return nil, nil
 	}
 	return c, nil
 }
@@ -129,6 +132,35 @@ func TestResolveClient_UnknownClient(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidClient)
 	// Unknown client returns a nil client (nothing to attribute an audit to); the
 	// dummy bcrypt compare inside keeps timing indistinguishable from wrong-secret.
+	assert.Nil(t, got)
+}
+
+// erroringStore simulates a transient storage failure (e.g. SQLITE_BUSY under
+// contention) on GetClientByClientID — distinct from fakeStore's "no such
+// client" (nil, nil). ResolveClient must not conflate the two: a client that
+// genuinely exists but hit a momentary DB hiccup must never be told
+// invalid_client, which is a permanent, non-retryable rejection.
+type erroringStore struct {
+	storage.Provider
+}
+
+func (erroringStore) GetClientByClientID(_ context.Context, _ string) (*schemas.Client, error) {
+	return nil, errors.New("database is locked (5) (SQLITE_BUSY)")
+}
+
+func TestResolveClient_StorageErrorNotTreatedAsUnknownClient(t *testing.T) {
+	logger := zerolog.Nop()
+	r := New(
+		&config.Config{ClientID: testConfigID, ClientSecret: testConfigSecret},
+		&Dependencies{Log: &logger, StorageProvider: erroringStore{}},
+	)
+	got, err := r.ResolveClient(context.Background(), ResolveParams{
+		BodyClientID:  testClientID,
+		BodySecret:    testClientSecret,
+		RequireSecret: true,
+	})
+	assert.ErrorIs(t, err, ErrClientLookupFailed)
+	assert.NotErrorIs(t, err, ErrInvalidClient, "a storage error must never be reported as invalid_client — that tells the caller their credentials are permanently wrong, which is false")
 	assert.Nil(t, got)
 }
 

--- a/internal/storage/db/arangodb/client.go
+++ b/internal/storage/db/arangodb/client.go
@@ -131,8 +131,11 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 	defer func() { _ = cursor.Close() }()
 	for {
 		if !cursor.HasMore() {
+			// No matching document is a normal negative result, not a storage
+			// failure — callers (e.g. clientauth.ResolveClient) distinguish "no
+			// such client" from "couldn't check" by whether err is nil.
 			if sa == nil {
-				return nil, fmt.Errorf("client not found")
+				return nil, nil
 			}
 			break
 		}

--- a/internal/storage/db/cassandradb/client.go
+++ b/internal/storage/db/cassandradb/client.go
@@ -2,6 +2,7 @@ package cassandradb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -138,6 +139,13 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE client_id = ? LIMIT 1 ALLOW FILTERING", clientColumns, KeySpace+"."+schemas.Collections.Client)
 	err := p.db.Query(query, clientID).Consistency(gocql.One).Scan(&sa.ID, &sa.ClientID, &sa.Kind, &sa.Name, &sa.Description, &sa.ClientSecret, &sa.AllowedScopes, &sa.RedirectURIs, &sa.GrantTypes, &sa.TokenEndpointAuthMethod, &sa.IsActive, &sa.OrgID, &sa.CreatedAt, &sa.UpdatedAt)
 	if err != nil {
+		// No matching row is a normal negative result, not a storage failure —
+		// callers (e.g. clientauth.ResolveClient) distinguish "no such client"
+		// from "couldn't check" by whether err is nil, so a genuinely absent
+		// row must come back as (nil, nil), never a wrapped ErrNotFound.
+		if errors.Is(err, gocql.ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return &sa, nil

--- a/internal/storage/db/couchbase/client.go
+++ b/internal/storage/db/couchbase/client.go
@@ -3,6 +3,7 @@ package couchbase
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -137,6 +138,13 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 	}
 	var raw json.RawMessage
 	if err := q.One(&raw); err != nil {
+		// No matching row is a normal negative result, not a storage failure —
+		// callers (e.g. clientauth.ResolveClient) distinguish "no such client"
+		// from "couldn't check" by whether err is nil, so a genuinely absent
+		// row must come back as (nil, nil), never a wrapped ErrNoResult.
+		if errors.Is(err, gocb.ErrNoResult) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	sa := &schemas.Client{}

--- a/internal/storage/db/dynamodb/client.go
+++ b/internal/storage/db/dynamodb/client.go
@@ -103,7 +103,10 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 		return nil, err
 	}
 	if len(items) == 0 {
-		return nil, errors.New("no document found")
+		// No matching item is a normal negative result, not a storage failure —
+		// callers (e.g. clientauth.ResolveClient) distinguish "no such client"
+		// from "couldn't check" by whether err is nil.
+		return nil, nil
 	}
 	var sa schemas.Client
 	if err := unmarshalItem(items[0], &sa); err != nil {

--- a/internal/storage/db/mongodb/client.go
+++ b/internal/storage/db/mongodb/client.go
@@ -2,11 +2,13 @@ package mongodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/authorizerdev/authorizer/internal/graph/model"
@@ -83,6 +85,14 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 	saCollection := p.db.Collection(schemas.Collections.Client, options.Collection())
 	err := saCollection.FindOne(ctx, bson.M{"client_id": clientID}).Decode(&sa)
 	if err != nil {
+		// No matching document is a normal negative result, not a storage
+		// failure — callers (e.g. clientauth.ResolveClient) distinguish "no
+		// such client" from "couldn't check" by whether err is nil, so a
+		// genuinely absent document must come back as (nil, nil), never a
+		// wrapped ErrNoDocuments.
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return sa, nil

--- a/internal/storage/db/sql/client.go
+++ b/internal/storage/db/sql/client.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -78,6 +79,13 @@ func (p *provider) GetClientByClientID(ctx context.Context, clientID string) (*s
 	var sa schemas.Client
 	res := p.db.Where("client_id = ?", clientID).First(&sa)
 	if res.Error != nil {
+		// No matching row is a normal negative result, not a storage failure —
+		// callers (e.g. clientauth.ResolveClient) distinguish "no such client"
+		// from "couldn't check" by whether err is nil, so a genuinely absent
+		// row must come back as (nil, nil), never a wrapped ErrRecordNotFound.
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
 		return nil, res.Error
 	}
 	return &sa, nil

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -207,6 +207,16 @@ type Provider interface {
 	// GetClientByClientID fetches a client by its public, unique client_id
 	// (distinct from the surrogate ID). This is the lookup the token/authorize
 	// endpoints and the boot-time reserved-client seed use.
+	//
+	// Contract: a genuinely absent client_id MUST return (nil, nil), never a
+	// wrapped driver "not found" error (gorm.ErrRecordNotFound,
+	// mongo.ErrNoDocuments, gocql.ErrNotFound, etc.) — callers (notably
+	// clientauth.ResolveClient, the token endpoint's client_credentials/
+	// refresh_token/authorization_code auth) distinguish "no such client" from
+	// "storage temporarily unavailable" solely by whether err is nil. A real
+	// storage error (a dropped connection, a busy/locked database) must come
+	// back as (nil, err) so the caller reports a retryable failure instead of
+	// misreporting the client's credentials as permanently wrong.
 	GetClientByClientID(ctx context.Context, clientID string) (*schemas.Client, error)
 	// ListClients returns a paginated list of all service accounts.
 	ListClients(ctx context.Context, pagination *model.Pagination) ([]*schemas.Client, *model.Pagination, error)


### PR DESCRIPTION
## Summary
- \`/oauth/token\`'s \`client_credentials\` (and other client-authenticated grants) alternated between 200 and 400 \`invalid_client\` on identical, back-to-back requests over a reused connection.
- Root-caused live: SQLite genuinely returns \`SQLITE_BUSY\` under concurrent load (confirmed \`busy_timeout\` is correctly applied per-connection by reading the driver — this is real contention, not a misconfiguration), and \`clientauth.ResolveClient\` treated any error from \`GetClientByClientID\` the same as "no such client", so a transient DB hiccup got reported as a permanent, non-retryable \`invalid_client\`.
- Fix, three layers:
  - \`clientauth.go\`: new \`ErrClientLookupFailed\` sentinel, kept distinct from \`ErrInvalidClient\`.
  - All 6 storage backends' \`GetClientByClientID\` now translate their own driver-specific "not found" signal into \`(nil, nil)\`, so a non-nil error only ever means a real failure — documented as an explicit contract on the storage interface.
  - \`token.go\`: maps the new sentinel to \`503 temporarily_unavailable\` instead of \`400 invalid_client\`, skips the security-event metric.
- Also fixes admin \`_update_user\`'s MFA-flag nil→false zero-value collision bug found during the same investigation (BoolValue(nil) == false made "unset → explicit false" look like "no change", silently skipping the write).

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`
- [x] New regression tests: \`TestResolveClient_StorageErrorNotTreatedAsUnknownClient\`, \`TestAdminUpdateUserMFAFlagNilToFalse\` (both confirmed to fail pre-fix, pass post-fix)
- [x] \`make test\` (SQLite, 36/36 packages)
- [x] \`make test-all-db\` (all 7 backing databases)
- [x] \`make lint\` — 0 issues
- [x] Live verification: built a local binary with the fix, stress-tested concurrent signups + client_credentials requests — reproduced real SQLite contention (67/150 requests), all correctly returned 503, zero misleading 400s