### PR TITLE
fix(saml): resume SP-initiated IdP login after login, unblock ACS auto-submit

### DIFF
--- a/internal/http_handlers/security_headers.go
+++ b/internal/http_handlers/security_headers.go
@@ -31,6 +31,25 @@ const playgroundCSP = "default-src 'self'; " +
 	"base-uri 'self'; " +
 	"form-action 'self'"
 
+// samlIDPSSOCSP omits form-action for the SAML IdP SSO endpoints. Their
+// response (crewjam WriteResponse) is a self-submitting HTML form that must
+// POST to the requesting SP's ACS URL — an arbitrary external origin by
+// design, so form-action 'self' would silently break every SAML IdP login.
+// This is safe to relax: form-action does not inherit from default-src, so
+// omitting it lifts the restriction only for this response, and the ACS
+// destination is never request-supplied — it's the SP's own URL, validated
+// server-side against the org's registered SP record before the response is
+// built (see saml.IdpAuthnRequest.Validate and
+// GetSAMLServiceProviderByOrgAndEntityID in saml_idp.go).
+const samlIDPSSOCSP = "default-src 'self'; " +
+	"script-src 'self' 'unsafe-inline'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: https:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'"
+
 // SecurityHeadersMiddleware sets standard security headers on every response.
 func (h *httpProvider) SecurityHeadersMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -51,8 +70,11 @@ func (h *httpProvider) SecurityHeadersMiddleware() gin.HandlerFunc {
 		// dashboard in the wild while we tighten the policy.
 		if !h.Config.DisableCSP {
 			csp := defaultCSP
-			if c.Request.URL.Path == "/playground" {
+			switch {
+			case c.Request.URL.Path == "/playground":
 				csp = playgroundCSP
+			case c.FullPath() == "/saml/idp/:org_slug/sso" || c.FullPath() == "/saml/idp/:org_slug/sso/:sp_id":
+				csp = samlIDPSSOCSP
 			}
 			hdr.Set("Content-Security-Policy", csp)
 		}

--- a/web/app/src/Root.tsx
+++ b/web/app/src/Root.tsx
@@ -16,6 +16,27 @@ const Settings = lazy(() => import('./pages/settings'));
 const SignUp = lazy(() => import('./pages/signup'));
 
 /**
+ * True only for the exact shape `bounceSAMLIDPToLogin` (saml_idp.go) produces:
+ * same-origin, path `/saml/idp/{slug}/sso`, carrying `saml_continue`. This is
+ * deliberately narrow — `redirect_uri` is a client-controllable query param on
+ * /app, so anything looser here becomes a post-login open redirect.
+ */
+function isSamlIdpContinueURL(url: string): boolean {
+	if (!hasWindow() || !url) return false;
+	let parsed: URL;
+	try {
+		parsed = new URL(url, window.location.origin);
+	} catch {
+		return false;
+	}
+	return (
+		parsed.origin === window.location.origin &&
+		/^\/saml\/idp\/[^/]+\/sso$/.test(parsed.pathname) &&
+		parsed.searchParams.has('saml_continue')
+	);
+}
+
+/**
  * Build a normalized parameter map from query + fragment.
  * We treat both as inputs because `/authorize` may choose fragment
  * depending on response_mode and our login UI should preserve the
@@ -120,6 +141,19 @@ export default function Root({
 		sessionStorage.removeItem('authorizer_state');
 		window.location.replace(`/authorize?${params.toString()}`);
 	}, [token, isAuthorizeContext, state]);
+
+	// Separate resumption mechanism: SP-initiated SAML IdP login. The server
+	// (bounceSAMLIDPToLogin) sends unauthenticated users here with
+	// redirect_uri pointing back at its own /saml/idp/{slug}/sso?saml_continue
+	// endpoint, which resumes and auto-submits the pending assertion once a
+	// session exists. Unlike the /authorize resumption above, we navigate to
+	// the literal redirect_uri - but only when it matches that exact shape,
+	// never for an arbitrary client-supplied redirect_uri.
+	useEffect(() => {
+		if (!token) return;
+		if (!isSamlIdpContinueURL(rawRedirectURL)) return;
+		window.location.replace(rawRedirectURL);
+	}, [token, rawRedirectURL]);
 
 	// Both MFA gates below are reached via a server redirect carrying the
 	// gate state in the URL, not client-side navigation - there's no prior

--- a/web/app/src/Root.tsx
+++ b/web/app/src/Root.tsx
@@ -112,6 +112,10 @@ export default function Root({
 			getParam('client_id') !== '' ||
 			getParam('scope') !== '');
 
+	// Two mutually exclusive post-login resumption mechanisms, merged into one
+	// effect so they can never both fire off the same render (two separate
+	// effects both calling window.location.replace would race on declaration
+	// order instead of on which one is actually correct for this URL).
 	useEffect(() => {
 		if (!token) return;
 
@@ -119,41 +123,40 @@ export default function Root({
 		// source of truth for redirect_uri validation and response_mode
 		// (query / fragment / form_post / web_message). The login UI should
 		// only establish a session and then resume the authorization request.
-		if (!isAuthorizeContext) return;
+		if (isAuthorizeContext) {
+			// Preserve exactly what we received on /app and send it back to
+			// /authorize; the backend will complete the authorization response.
+			const params = new URLSearchParams();
+			for (const [k, v] of combinedParams.entries()) {
+				// Ignore any accidental app-only params.
+				if (k === '') continue;
+				params.set(k, v);
+			}
 
-		// Preserve exactly what we received on /app and send it back to
-		// /authorize; the backend will complete the authorization response.
-		const params = new URLSearchParams();
-		for (const [k, v] of combinedParams.entries()) {
-			// Ignore any accidental app-only params.
-			if (k === '') continue;
-			params.set(k, v);
+			// Ensure state exists; do NOT overwrite if provided.
+			if (!params.get('state')) {
+				params.set('state', state);
+			}
+			if (scope?.length && !params.get('scope')) {
+				params.set('scope', scope.join(' '));
+			}
+
+			sessionStorage.removeItem('authorizer_state');
+			window.location.replace(`/authorize?${params.toString()}`);
+			return;
 		}
 
-		// Ensure state exists; do NOT overwrite if provided.
-		if (!params.get('state')) {
-			params.set('state', state);
+		// SP-initiated SAML IdP login. The server (bounceSAMLIDPToLogin) sends
+		// unauthenticated users here with redirect_uri pointing back at its own
+		// /saml/idp/{slug}/sso?saml_continue endpoint, which resumes and
+		// auto-submits the pending assertion once a session exists. Unlike the
+		// /authorize resumption above, we navigate to the literal redirect_uri
+		// - but only when it matches that exact shape, never for an arbitrary
+		// client-supplied redirect_uri.
+		if (isSamlIdpContinueURL(rawRedirectURL)) {
+			window.location.replace(rawRedirectURL);
 		}
-		if (scope?.length && !params.get('scope')) {
-			params.set('scope', scope.join(' '));
-		}
-
-		sessionStorage.removeItem('authorizer_state');
-		window.location.replace(`/authorize?${params.toString()}`);
-	}, [token, isAuthorizeContext, state]);
-
-	// Separate resumption mechanism: SP-initiated SAML IdP login. The server
-	// (bounceSAMLIDPToLogin) sends unauthenticated users here with
-	// redirect_uri pointing back at its own /saml/idp/{slug}/sso?saml_continue
-	// endpoint, which resumes and auto-submits the pending assertion once a
-	// session exists. Unlike the /authorize resumption above, we navigate to
-	// the literal redirect_uri - but only when it matches that exact shape,
-	// never for an arbitrary client-supplied redirect_uri.
-	useEffect(() => {
-		if (!token) return;
-		if (!isSamlIdpContinueURL(rawRedirectURL)) return;
-		window.location.replace(rawRedirectURL);
-	}, [token, rawRedirectURL]);
+	}, [token, isAuthorizeContext, rawRedirectURL, state]);
 
 	// Both MFA gates below are reached via a server redirect carrying the
 	// gate state in the URL, not client-side navigation - there's no prior


### PR DESCRIPTION
## What's broken

SAML 2.0 Identity Provider role (#691) shipped two bugs that together make SP-initiated SAML login non-functional for any real external SP:

1. **Login resumption dropped silently.** `bounceSAMLIDPToLogin` sends an unauthenticated user to `/app?redirect_uri=/saml/idp/{slug}/sso?saml_continue=...`. `Root.tsx`'s post-login resume effect only recognizes OIDC-authorize-shaped params (`state`/`response_type`/`response_mode`/`client_id`/`scope`) — none of which this URL carries — so the effect never fires. User logs in, lands on the plain dashboard, pending SAML flow is gone.
2. **CSP blocked the assertion delivery.** Once (1) is fixed and the browser reaches the SSO resume endpoint, crewjam's auto-submit response (a self-posting form to the SP's ACS URL) gets blocked by `form-action 'self'` — the ACS is by definition a different origin.

Found while building live e2e coverage for the SAML IdP feature (a real browser driving a real SP-initiated login against a real external SP).

## The fix

- `web/app/src/Root.tsx`: added a narrow, separate resumption path — same-origin + exact `/saml/idp/{slug}/sso` path + `saml_continue` query param present — that navigates directly to that URL post-login. Anything not matching this exact shape falls through unchanged; this is not a generic redirect_uri navigator (`redirect_uri` is attacker-controllable on `/app`, so a blanket "navigate wherever it says" would be an open redirect).
- `internal/http_handlers/security_headers.go`: omits `form-action` (doesn't inherit from `default-src`) for exactly the two SAML IdP SSO routes, matched via Gin's `FullPath()` (route pattern, not attacker-controllable). Safe because the ACS destination is never request-supplied — it's resolved server-side from the org's registered `SAMLServiceProvider` record during `AuthnRequest` validation, before the response is built.

## Security review

Both changes went through a dedicated security-engineer pass. Verdict: **safe to merge as-is**, no Critical/Important findings.

- Root.tsx gate: enumerated bypasses (cross-origin URLs, protocol-relative `//evil.com`, userinfo confusion `host@evil.com`, `javascript:`/`data:` schemes, encoded path traversal `%2f`, case variations) — all rejected by the same-origin + regex-anchor + parsed-URL check.
- CSP relaxation: confirmed no other route shares the matched `FullPath()` patterns; confirmed against crewjam/saml source that the form `action` only ever resolves from server-validated SP metadata, never request input; confirmed the response body is `html/template`-escaped so there's no attacker-controlled form to inject.

## Test plan

`e2e-playground/tests/saml-idp.spec.ts` (lands separately with the full e2e-playground test suite, not part of this PR) went from 1/2 to 2/2 passing after these fixes. No regression in the other already-passing SAML/OIDC browser specs: `oidc-provider.spec.ts` 5/5, `oidc-sso-rp.spec.ts` 2/2, `saml-sp.spec.ts` 3/3 — all re-run against the containerized Playwright runner.