### PR TITLE
fix(webapp): clear mfa redirect params once mfa gate resolves

### DIFF
--- a/web/app/src/Root.tsx
+++ b/web/app/src/Root.tsx
@@ -36,6 +36,23 @@ function isSamlIdpContinueURL(url: string): boolean {
 	);
 }
 
+// clearMfaRedirectParams strips mfa_required/mfa_gate/mfa_methods from the
+// current URL once the MFA gate resolves (skip or verify succeeds). Root's
+// `mfaRedirect` (below) is recomputed from window.location.href on every
+// render and is checked before `token` - without this, a successful
+// skip/verify sets a real token but the URL still carries the server's
+// original mfa_required=1 redirect params, so the very next render matches
+// mfaRedirect again and re-renders the same MFA screen forever instead of
+// falling through to the token check and the dashboard/resumption effect.
+function clearMfaRedirectParams(): void {
+	if (!hasWindow()) return;
+	const url = new URL(window.location.href);
+	url.searchParams.delete('mfa_required');
+	url.searchParams.delete('mfa_gate');
+	url.searchParams.delete('mfa_methods');
+	window.history.replaceState(null, '', url.toString());
+}
+
 /**
  * Build a normalized parameter map from query + fragment.
  * We treat both as inputs because `/authorize` may choose fragment
@@ -183,6 +200,7 @@ export default function Root({
 				}
 				onBack={backToLogin}
 				onLogin={(data: any) => {
+					clearMfaRedirectParams();
 					setAuthData({
 						user: data?.user || null,
 						token: data,
@@ -206,6 +224,7 @@ export default function Root({
 				onBack={backToLogin}
 				loginContext={{
 					onComplete: (data: any) => {
+						clearMfaRedirectParams();
 						setAuthData({
 							user: data?.user || null,
 							token: data,


### PR DESCRIPTION
## What's broken

Any login that lands on `/app` via a server-side redirect carrying `mfa_required=1&mfa_gate=...&mfa_methods=...` — that's every OAuth social login, magic-link login, and email-verification click-through, whenever MFA is enabled (on by default; TOTP needs no external provider) — gets stuck on the MFA-setup/verify screen forever, even after successfully skipping or completing it.

`Root.tsx` computes `mfaRedirect` from `window.location.href` on **every render** and checks it before `token`. Clicking "Skip for now" (or completing verification) calls the real GraphQL mutation, which succeeds server-side and returns a real token via `setAuthData` — but nothing ever stripped the MFA params from the URL. On the next render, `mfaRedirect` is recomputed from the still-stale URL, matches again, and the app re-renders the same MFA screen instead of falling through to the token check and the dashboard.

Found via a real Google OAuth e2e login (live browser, live backend) while building e2e coverage for social login providers — confirmed via git-stash bisection (reproduces reliably without the fix, resolves with it) and cross-checked against server logs showing `skip_mfa_setup` succeeding while the client never left the screen.

## The fix

Added `clearMfaRedirectParams()` — strips `mfa_required`/`mfa_gate`/`mfa_methods` via `window.history.replaceState`, leaving every other query param (`redirect_uri`, `state`, `saml_continue`, etc.) untouched. Called right before `setAuthData` in both the verify-gate's `onLogin` and the offer-gate's `loginContext.onComplete` — the only two places this file calls `setAuthData`. 19-line diff, one shared function, both call sites covered.

## Test plan

Reproduced and fixed via `e2e-playground/tests/social/google.spec.ts` (lands separately with the e2e-playground test suite). Bisection: with the original code, the Google OAuth signup test reliably fails, stuck on "Set up multi-factor authentication"; with the fix, it passes. Full regression: 24/24 tests across the existing e2e-playground suite pass with the fix in place.