### PR TITLE
fix(oauth): don't 400 Apple callback when returning user omits `user` field

### DIFF
--- a/internal/http_handlers/oauth_callback.go
+++ b/internal/http_handlers/oauth_callback.go
@@ -41,6 +41,24 @@ type AppleUserInfo struct {
 	} `json:"name"`
 }
 
+// parseAppleUserField parses the optional Apple `user` callback form field.
+// Apple sends this field only on the very first authorization for a given
+// app; every subsequent login omits it entirely (documented Apple behavior —
+// a one-time grant, not re-sent). An absent/empty field is therefore expected
+// steady-state behavior, not an error, and yields a zero-value AppleUserInfo.
+// A non-empty but malformed value is a real error (buggy provider or
+// tampered request) and is still rejected.
+func parseAppleUserField(userRaw string) (*AppleUserInfo, error) {
+	user_ := &AppleUserInfo{}
+	if userRaw == "" {
+		return user_, nil
+	}
+	if err := json.Unmarshal([]byte(userRaw), user_); err != nil {
+		return nil, err
+	}
+	return user_, nil
+}
+
 // OAuthCallbackHandler handles the OAuth callback for various oauth providers
 func (h *httpProvider) OAuthCallbackHandler() gin.HandlerFunc {
 	log := h.Log.With().Str("func", "OAuthCallbackHandler").Logger()
@@ -101,15 +119,14 @@ func (h *httpProvider) OAuthCallbackHandler() gin.HandlerFunc {
 		case constants.AuthRecipeMethodLinkedIn:
 			user, err = h.processLinkedInUserInfo(ctx, oauthCode)
 		case constants.AuthRecipeMethodApple:
-			user_ := AppleUserInfo{}
-			userRaw := ctx.Request.FormValue("user")
-			err = json.Unmarshal([]byte(userRaw), &user_)
+			var user_ *AppleUserInfo
+			user_, err = parseAppleUserField(ctx.Request.FormValue("user"))
 			if err != nil {
 				log.Debug().Err(err).Msg("Failed to unmarshal apple user info")
 				ctx.JSON(400, gin.H{"error": "invalid apple user info"})
 				return
 			}
-			user, err = h.processAppleUserInfo(ctx, oauthCode, &user_)
+			user, err = h.processAppleUserInfo(ctx, oauthCode, user_)
 		case constants.AuthRecipeMethodDiscord:
 			user, err = h.processDiscordUserInfo(ctx, oauthCode)
 		case constants.AuthRecipeMethodTwitter:

--- a/internal/http_handlers/oauth_callback.go
+++ b/internal/http_handlers/oauth_callback.go
@@ -49,14 +49,14 @@ type AppleUserInfo struct {
 // A non-empty but malformed value is a real error (buggy provider or
 // tampered request) and is still rejected.
 func parseAppleUserField(userRaw string) (*AppleUserInfo, error) {
-	user_ := &AppleUserInfo{}
+	appleUser := &AppleUserInfo{}
 	if userRaw == "" {
-		return user_, nil
+		return appleUser, nil
 	}
-	if err := json.Unmarshal([]byte(userRaw), user_); err != nil {
+	if err := json.Unmarshal([]byte(userRaw), appleUser); err != nil {
 		return nil, err
 	}
-	return user_, nil
+	return appleUser, nil
 }
 
 // OAuthCallbackHandler handles the OAuth callback for various oauth providers
@@ -119,14 +119,14 @@ func (h *httpProvider) OAuthCallbackHandler() gin.HandlerFunc {
 		case constants.AuthRecipeMethodLinkedIn:
 			user, err = h.processLinkedInUserInfo(ctx, oauthCode)
 		case constants.AuthRecipeMethodApple:
-			var user_ *AppleUserInfo
-			user_, err = parseAppleUserField(ctx.Request.FormValue("user"))
+			var appleUser *AppleUserInfo
+			appleUser, err = parseAppleUserField(ctx.Request.FormValue("user"))
 			if err != nil {
 				log.Debug().Err(err).Msg("Failed to unmarshal apple user info")
 				ctx.JSON(400, gin.H{"error": "invalid apple user info"})
 				return
 			}
-			user, err = h.processAppleUserInfo(ctx, oauthCode, user_)
+			user, err = h.processAppleUserInfo(ctx, oauthCode, appleUser)
 		case constants.AuthRecipeMethodDiscord:
 			user, err = h.processDiscordUserInfo(ctx, oauthCode)
 		case constants.AuthRecipeMethodTwitter:
@@ -796,7 +796,7 @@ func (h *httpProvider) processLinkedInUserInfo(ctx *gin.Context, code string) (*
 	return user, nil
 }
 
-func (h *httpProvider) processAppleUserInfo(ctx *gin.Context, code string, user_ *AppleUserInfo) (*schemas.User, error) {
+func (h *httpProvider) processAppleUserInfo(ctx *gin.Context, code string, appleUser *AppleUserInfo) (*schemas.User, error) {
 	log := h.Log.With().Str("func", "processAppleUserInfo").Logger()
 	cfg, err := h.OAuthProvider.GetOAuthConfig(ctx, constants.AuthRecipeMethodApple)
 	if err != nil {
@@ -845,8 +845,8 @@ func (h *httpProvider) processAppleUserInfo(ctx *gin.Context, code string, user_
 		user.Email = &email
 	}
 
-	user.GivenName = &user_.Name.FirstName
-	user.FamilyName = &user_.Name.LastName
+	user.GivenName = &appleUser.Name.FirstName
+	user.FamilyName = &appleUser.Name.LastName
 
 	return user, nil
 }

--- a/internal/http_handlers/oauth_callback_test.go
+++ b/internal/http_handlers/oauth_callback_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseScopes(t *testing.T) {
@@ -53,6 +54,56 @@ func TestParseScopes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseScopes(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// REGRESSION: Apple only sends the `user` form field on the very first
+// authorization for a given app; every subsequent login omits it entirely
+// (documented Apple behavior — a one-time grant, not re-sent). Before this
+// fix, an absent field made json.Unmarshal([]byte(""), ...) fail and the
+// whole callback 400 out, rejecting every returning Apple user. A malformed
+// non-empty field is still a real error and must still be rejected.
+func TestParseAppleUserField(t *testing.T) {
+	tests := []struct {
+		name    string
+		userRaw string
+		want    *AppleUserInfo
+		wantErr bool
+	}{
+		{
+			name:    "absent field (returning-user login) succeeds with zero value",
+			userRaw: "",
+			want:    &AppleUserInfo{},
+		},
+		{
+			name:    "valid json (first-time signup) parses normally",
+			userRaw: `{"email":"a@example.com","name":{"firstName":"Ada","lastName":"Lovelace"}}`,
+			want: &AppleUserInfo{
+				Email: "a@example.com",
+				Name: struct {
+					FirstName string `json:"firstName"`
+					LastName  string `json:"lastName"`
+				}{FirstName: "Ada", LastName: "Lovelace"},
+			},
+		},
+		{
+			name:    "non-empty malformed json still errors",
+			userRaw: `{"email":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAppleUserField(tt.userRaw)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## What's broken

Real "Sign in with Apple" sends the `user` form field (JSON: given/family name) only on an account's very first authorization ever — every subsequent login omits it entirely (a documented, one-time Apple grant, never re-sent).

`OAuthCallbackHandler`'s Apple branch unconditionally required this field and `json.Unmarshal`'d it without a presence check. An absent field meant `json.Unmarshal([]byte(""), ...)` failed, and the whole callback 400'd — **rejecting every returning Apple user's login**, not just a missing-name edge case.

Found while building live e2e coverage for Apple social login (a real browser driving a real OAuth round-trip).

## The fix

Extracted the parse into `parseAppleUserField`, now presence-optional: an empty `user` field returns a zero-value `AppleUserInfo{}` and login proceeds; a non-empty-but-malformed field still errors exactly as before. `processAppleUserInfo`'s `user.Email` comes solely from the verified id_token's `email` claim — entirely independent of the `user` field — so identity establishment is untouched; only `given_name`/`family_name` availability changes (empty on repeat logins, exactly matching what real Apple actually sends).

## Test plan

`TestParseAppleUserField` — three cases: absent field succeeds with zero value, valid JSON parses normally, malformed non-empty JSON still errors. `go build`/`go vet`/`make test` all clean.

Also verified via a live e2e regression: a real browser-driven repeat Apple login (no `user` field supplied, matching real Apple's behavior) now completes successfully instead of 400ing, with email correctly resolved from the id_token. That coverage lands separately with the larger e2e-playground test suite.