### PR TITLE
fix(oauth): give Twitter/X users a stable, real-when-available email

### DIFF
--- a/internal/constants/oauth_info_urls.go
+++ b/internal/constants/oauth_info_urls.go
@@ -15,7 +15,26 @@ const (
 	LinkedInUserInfoURL = "https://api.linkedin.com/v2/me?projection=(id,localizedFirstName,localizedLastName,emailAddress,profilePicture(displayImage~:playableStreams))"
 	LinkedInEmailURL    = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))"
 
-	TwitterUserInfoURL = "https://api.twitter.com/2/users/me?user.fields=id,name,profile_image_url,username"
+	// TwitterUserInfoURL requests confirmed_email as a sparse-fieldset field
+	// alongside the always-present id/name/profile_image_url/username. Per
+	// X's documented sparse fieldset behavior, an unauthorized-or-unrequested
+	// field is simply omitted from the response rather than erroring the
+	// request, so asking for it is safe for every operator - whether or not
+	// they've opted in below.
+	//
+	// X only populates confirmed_email when BOTH of these are true for the
+	// operator's own X Developer App:
+	//   1. The OAuth request includes the `users.email` scope - add it via
+	//      the --twitter-scopes flag (defaultTwitterScopes in cmd/root.go is
+	//      deliberately left unchanged; requesting a scope the operator's
+	//      app dashboard hasn't enabled risks X rejecting the whole
+	//      authorization request for THEIR app, so this is opt-in only).
+	//   2. "Request email from users" is enabled in that app's X Developer
+	//      dashboard.
+	// Without both, processTwitterUserInfo falls back to the synthetic
+	// per-id email, which still correctly prevents duplicate accounts, just
+	// without a real deliverable address.
+	TwitterUserInfoURL = "https://api.twitter.com/2/users/me?user.fields=confirmed_email,id,name,profile_image_url,username"
 
 	// RobloxUserInfoURL is the URL to get user info from Roblox
 	RobloxUserInfoURL = "https://apis.roblox.com/oauth/v1/userinfo"

--- a/internal/http_handlers/oauth_callback.go
+++ b/internal/http_handlers/oauth_callback.go
@@ -907,6 +907,14 @@ func (h *httpProvider) processDiscordUserInfo(ctx *gin.Context, code string) (*s
 	return user, nil
 }
 
+// processTwitterUserInfo exchanges the Twitter/X OAuth code for the user's
+// profile. By default Twitter/X does not return a real email address (see
+// comment below), so the returned user's Email is a synthetic address
+// derived from Twitter's numeric id, not a real, contactable address - this
+// lets the caller's signup-vs-login lookup (GetUserByEmail) recognize a
+// returning Twitter user instead of creating a duplicate account on every
+// login. Operators who opt into X's `users.email` scope + app permission get
+// a real confirmed_email instead (see TwitterUserInfoURL's doc comment).
 func (h *httpProvider) processTwitterUserInfo(ctx *gin.Context, code, verifier string) (*schemas.User, error) {
 	log := h.Log.With().Str("func", "processTwitterUserInfo").Logger()
 	cfg, err := h.OAuthProvider.GetOAuthConfig(ctx, constants.AuthRecipeMethodTwitter)
@@ -962,6 +970,22 @@ func (h *httpProvider) processTwitterUserInfo(ctx *gin.Context, code, verifier s
 
 	// Twitter API does not return E-Mail adresses by default. For that case special privileges have
 	// to be granted on a per-App basis. See https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
+	//
+	// Without an email, the signup-vs-login check in OAuthCallbackHandler
+	// (h.StorageProvider.GetUserByEmail(ctx, refs.StringValue(user.Email)))
+	// would always be called with "" and never match, so every Twitter login
+	// would be treated as a brand-new signup - duplicate accounts on every
+	// login for the same person. To keep that lookup working, synthesize a
+	// stable, non-routable email from Twitter's numeric `id` (permanent,
+	// unlike `username`, which can change). Unlike GitHub's noreply address
+	// (a real, GitHub-issued, deliverable email fetched from GitHub's own
+	// API further down in this file), this one is constructed client-side
+	// and never delivers anywhere - it exists purely as a stable lookup key.
+	twitterID, ok := userRawData["id"].(string)
+	if !ok || twitterID == "" {
+		log.Debug().Msg("Twitter user info missing id")
+		return nil, fmt.Errorf("twitter response missing id field")
+	}
 
 	// Currently Twitter API only provides the full name of a user. To fill givenName and familyName
 	// the full name will be split at the first whitespace. This approach will not be valid for all name combinations
@@ -977,7 +1001,10 @@ func (h *httpProvider) processTwitterUserInfo(ctx *gin.Context, code, verifier s
 	nickname, _ := userRawData["username"].(string)
 	profilePicture, _ := userRawData["profile_image_url"].(string)
 
+	email := resolveTwitterEmail(twitterID, userRawData)
+
 	user := &schemas.User{
+		Email:      &email,
 		GivenName:  &firstName,
 		FamilyName: &lastName,
 		Picture:    &profilePicture,
@@ -985,6 +1012,27 @@ func (h *httpProvider) processTwitterUserInfo(ctx *gin.Context, code, verifier s
 	}
 
 	return user, nil
+}
+
+// twitterSyntheticEmail derives a stable, non-routable synthetic email from
+// Twitter's numeric user id, so the same Twitter account always maps to the
+// same Authorizer email (see processTwitterUserInfo doc comment).
+func twitterSyntheticEmail(twitterID string) string {
+	return fmt.Sprintf("twitter-%s@twitter.oauth.internal", twitterID)
+}
+
+// resolveTwitterEmail picks the email to store for a Twitter-authenticated
+// user. X's `users.email` scope + "Request email from users" app permission
+// (see the TwitterUserInfoURL doc comment in internal/constants/oauth_info_urls.go
+// for how an operator opts in) makes the API return a real, deliverable
+// confirmed_email; this is preferred when present. Otherwise falls back to
+// the synthetic per-id email, which still correctly prevents duplicate
+// accounts (see processTwitterUserInfo doc comment) without a real address.
+func resolveTwitterEmail(twitterID string, userRawData map[string]interface{}) string {
+	if confirmedEmail, ok := userRawData["confirmed_email"].(string); ok && confirmedEmail != "" {
+		return confirmedEmail
+	}
+	return twitterSyntheticEmail(twitterID)
 }
 
 // process microsoft user information

--- a/internal/http_handlers/oauth_twitter_test.go
+++ b/internal/http_handlers/oauth_twitter_test.go
@@ -1,0 +1,58 @@
+package http_handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTwitterSyntheticEmail(t *testing.T) {
+	assert.Equal(t, twitterSyntheticEmail("42"), twitterSyntheticEmail("42"), "deterministic for the same id")
+	assert.NotEqual(t, twitterSyntheticEmail("1"), twitterSyntheticEmail("2"), "distinct ids must not collide")
+	assert.Contains(t, twitterSyntheticEmail("42"), "42")
+}
+
+// REGRESSION (account-duplication bug): Twitter's API never returns an
+// email by default, so processTwitterUserInfo used to leave user.Email nil.
+// OAuthCallbackHandler's signup-vs-login check
+// (GetUserByEmail(refs.StringValue(user.Email))) then always ran as
+// GetUserByEmail(""), which never matches a NULL email column in SQL - so
+// every Twitter login, even for the exact same person, created a brand-new
+// account. resolveTwitterEmail's synthetic fallback (keyed on Twitter's
+// permanent numeric id, not the mutable username) fixes this: the same
+// identity always resolves to the same email, so returning users are
+// recognized.
+func TestResolveTwitterEmail_NoConfirmedEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"name": "Ada Lovelace", "username": "ada"}
+	got := resolveTwitterEmail("42", userRawData)
+	assert.Equal(t, twitterSyntheticEmail("42"), got)
+}
+
+// EDGE CASE: X sends the field present but empty (rather than omitting it
+// entirely) when a user hasn't confirmed an email - must still be treated
+// as absent, not as a real (empty) address.
+func TestResolveTwitterEmail_EmptyConfirmedEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"confirmed_email": ""}
+	got := resolveTwitterEmail("42", userRawData)
+	assert.Equal(t, twitterSyntheticEmail("42"), got)
+}
+
+// REFINEMENT: X API v2 (2025-04-03+) returns confirmed_email when the OAuth
+// request carries the users.email scope and the operator's X Developer App
+// has "Request email from users" enabled (see TwitterUserInfoURL's doc
+// comment in internal/constants/oauth_info_urls.go). When present, the
+// real, deliverable email must be preferred over the synthetic one.
+func TestResolveTwitterEmail_ConfirmedEmailPresent_PreferredOverSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"confirmed_email": "ada@example.com"}
+	got := resolveTwitterEmail("42", userRawData)
+	assert.Equal(t, "ada@example.com", got)
+	assert.NotEqual(t, twitterSyntheticEmail("42"), got)
+}
+
+// Distinct Twitter ids must never collide onto the same synthetic email
+// (which would incorrectly merge two real users' accounts).
+func TestResolveTwitterEmail_DifferentIDsNoConfirmedEmail_NeverCollide(t *testing.T) {
+	emailA := resolveTwitterEmail("1", map[string]interface{}{})
+	emailB := resolveTwitterEmail("2", map[string]interface{}{})
+	assert.NotEqual(t, emailA, emailB)
+}

--- a/internal/integration_tests/oauth_twitter_identity_test.go
+++ b/internal/integration_tests/oauth_twitter_identity_test.go
@@ -1,0 +1,117 @@
+package integration_tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/refs"
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
+)
+
+// twitterSyntheticEmail mirrors internal/http_handlers/oauth_callback.go's
+// unexported twitterSyntheticEmail helper (fmt.Sprintf("twitter-%s@twitter.oauth.internal", id)),
+// used here to simulate what processTwitterUserInfo hands the
+// OAuthCallbackHandler signup-vs-login branch for a given Twitter numeric id.
+func twitterSyntheticEmail(twitterID string) string {
+	return fmt.Sprintf("twitter-%s@twitter.oauth.internal", twitterID)
+}
+
+// TestOAuthTwitterIdentityStability is the regression test for the bug this
+// change fixes: real Twitter never returns an email, so before this fix
+// processTwitterUserInfo left User.Email nil and OAuthCallbackHandler's
+// signup-vs-login lookup (GetUserByEmail(ctx, refs.StringValue(user.Email)))
+// always ran as GetUserByEmail(ctx, "") — which never matches a NULL email
+// column in SQL (NULL never equals an empty string) — so every single Twitter login
+// created a brand-new, duplicate account.
+//
+// This test drives the exact same GetUserByEmail -> AddUser/UpdateUser
+// sequence OAuthCallbackHandler runs (see oauth_account_linking_test.go for
+// the established pattern of simulating the handler's storage-layer
+// decisions directly rather than a full HTTP round trip), keyed on the
+// synthetic email the fix now derives from Twitter's stable numeric id.
+func TestOAuthTwitterIdentityStability(t *testing.T) {
+	cfg := getTestConfig()
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	t.Run("same_twitter_id_resolves_to_same_user_on_second_login", func(t *testing.T) {
+		twitterID := "tw-" + uuid.New().String()
+		email := twitterSyntheticEmail(twitterID)
+
+		// --- First login: OAuthCallbackHandler's GetUserByEmail misses, so it signs up. ---
+		_, err := ts.StorageProvider.GetUserByEmail(ctx, email)
+		require.Error(t, err, "no account should exist yet for this Twitter id")
+
+		now := time.Now().Unix()
+		firstUser := &schemas.User{
+			ID:            uuid.New().String(),
+			Email:         refs.NewStringRef(email),
+			GivenName:     refs.NewStringRef("Ada"),
+			FamilyName:    refs.NewStringRef("Lovelace"),
+			SignupMethods: constants.AuthRecipeMethodTwitter,
+			Roles:         "user",
+		}
+		firstUser.EmailVerifiedAt = &now
+		createdUser, err := ts.StorageProvider.AddUser(ctx, firstUser)
+		require.NoError(t, err)
+		require.NotNil(t, createdUser)
+
+		// --- Second login with the SAME Twitter id: this is the bug's regression check. ---
+		// Before the fix, Email was always nil for Twitter, so this lookup
+		// would always be GetUserByEmail(ctx, "") and always miss, creating a
+		// second, duplicate account. After the fix, the synthetic email is
+		// stable across logins, so this must be a hit.
+		existingUser, err := ts.StorageProvider.GetUserByEmail(ctx, email)
+		require.NoError(t, err, "second login with the same Twitter id must recognize the existing account")
+		assert.Equal(t, createdUser.ID, existingUser.ID,
+			"second login must resolve to the SAME user, not create a duplicate")
+
+		// OAuthCallbackHandler's "existing user" branch updates in place
+		// (UpdateUser), it never calls AddUser again.
+		updatedUser, err := ts.StorageProvider.UpdateUser(ctx, existingUser)
+		require.NoError(t, err)
+		assert.Equal(t, createdUser.ID, updatedUser.ID)
+	})
+
+	t.Run("different_twitter_ids_never_collide_onto_the_same_user", func(t *testing.T) {
+		idA := "tw-" + uuid.New().String()
+		idB := "tw-" + uuid.New().String()
+		emailA := twitterSyntheticEmail(idA)
+		emailB := twitterSyntheticEmail(idB)
+		require.NotEqual(t, emailA, emailB)
+
+		now := time.Now().Unix()
+		userA := &schemas.User{
+			ID:            uuid.New().String(),
+			Email:         refs.NewStringRef(emailA),
+			SignupMethods: constants.AuthRecipeMethodTwitter,
+			Roles:         "user",
+		}
+		userA.EmailVerifiedAt = &now
+		createdA, err := ts.StorageProvider.AddUser(ctx, userA)
+		require.NoError(t, err)
+
+		// A GetUserByEmail lookup for the second (different) Twitter id must
+		// miss - it must never accidentally resolve to the first user.
+		_, err = ts.StorageProvider.GetUserByEmail(ctx, emailB)
+		require.Error(t, err, "a different Twitter id must not match an unrelated existing account")
+
+		userB := &schemas.User{
+			ID:            uuid.New().String(),
+			Email:         refs.NewStringRef(emailB),
+			SignupMethods: constants.AuthRecipeMethodTwitter,
+			Roles:         "user",
+		}
+		userB.EmailVerifiedAt = &now
+		createdB, err := ts.StorageProvider.AddUser(ctx, userB)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, createdA.ID, createdB.ID, "different Twitter ids must produce two distinct accounts")
+	})
+}


### PR DESCRIPTION
## What's broken

Twitter's API never returns an email by default. `processTwitterUserInfo` left `user.Email` nil, so `OAuthCallbackHandler`'s signup-vs-login check (`GetUserByEmail(refs.StringValue(user.Email))`) always ran as `GetUserByEmail("")` — which never matches a `NULL` email column in SQL.

**Every single Twitter login, even for the exact same person, created a brand-new account.** Verified empirically, not just by reading code: logging in with the same Twitter identity twice produced two entirely separate Authorizer accounts, the second with no memory of the first — real users lose all roles/org-membership between sessions and accumulate an ever-growing pile of orphaned duplicate accounts.

Found while building live e2e coverage for Twitter/X social login (a real browser driving a real OAuth round-trip).

## The fix

`resolveTwitterEmail` now:
1. **Prefers X's real `confirmed_email`** when present — X API v2 added this on 2025-04-03, returned when the OAuth request carries the `users.email` scope and the operator's X Developer App has "Request email from users" enabled (neither on by default; opt-in via the existing `--twitter-scopes` flag, not a new default — forcing an unrequested scope risks X rejecting the whole authorization for an operator who hasn't set up the dashboard permission).
2. **Falls back to a stable synthetic email** derived from Twitter's numeric `id` (permanent, unlike `username`, which can change) when no real email is available — this alone fixes the duplicate-account bug for every operator, whether or not they've opted into the newer X API capability.

A response missing `id` is a hard error rather than silently constructing a garbage synthetic address.

## Test plan

`TestResolveTwitterEmail_*` (4 cases: no confirmed_email → synthetic, empty confirmed_email → synthetic, real confirmed_email → preferred, different ids never collide) plus `TestOAuthTwitterIdentityStability` (integration test: same id resolves to the same user on a second login, different ids never collide). `go build`/`go vet`/`make test` all clean.

Also verified via live e2e regression (lands separately with the larger e2e-playground test suite): two independent browser sessions authenticating as the same Twitter identity now resolve to the same account instead of creating a duplicate, and a session with `confirmed_email` configured uses the real address instead of the synthetic one.