### PR TITLE
fix(oauth): extract real email from Discord users/@me, not oauth2/@me

### DIFF
--- a/internal/constants/oauth_info_urls.go
+++ b/internal/constants/oauth_info_urls.go
@@ -39,7 +39,14 @@ const (
 	// RobloxUserInfoURL is the URL to get user info from Roblox
 	RobloxUserInfoURL = "https://apis.roblox.com/oauth/v1/userinfo"
 
-	DiscordUserInfoURL = "https://discord.com/api/oauth2/@me"
+	// DiscordUserInfoURL intentionally points at GET /users/@me, not
+	// /oauth2/@me (Discord's "current authorization" endpoint). Per Discord's
+	// OAuth2 docs, /oauth2/@me's `user` sub-object never includes `email`
+	// regardless of granted scopes - the `email` scope's documented effect is
+	// "enables /users/@me to return an email". /users/@me also returns a
+	// flat object (id/username/avatar/email at the top level), unlike
+	// /oauth2/@me's nested `{"user": {...}}` shape.
+	DiscordUserInfoURL = "https://discord.com/api/users/@me"
 	// Get microsoft user info.
 	// Ref: https://learn.microsoft.com/en-us/azure/active-directory/develop/userinfo
 	MicrosoftUserInfoURL = "https://graph.microsoft.com/oidc/userinfo"

--- a/internal/http_handlers/oauth_callback.go
+++ b/internal/http_handlers/oauth_callback.go
@@ -851,6 +851,20 @@ func (h *httpProvider) processAppleUserInfo(ctx *gin.Context, code string, apple
 	return user, nil
 }
 
+// processDiscordUserInfo exchanges the Discord OAuth code for the user's
+// profile via GET /users/@me (constants.DiscordUserInfoURL), which returns a
+// flat id/username/avatar/email object. defaultDiscordScopes (cmd/root.go)
+// already requests `identify email` by default, and Discord returns a real,
+// deliverable email whenever the user grants it - no special app-dashboard
+// permission needed, unlike X's confirmed_email. Discord's consent screen
+// does allow granular per-scope denial though, so a user can authorize
+// `identify` while declining `email`; for that case, fall back to a stable
+// synthetic address keyed on Discord's permanent id (never username, which
+// can change) so the signup-vs-login lookup (GetUserByEmail in
+// OAuthCallbackHandler) still recognizes a returning user instead of
+// creating a duplicate account - the same fallback discipline
+// processTwitterUserInfo uses above for X, which never returns a real email
+// at all.
 func (h *httpProvider) processDiscordUserInfo(ctx *gin.Context, code string) (*schemas.User, error) {
 	log := h.Log.With().Str("func", "processDiscordUserInfo").Logger()
 	cfg, err := h.OAuthProvider.GetOAuthConfig(ctx, constants.AuthRecipeMethodDiscord)
@@ -892,18 +906,13 @@ func (h *httpProvider) processDiscordUserInfo(ctx *gin.Context, code string) (*s
 		return nil, fmt.Errorf("failed to request Discord user info: %s", string(body))
 	}
 
-	// Unmarshal the response body into a map
-	responseRawData := make(map[string]interface{})
-	if err := json.Unmarshal(body, &responseRawData); err != nil {
+	// Unmarshal the response body into a map. GET /users/@me returns a flat
+	// object - no "user" sub-key to unwrap (unlike /oauth2/@me, which this
+	// used to call).
+	userRawData := make(map[string]interface{})
+	if err := json.Unmarshal(body, &userRawData); err != nil {
 		log.Debug().Err(err).Msg("Failed to unmarshal Discord response")
 		return nil, fmt.Errorf("failed to unmarshal Discord response: %s", err.Error())
-	}
-
-	// Safely extract the user data
-	userRawData, ok := responseRawData["user"].(map[string]interface{})
-	if !ok {
-		log.Debug().Err(err).Msg("User data is not in expected format or missing in response")
-		return nil, fmt.Errorf("user data is not in expected format or missing in response")
 	}
 
 	// Extract the username
@@ -912,16 +921,42 @@ func (h *httpProvider) processDiscordUserInfo(ctx *gin.Context, code string) (*s
 		log.Debug().Err(err).Msg("Username is not in expected format or missing in user data")
 		return nil, fmt.Errorf("username is not in expected format or missing in user data")
 	}
-	discordID, _ := userRawData["id"].(string)
+	discordID, ok := userRawData["id"].(string)
+	if !ok || discordID == "" {
+		log.Debug().Msg("Discord user info missing id")
+		return nil, fmt.Errorf("discord response missing id field")
+	}
 	avatar, _ := userRawData["avatar"].(string)
 	profilePicture := fmt.Sprintf("https://cdn.discordapp.com/avatars/%s/%s.png", discordID, avatar)
+
+	email := resolveDiscordEmail(discordID, userRawData)
 
 	user := &schemas.User{
 		GivenName: &firstName,
 		Picture:   &profilePicture,
+		Email:     &email,
 	}
 
 	return user, nil
+}
+
+// resolveDiscordEmail prefers the real email Discord returns; falls back to
+// a synthetic one keyed on the permanent id if the user denied the `email`
+// scope at Discord's consent screen (see processDiscordUserInfo doc
+// comment). Mirrors resolveTwitterEmail below.
+func resolveDiscordEmail(discordID string, userRawData map[string]interface{}) string {
+	if realEmail, ok := userRawData["email"].(string); ok && realEmail != "" {
+		return realEmail
+	}
+	return discordSyntheticEmail(discordID)
+}
+
+// discordSyntheticEmail derives a stable, non-routable synthetic email from
+// Discord's permanent user id, used when a user grants `identify` but denies
+// the `email` scope (see processDiscordUserInfo doc comment). Mirrors
+// twitterSyntheticEmail below.
+func discordSyntheticEmail(discordID string) string {
+	return fmt.Sprintf("discord-%s@discord.oauth.internal", discordID)
 }
 
 // processTwitterUserInfo exchanges the Twitter/X OAuth code for the user's

--- a/internal/http_handlers/oauth_discord_test.go
+++ b/internal/http_handlers/oauth_discord_test.go
@@ -1,0 +1,57 @@
+package http_handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscordSyntheticEmail(t *testing.T) {
+	assert.Equal(t, discordSyntheticEmail("42"), discordSyntheticEmail("42"), "deterministic for the same id")
+	assert.NotEqual(t, discordSyntheticEmail("1"), discordSyntheticEmail("2"), "distinct ids must not collide")
+	assert.Contains(t, discordSyntheticEmail("42"), "42")
+}
+
+// REGRESSION (account-duplication bug): processDiscordUserInfo used to call
+// GET /oauth2/@me, whose user object never includes email regardless of
+// granted scopes, and even ignored userRawData["email"] entirely. Every
+// Discord login then hit GetUserByEmail(""), which never matches a NULL
+// email column in SQL, so every login (even repeat logins from the same
+// person) created a brand-new account. resolveDiscordEmail's synthetic
+// fallback (keyed on Discord's permanent id, not the mutable username)
+// fixes this: the same identity always resolves to the same email, so
+// returning users are recognized.
+func TestResolveDiscordEmail_NoEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"username": "gracehopper", "avatar": "abc123"}
+	got := resolveDiscordEmail("42", userRawData)
+	assert.Equal(t, discordSyntheticEmail("42"), got)
+}
+
+// EDGE CASE: a user can authorize `identify` while denying the `email`
+// scope at Discord's consent screen even though the app requested it, so
+// GET /users/@me can return the field present but empty rather than
+// omitting it entirely - must still be treated as absent.
+func TestResolveDiscordEmail_EmptyEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"email": ""}
+	got := resolveDiscordEmail("42", userRawData)
+	assert.Equal(t, discordSyntheticEmail("42"), got)
+}
+
+// GET /users/@me (unlike Twitter/X's confirmed_email) returns a real,
+// deliverable email for the common case - defaultDiscordScopes (cmd/root.go)
+// already requests `identify email` - and that real address must be
+// preferred over the synthetic one.
+func TestResolveDiscordEmail_RealEmailPresent_PreferredOverSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"email": "grace@example.com"}
+	got := resolveDiscordEmail("42", userRawData)
+	assert.Equal(t, "grace@example.com", got)
+	assert.NotEqual(t, discordSyntheticEmail("42"), got)
+}
+
+// Distinct Discord ids must never collide onto the same synthetic email
+// (which would incorrectly merge two real users' accounts).
+func TestResolveDiscordEmail_DifferentIDsNoEmail_NeverCollide(t *testing.T) {
+	emailA := resolveDiscordEmail("1", map[string]interface{}{})
+	emailB := resolveDiscordEmail("2", map[string]interface{}{})
+	assert.NotEqual(t, emailA, emailB)
+}


### PR DESCRIPTION
## Summary

- Discord OAuth was calling `GET /oauth2/@me` (Discord's "current authorization" endpoint), whose `user` sub-object never includes `email` regardless of granted scopes, and the code even ignored `userRawData["email"]` entirely
- `defaultDiscordScopes` (cmd/root.go) already requests `identify email`, but the wrong endpoint meant email was unreachable — `GetUserByEmail(ctx, "")` never matches a NULL column in SQL, so every Discord login created a duplicate account instead of resolving to the returning user
- Switched `DiscordUserInfoURL` to `GET /users/@me`, which returns a flat object (no `user` wrapper) and includes a real, deliverable email once the user grants the scope
- Extracted `resolveDiscordEmail` as a pure helper (mirrors `resolveTwitterEmail` from #716) that falls back to a stable synthetic per-id email for the edge case where a user grants `identify` but denies `email` at Discord's consent screen

Found while building live e2e coverage for social OAuth providers (a real browser driving a real Discord login through Authorizer, verifying the same account is reused across repeat logins).

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `internal/http_handlers/oauth_discord_test.go` — 5 unit tests covering: real email preferred, empty/absent email falls back to synthetic, distinct ids never collide, deterministic synthetic email
- [x] Full `go test ./internal/...` (SQLite) clean, no regressions