### PR TITLE
fix(magic-link): require IsEmailServiceEnabled, not just EnableEmailVerification

### DIFF
--- a/internal/integration_tests/magic_link_login_test.go
+++ b/internal/integration_tests/magic_link_login_test.go
@@ -74,6 +74,35 @@ func TestMagicLinkLogin(t *testing.T) {
 	})
 }
 
+// TestMagicLinkLoginEmailServiceDisabled is a regression guard: when
+// EnableEmailVerification is on but IsEmailServiceEnabled is off (e.g. no
+// SMTP sender email configured), MagicLinkLogin used to still create a
+// VerificationRequest row and fire an async SendEmail that was guaranteed
+// to fail - the caller got a success message, but no email was ever
+// deliverable and the token could never be verified. It must now behave
+// the same as EnableEmailVerification being off entirely: no verification
+// request created, matching signup.go's isEmailVerificationEnabled guard.
+func TestMagicLinkLoginEmailServiceDisabled(t *testing.T) {
+	cfg := getTestConfig()
+	cfg.EnableMagicLinkLogin = true
+	cfg.EnableEmailVerification = true
+	cfg.IsEmailServiceEnabled = false
+	ts := initTestSetup(t, cfg)
+	_, ctx := createContext(ts)
+
+	email := "magic_link_no_email_service_" + uuid.New().String() + "@authorizer.dev"
+
+	res, err := ts.GraphQLProvider.MagicLinkLogin(ctx, &model.MagicLinkLoginRequest{
+		Email: email,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.NotEmpty(t, res.Message)
+
+	_, err = ts.StorageProvider.GetVerificationRequestByEmail(ctx, email, constants.VerificationTypeMagicLinkLogin)
+	assert.Error(t, err, "no verification request should be created when the email service isn't configured")
+}
+
 // TestMagicLinkLoginMFAGate is a regression guard for VerifyEmail's MFA
 // check: it used to be an ad-hoc TOTP-only condition
 // (refs.BoolValue(user.IsMultiFactorAuthEnabled) && isMFAEnabled &&

--- a/internal/service/magic_link_login.go
+++ b/internal/service/magic_link_login.go
@@ -154,7 +154,13 @@ func (p *provider) MagicLinkLogin(ctx context.Context, meta RequestMetadata, par
 	}
 
 	hostname := meta.HostURL
-	isEmailVerificationEnabled := p.Config.EnableEmailVerification
+	// Matches signup.go's isEmailVerificationEnabled guard: without also
+	// requiring IsEmailServiceEnabled (SMTP fully configured, including a
+	// sender email), this branch would still create a VerificationRequest
+	// row and fire an async SendEmail that's guaranteed to fail - the
+	// caller gets a success message, but no email is ever deliverable and
+	// the failure is only visible at debug log level.
+	isEmailVerificationEnabled := p.Config.EnableEmailVerification && p.Config.IsEmailServiceEnabled
 	if isEmailVerificationEnabled {
 		// insert verification request
 		_, nonceHash, err := utils.GenerateNonce()


### PR DESCRIPTION
## Summary

- `internal/service/magic_link_login.go`'s `isEmailVerificationEnabled` guard only checked `EnableEmailVerification` — unlike `internal/service/signup.go`'s identical-purpose guard, which also requires `IsEmailServiceEnabled`
- With email verification on but SMTP not fully configured (e.g. no `--smtp-sender-email`), the mutation still created a `VerificationRequest` row and fired an async `SendEmail` that was guaranteed to fail — the caller got the generic success message ("If an account exists for this email, a magic link has been sent...") but no email was ever deliverable, and the failure was silently swallowed (`_ = p.EmailProvider.SendEmail(...)`), only visible at debug log level
- Found live while building e2e coverage for magic-link login: the test compose service needed `--smtp-sender-email` added because nothing had exercised a real send through this stack before, surfacing a `gomail: invalid address` failure a caller would never see in practice
- Fix is a one-line guard change (`&& p.Config.IsEmailServiceEnabled`), mirroring `signup.go` exactly — narrow in scope: `IsEmailServiceEnabled` is derived purely from a complete SMTP config at `Finalize()` time, so any operator with working SMTP already has it `true` and sees no behavior change; this only fixes the previously-broken "verification requested but SMTP incomplete" case
- Verified the "no email enumeration" property is preserved: both the guarded and now-skipped branches fall through to the same generic response

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] New integration test `TestMagicLinkLoginEmailServiceDisabled` — asserts a generic success message is still returned, but no `VerificationRequest` row is created, when `IsEmailServiceEnabled` is false
- [x] Existing `TestMagicLinkLogin`/`TestMagicLinkLoginMFAGate` still pass, no regression
- [x] Full `go test ./internal/...` (SQLite) clean