### PR TITLE
fix(oauth): synthesize roblox email from sub instead of storing raw id

### DIFF
--- a/internal/http_handlers/oauth_callback.go
+++ b/internal/http_handlers/oauth_callback.go
@@ -1238,12 +1238,8 @@ func (h *httpProvider) processRobloxUserInfo(ctx *gin.Context, code string) (*sc
 	}
 	nickname, _ := userRawData["nickname"].(string)
 	profilePicture, _ := userRawData["picture"].(string)
-	email := ""
-	if val, ok := userRawData["email"].(string); ok && val != "" {
-		email = val
-	} else if sub, ok := userRawData["sub"].(string); ok {
-		email = sub
-	}
+	sub, _ := userRawData["sub"].(string)
+	email := resolveRobloxEmail(sub, userRawData)
 	user := &schemas.User{
 		GivenName:  &firstName,
 		FamilyName: &lastName,
@@ -1253,6 +1249,32 @@ func (h *httpProvider) processRobloxUserInfo(ctx *gin.Context, code string) (*sc
 	}
 
 	return user, nil
+}
+
+// resolveRobloxEmail prefers the real email Roblox returns; falls back to a
+// synthetic one keyed on the permanent sub if it's absent. defaultRobloxScopes
+// (cmd/root.go) is ["openid", "profile"] - no `email` scope - so real Roblox
+// userinfo (an OIDC-standard endpoint, see constants.RobloxUserInfoURL)
+// returns the mandatory `sub` claim but omits `email` under the default
+// config. Falling back to the bare `sub` would store a non-email-shaped
+// numeric id in user.Email, so this synthesizes a stable, non-routable
+// address instead - mirrors resolveTwitterEmail/resolveDiscordEmail above.
+func resolveRobloxEmail(sub string, userRawData map[string]interface{}) string {
+	if val, ok := userRawData["email"].(string); ok && val != "" {
+		return val
+	}
+	if sub != "" {
+		return robloxSyntheticEmail(sub)
+	}
+	return ""
+}
+
+// robloxSyntheticEmail derives a stable, non-routable synthetic email from
+// Roblox's numeric user id, used when a user's granted scopes don't include
+// `email` (see processRobloxUserInfo doc comment). Mirrors
+// twitterSyntheticEmail/discordSyntheticEmail above.
+func robloxSyntheticEmail(sub string) string {
+	return fmt.Sprintf("roblox-%s@roblox.oauth.internal", sub)
 }
 
 // parseScopes parses a scope string into a slice of individual scope values.

--- a/internal/http_handlers/oauth_roblox_test.go
+++ b/internal/http_handlers/oauth_roblox_test.go
@@ -1,0 +1,62 @@
+package http_handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRobloxSyntheticEmail(t *testing.T) {
+	assert.Equal(t, robloxSyntheticEmail("42"), robloxSyntheticEmail("42"), "deterministic for the same id")
+	assert.NotEqual(t, robloxSyntheticEmail("1"), robloxSyntheticEmail("2"), "distinct ids must not collide")
+	assert.Contains(t, robloxSyntheticEmail("42"), "42")
+}
+
+// REGRESSION (data-quality bug): defaultRobloxScopes (cmd/root.go) is
+// ["openid", "profile"] - no `email` scope - so real Roblox userinfo (an
+// OIDC-standard endpoint) omits `email` under the default config.
+// resolveRobloxEmail used to fall back to the bare numeric `sub`, storing a
+// non-email-shaped value directly in user.Email. The fix synthesizes a
+// stable, email-shaped address from `sub` instead, mirroring
+// resolveTwitterEmail/resolveDiscordEmail.
+func TestResolveRobloxEmail_NoEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"name": "Ada Lovelace", "nickname": "ada"}
+	got := resolveRobloxEmail("123456789", userRawData)
+	assert.Equal(t, robloxSyntheticEmail("123456789"), got)
+	assert.NotEqual(t, "123456789", got, "the raw sub must never land directly in the result")
+	assert.Contains(t, got, "@", "fallback must be email-shaped")
+}
+
+// EDGE CASE: the response can carry the field present but empty rather than
+// omitting it entirely - must still be treated as absent.
+func TestResolveRobloxEmail_EmptyEmail_FallsBackToSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"email": ""}
+	got := resolveRobloxEmail("42", userRawData)
+	assert.Equal(t, robloxSyntheticEmail("42"), got)
+}
+
+// When the operator has opted into the `email` scope, the real address must
+// be preferred over the synthetic one.
+func TestResolveRobloxEmail_RealEmailPresent_PreferredOverSynthetic(t *testing.T) {
+	userRawData := map[string]interface{}{"email": "ada@example.com"}
+	got := resolveRobloxEmail("42", userRawData)
+	assert.Equal(t, "ada@example.com", got)
+	assert.NotEqual(t, robloxSyntheticEmail("42"), got)
+}
+
+// Distinct Roblox subs must never collide onto the same synthetic email
+// (which would incorrectly merge two real users' accounts).
+func TestResolveRobloxEmail_DifferentSubsNoEmail_NeverCollide(t *testing.T) {
+	emailA := resolveRobloxEmail("1", map[string]interface{}{})
+	emailB := resolveRobloxEmail("2", map[string]interface{}{})
+	assert.NotEqual(t, emailA, emailB)
+}
+
+// DEFENSIVE EDGE CASE: an empty-string sub (present key, zero value) must be
+// treated the same as a missing sub, not passed to robloxSyntheticEmail -
+// which would otherwise mint the same collision-prone
+// "roblox-@roblox.oauth.internal" address for every such response.
+func TestResolveRobloxEmail_EmptySub_LeavesEmailEmpty(t *testing.T) {
+	got := resolveRobloxEmail("", map[string]interface{}{})
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Summary

- `defaultRobloxScopes` (`cmd/root.go`) is `["openid", "profile"]` — no `email` scope — so real Roblox userinfo (an OIDC-standard endpoint) returns the mandatory `sub` claim but omits `email` under the default configuration
- `processRobloxUserInfo`'s fallback stored the bare numeric `sub` directly into `user.Email` — not an email-shaped address at all
- Unlike the Twitter/Discord bugs (#716/#717 — an empty email caused `GetUserByEmail("")` to never match, creating duplicate accounts on every login), each Roblox `sub` is unique, so accounts didn't collide — but the stored `email` column contained a non-email string, liable to break anything downstream that assumes a valid, well-formed address (magic-link resend, "Signed in as `{email}`" display text, webhook payloads)
- Extracted `resolveRobloxEmail` as a pure helper mirroring `resolveTwitterEmail`/`resolveDiscordEmail`: derives `roblox-<sub>@roblox.oauth.internal` instead of using the bare `sub`

Found while building live e2e coverage for social OAuth providers — a real browser driving a real Roblox login through Authorizer under the default (no `email` scope) configuration.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] 6 unit tests covering: real email preferred, empty/absent email falls back to synthetic, distinct subs never collide, deterministic synthetic email, empty-string sub treated as absent (not passed to the synthesizer)
- [x] Full `go test ./internal/...` (SQLite) clean, no regressions