### PR TITLE
fix(dashboard): send double-nested pagination in OrgDomains' list query

### DIFF
--- a/web/dashboard/src/components/OrgDomains.test.tsx
+++ b/web/dashboard/src/components/OrgDomains.test.tsx
@@ -86,6 +86,28 @@ describe('OrgDomains', () => {
 		expect(await screen.findByText('acme.com')).toBeTruthy();
 	});
 
+	// REGRESSION: ListOrgDomainsRequest.pagination is PaginatedRequest, which
+	// itself wraps a `pagination: PaginationRequest` field
+	// (internal/graph/schema.graphqls) - fetchDomains used to send
+	// `pagination: { limit: 100 }` (single-nested), which the server rejected
+	// with GRAPHQL_VALIDATION_FAILED on every call. The mock client here
+	// doesn't validate variable shape against a real schema, so this bug was
+	// invisible to every other test in this file - assert the exact shape
+	// directly instead.
+	it('requests domains with the double-nested pagination shape the schema requires', async () => {
+		render(<OrgDomains orgId="org1" orgSlug="Acme" />);
+		await screen.findByText('No verified domains yet.');
+		expect(mockClient.query).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				params: {
+					org_id: 'org1',
+					pagination: { pagination: { limit: 100 } },
+				},
+			}),
+		);
+	});
+
 	it('runs the DNS challenge flow: request → shows TXT → verify → verified', async () => {
 		mockClient.mutation.mockImplementation((doc: unknown) => {
 			if (doc === RequestOrgDomain) {

--- a/web/dashboard/src/components/OrgDomains.tsx
+++ b/web/dashboard/src/components/OrgDomains.tsx
@@ -110,9 +110,19 @@ const OrgDomains = ({ orgId, orgSlug }: OrgDomainsProps) => {
 				// Verified domains per org are expected to be a handful at most; a
 				// generous single-page limit avoids silently truncating at the
 				// backend's default of 10 without needing full pagination UI.
-				params: { org_id: orgId, pagination: { limit: 100 } },
+				// ListOrgDomainsRequest.pagination is PaginatedRequest, which itself
+				// wraps a `pagination: PaginationRequest` field - double-nested, not
+				// { limit }  directly (internal/graph/schema.graphqls).
+				params: { org_id: orgId, pagination: { pagination: { limit: 100 } } },
 			})
 			.toPromise();
+		if (res.error) {
+			toast.error(
+				capitalizeFirstLetter(
+					getGraphQLErrorMessage(res.error, 'Failed to load verified domains'),
+				),
+			);
+		}
 		setDomains(res.data?._org_domains?.org_domains || []);
 		setDomainsLoading(false);
 	};


### PR DESCRIPTION
## Summary

- `web/dashboard/src/components/OrgDomains.tsx`'s `fetchDomains()` sent `pagination: { limit: 100 }`, but `ListOrgDomainsRequest.pagination` is `PaginatedRequest`, which itself wraps a `pagination: PaginationRequest` field (`internal/graph/schema.graphqls`) — the correct shape is double-nested: `pagination: { pagination: { limit: 100 } } }`
- The wrong shape meant every `_org_domains` query failed server-side with `GRAPHQL_VALIDATION_FAILED` — silently swallowed (`res.data?._org_domains?.org_domains || []` never checked `res.error`), so the verified-domains table always rendered "No verified domains yet." even when domains existed
- **This feature (added in #707) has never worked since it shipped** — every org admin managing verified domains through the dashboard UI would see an empty list regardless of what was actually configured
- Also adds the missing `res.error` handling `fetchDomains` lacked, matching the exact pattern already used by every other mutation handler in this file (`RequestOrgDomain`/`VerifyOrgDomain`/`AddVerifiedOrgDomain`/`DeleteOrgDomain`)
- Added a regression test asserting the exact query variable shape sent — the existing test file's mock client had no schema awareness, which is why this went unnoticed by the pre-existing unit tests for as long as the feature existed

Found while building an e2e spec that drives this UI through a real browser and backend (not the mocked client the existing unit tests use).

## Test plan

- [x] `npx vitest run src/components/OrgDomains.test.tsx` — 6/6 pass (5 pre-existing + 1 new regression test asserting the correct double-nested shape)
- [x] Full `npx vitest run` (web/dashboard) — 43/43 pass, no regressions
- [x] `npm run build` clean