### PR TITLE
fix(webhooks): allow-list the SCIM/group webhook event names

### DIFF
--- a/internal/validators/webhook.go
+++ b/internal/validators/webhook.go
@@ -2,11 +2,28 @@ package validators
 
 import "github.com/authorizerdev/authorizer/internal/constants"
 
+// validWebhookEventNames are the only event names an admin may register a
+// webhook against. PR #705 added the SCIM/group events
+// (internal/constants/webhook_event_scim.go) but never added them here, so
+// registering a webhook for any of them was rejected as invalid - the whole
+// SCIM webhook feature had no working configuration path.
+var validWebhookEventNames = map[string]bool{
+	constants.UserCreatedWebhookEvent:       true,
+	constants.UserLoginWebhookEvent:         true,
+	constants.UserSignUpWebhookEvent:        true,
+	constants.UserDeletedWebhookEvent:       true,
+	constants.UserAccessEnabledWebhookEvent: true,
+	constants.UserAccessRevokedWebhookEvent: true,
+	constants.UserDeactivatedWebhookEvent:   true,
+	constants.UserProvisionedWebhookEvent:   true,
+	constants.UserDeprovisionedWebhookEvent: true,
+	constants.UserScimUpdatedWebhookEvent:   true,
+	constants.GroupCreatedWebhookEvent:      true,
+	constants.GroupUpdatedWebhookEvent:      true,
+	constants.GroupDeletedWebhookEvent:      true,
+}
+
 // IsValidWebhookEventName to validate webhook event name
 func IsValidWebhookEventName(eventName string) bool {
-	if eventName != constants.UserCreatedWebhookEvent && eventName != constants.UserLoginWebhookEvent && eventName != constants.UserSignUpWebhookEvent && eventName != constants.UserDeletedWebhookEvent && eventName != constants.UserAccessEnabledWebhookEvent && eventName != constants.UserAccessRevokedWebhookEvent && eventName != constants.UserDeactivatedWebhookEvent {
-		return false
-	}
-
-	return true
+	return validWebhookEventNames[eventName]
 }

--- a/internal/validators/webhook_test.go
+++ b/internal/validators/webhook_test.go
@@ -1,0 +1,42 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+)
+
+// REGRESSION: IsValidWebhookEventName's allow-list was never updated when
+// PR #705 added the SCIM/group webhook events
+// (internal/constants/webhook_event_scim.go) - registering a webhook for
+// any of them was rejected as invalid, leaving the whole SCIM webhook
+// feature with no working configuration path.
+func TestIsValidWebhookEventName(t *testing.T) {
+	valid := []string{
+		constants.UserCreatedWebhookEvent,
+		constants.UserLoginWebhookEvent,
+		constants.UserSignUpWebhookEvent,
+		constants.UserDeletedWebhookEvent,
+		constants.UserAccessEnabledWebhookEvent,
+		constants.UserAccessRevokedWebhookEvent,
+		constants.UserDeactivatedWebhookEvent,
+		constants.UserProvisionedWebhookEvent,
+		constants.UserDeprovisionedWebhookEvent,
+		constants.UserScimUpdatedWebhookEvent,
+		constants.GroupCreatedWebhookEvent,
+		constants.GroupUpdatedWebhookEvent,
+		constants.GroupDeletedWebhookEvent,
+	}
+	for _, name := range valid {
+		if !IsValidWebhookEventName(name) {
+			t.Errorf("IsValidWebhookEventName(%q) = false, want true", name)
+		}
+	}
+
+	invalid := []string{"", "not.a.real.event", "user.created "}
+	for _, name := range invalid {
+		if IsValidWebhookEventName(name) {
+			t.Errorf("IsValidWebhookEventName(%q) = true, want false", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/validators/webhook.go`'s `IsValidWebhookEventName` allow-list was never updated when PR #705 added the SCIM/group webhook events (`user.provisioned`, `user.deprovisioned`, `user.scim_updated`, `group.created`, `group.updated`, `group.deleted` — `internal/constants/webhook_event_scim.go`)
- The SCIM service fires these events correctly, but an admin could never register a webhook for any of them — `_add_webhook` rejected every one as `"invalid event name"`, leaving the whole feature with no working configuration path since it shipped
- Rewritten as a map lookup rather than extending the existing 7-way `!=` chain to 13, which was already at the edge of readability

Found while extending e2e SCIM coverage for #705's provisioning webhooks — the test could not even register a webhook to observe delivery against, let alone verify it fired.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] New unit test `TestIsValidWebhookEventName` covering all 13 valid names + 3 invalid cases
- [x] Full `go test ./internal/...` (SQLite) clean, no regressions