### PR TITLE
fix(dashboard): add SCIM/group events to webhook event dropdown

### DIFF
--- a/web/dashboard/src/constants.ts
+++ b/web/dashboard/src/constants.ts
@@ -241,6 +241,12 @@ export const webhookEventNames = {
 	'User access enabled': 'user.access_enabled',
 	'User access revoked': 'user.access_revoked',
 	'User deactivated': 'user.deactivated',
+	'User provisioned': 'user.provisioned',
+	'User deprovisioned': 'user.deprovisioned',
+	'User SCIM updated': 'user.scim_updated',
+	'Group created': 'group.created',
+	'Group updated': 'group.updated',
+	'Group deleted': 'group.deleted',
 };
 
 export const emailTemplateEventNames = {


### PR DESCRIPTION
## Summary
- internal/validators/webhook.go (#722) allow-lists 6 new SCIM/group webhook events: user.provisioned, user.deprovisioned, user.scim_updated, group.created, group.updated, group.deleted
- web/dashboard/src/constants.ts's webhookEventNames was never updated to match, so the Add/Edit Webhook dropdown (UpdateWebhookModal.tsx) had no way to select any of them — backend accepted the events, dashboard couldn't configure them
- Adds the 6 missing entries, string values matching internal/constants/webhook_event_scim.go exactly

## Test plan
- [x] `npm run build` in web/dashboard passes
- [x] Values verified against internal/constants/webhook_event_scim.go and internal/validators/webhook.go's allow-list