### PR TITLE
chore(web/app): bump authorizer-react to 2.2.0-rc.3

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "2.2.0-rc.2",
+				"@authorizerdev/authorizer-react": "2.2.0-rc.3",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-js": {
-			"version": "3.3.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.3.tgz",
-			"integrity": "sha512-u2gs/srkiutn3j1DGPPiWEMkJj1G3lvHgAKVmo8ZzuOSrzU5hqHSrlSIrgQiuBEh6ozpGSnzsR251oz5FNJipA==",
+			"version": "3.3.0-rc.4",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.4.tgz",
+			"integrity": "sha512-OtI9bZOn5bLFPfMwXj0Eh9VOO04VEmoK3pr8vTsmb5ieejITRvFjMOm/tmCLTzIEE0uk0tToMAD3tkUSqGGBwQ==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-fetch": "^4.1.0"
@@ -43,12 +43,12 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
-			"version": "2.2.0-rc.2",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.2.tgz",
-			"integrity": "sha512-wYshbuLp2nQ0OC3vqpMKO5HLnZZNIJOjr4tJcT2R1IX0Rjukt9y8xPd/Ov2fhRlrgHw0et4O3T5MZqpSOVnC6Q==",
+			"version": "2.2.0-rc.3",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.3.tgz",
+			"integrity": "sha512-0WutAKhKYwlmeLJbgcfqEYm5e0mx9MREjUVAJQaZaJcN13Shp3jOn/yHQTayXJHaEsqnQyNHtz1noA1ondkjww==",
 			"license": "MIT",
 			"dependencies": {
-				"@authorizerdev/authorizer-js": "^3.3.0-rc.3",
+				"@authorizerdev/authorizer-js": "^3.3.0-rc.4",
 				"@storybook/preset-scss": "^1.0.3",
 				"validator": "^13.11.0"
 			},

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
 	"author": "Lakhan Samani",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@authorizerdev/authorizer-react": "2.2.0-rc.2",
+		"@authorizerdev/authorizer-react": "2.2.0-rc.3",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-is": "^18.3.1",


### PR DESCRIPTION
## Summary
- Bumps `@authorizerdev/authorizer-react` in web/app from 2.2.0-rc.2 to 2.2.0-rc.3.
- rc.3 picks up authorizer-js 3.3.0-rc.4 (this session's pagination fix + signup MFA-flag security fix — verified neither touches this package) and PR #67: real WebOTP auto-fill via `navigator.credentials.get()`, feature-detected and scoped to an actual SMS-OTP factor.

## Test plan
- [x] `npm run build` clean
- [x] `tsc --noEmit` clean
- [x] Full playground e2e browser suite against a rebuilt image running this dependency: oidc-provider, oidc-sso-rp, magic-link, webauthn, totp, sms-otp, web-otp, mfa-routing-matrix — 18/18 pass (1 pre-existing unrelated skip)