### PR TITLE
fix(web/app): wire hasSmsOtp so WebOTP auto-fill actually activates

### DIFF
--- a/web/app/src/Root.tsx
+++ b/web/app/src/Root.tsx
@@ -193,6 +193,7 @@ export default function Root({
 			<AuthorizerVerifyOtp
 				is_totp={mfaRedirect.mfaMethods.includes('totp')}
 				offerWebauthnVerify={mfaRedirect.mfaMethods.includes('webauthn')}
+				hasSmsOtp={mfaRedirect.mfaMethods.includes('sms_otp')}
 				hasCodeFactor={
 					mfaRedirect.mfaMethods.includes('totp') ||
 					mfaRedirect.mfaMethods.includes('email_otp') ||


### PR DESCRIPTION
## Summary
- authorizer-react 2.2.0-rc.3 (#725) added real WebOTP auto-fill (`navigator.credentials.get({otp:...})`) to `AuthorizerVerifyOtp`, gated behind a `hasSmsOtp` prop.
- `Root.tsx`'s mfa-redirect verify screen (the query-param-driven post-OAuth/magic-link continuation, distinct from the direct-login-triggered verify screen which `AuthorizerBasicAuthLogin.tsx` already wires internally) never passed it — the capability shipped but silently never activated for this flow.
- One-line fix: `hasSmsOtp={mfaRedirect.mfaMethods.includes('sms_otp')}`, matching the existing pattern for `is_totp`/`offerWebauthnVerify`/`hasCodeFactor` on the same component.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Verified end-to-end in e2e-playground with a mocked `navigator.credentials.get()` resolving the real SMS-sink code: input auto-fills, submit completes login (this exercises the sibling direct-login path, which was already correctly wired; this PR fixes the redirect path specifically)