### PR TITLE
chore(web/app): bump authorizer-react to 2.2.0-rc.4

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "2.2.0-rc.3",
+				"@authorizerdev/authorizer-react": "2.2.0-rc.4",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -43,9 +43,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
-			"version": "2.2.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.3.tgz",
-			"integrity": "sha512-0WutAKhKYwlmeLJbgcfqEYm5e0mx9MREjUVAJQaZaJcN13Shp3jOn/yHQTayXJHaEsqnQyNHtz1noA1ondkjww==",
+			"version": "2.2.0-rc.4",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.4.tgz",
+			"integrity": "sha512-eT69YX/PrQf5zOcF+6DKOEbTazGW55GFH7ZToe263N3s9aP+m96d44HgIVq4eHZVC0AnwxQA+WVkiTbW6O4kTQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@authorizerdev/authorizer-js": "^3.3.0-rc.4",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
 	"author": "Lakhan Samani",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@authorizerdev/authorizer-react": "2.2.0-rc.3",
+		"@authorizerdev/authorizer-react": "2.2.0-rc.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-is": "^18.3.1",


### PR DESCRIPTION
## Summary

- Bumps `web/app`'s `@authorizerdev/authorizer-react` dependency from `2.2.0-rc.3` to `2.2.0-rc.4`.
- Picks up the passkey-verify lockout fix from authorizer-react#70 (closes authorizer-react#69): `onVerifyWithPasskey` previously returned early on any GraphQL error before ever calling `resolveAuthStep`, making the locked-account branch unreachable dead code - a user whose account got MFA-locked during passkey verify saw a generic dismissable error instead of the intended full-screen `AuthorizerMfaLocked` lockout.

## Test plan

- `npm install` resolves `2.2.0-rc.4` (confirmed in `package-lock.json`).
- `npm run build` (vite) succeeds with no errors.
- `npx prettier --check` clean (no source changes, dependency bump only).
- The underlying fix has 7/7 passing Playwright e2e coverage in `authorizer-react`'s own suite (`example/e2e/`), including a new regression test for the fixed interaction, run against this exact published package version.