### PR TITLE
security(e2e): warn at startup when --env=e2e is set

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -421,6 +421,16 @@ func runRoot(c *cobra.Command, args []string) {
 		}
 	}
 
+	// Warn if --env=e2e is set — this relaxes SSRF protection (private/loopback-IP
+	// rejection) for the per-org SSO broker and webhook registration/delivery, and
+	// routes social-login OAuth and SMS sending to fixed e2e-playground mock
+	// addresses. It exists solely for e2e-playground/docker-compose.yml and must
+	// never be set on a real deployment; unlike production/staging, there is no
+	// other visible symptom if it is (see internal/constants/env.go's E2EEnv doc).
+	if rootArgs.config.Env == constants.E2EEnv {
+		log.Warn().Msg("running with --env=e2e: SSRF protection is relaxed for the SSO broker and webhooks, and OAuth/SMS are routed to e2e-playground mock addresses. This must never be set in a real deployment.")
+	}
+
 	// Initialize prometheus metrics
 	metrics.Init()
 


### PR DESCRIPTION
## Summary

Stacked on #729 — depends on `constants.E2EEnv`, which only exists on that branch. GitHub will auto-retarget this to `main` once #729 merges.

- Follow-up from the adversarial security review of #729's `--env=e2e` redesign: `--env` takes free text with zero validation, and `Env == E2EEnv` silently disables SSRF protection (private/loopback-IP rejection) for the per-org SSO broker and webhook registration/delivery, and routes OAuth/SMS to fixed e2e-playground mock addresses.
- The 13 flags this replaced (`--test-allow-private-sso-hosts=true`, etc.) were self-documenting as dangerous by name. A bare `--env=e2e` is not — it reads like an ordinary environment label and could be copy-pasted from `e2e-playground/docker-compose.yml` into a real deployment with no runtime signal.
- Adds a `log.Warn()` at startup when `Env == constants.E2EEnv`, mirroring the existing `AllowedOrigins` wildcard warning already in `cmd/root.go` right above it.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l cmd/root.go`: clean.
- `go test ./cmd/...`: passing (no existing test covers the sibling `AllowedOrigins` warning either, so no new test was added for this one-line, same-shaped conditional — matches existing convention in this function).