### PR TITLE
security(deps): bump google.golang.org/grpc to v1.82.1 (GO-2026-6061)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/mail.v2 v2.3.1
 	gorm.io/driver/mysql v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -725,8 +725,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=


### PR DESCRIPTION
## Summary
- `google.golang.org/grpc@v1.81.1` is affected by GO-2026-6061 (xDS RBAC authorization engine + HTTP/2 transport server vulnerabilities). govulncheck confirms this repo's own code reaches the affected transport paths via `internal/grpcsrv/server.go`, `internal/gateway/mount.go`, `internal/metrics/metrics.go`, and the generated admin gRPC client.
- Fresh advisory disclosure, not caused by any pending PR — #733's `govulncheck` run passed on this identical grpc version hours before this run failed on the same dependency.
- `2.4.0-rc.11` (published from `main` before this advisory surfaced) ships the vulnerable version. This should be merged and a superseding RC cut once in.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `govulncheck ./...` — 0 vulnerabilities (was 1 reachable)
- [x] `make lint` — 0 issues
- [x] `make test` (SQLite) — 0 failures
- [x] `make smoke` — all pass, including gRPC-specific subtests