### PR TITLE
chore(web/app): bump authorizer-react to 2.2.0-rc.5

### DIFF
--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@authorizerdev/authorizer-react": "2.2.0-rc.4",
+				"@authorizerdev/authorizer-react": "2.2.0-rc.5",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-is": "^18.3.1",
@@ -43,9 +43,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-react": {
-			"version": "2.2.0-rc.4",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.4.tgz",
-			"integrity": "sha512-eT69YX/PrQf5zOcF+6DKOEbTazGW55GFH7ZToe263N3s9aP+m96d44HgIVq4eHZVC0AnwxQA+WVkiTbW6O4kTQ==",
+			"version": "2.2.0-rc.5",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-react/-/authorizer-react-2.2.0-rc.5.tgz",
+			"integrity": "sha512-xcGEMJHqFzZMIKvVGl/BLj1ObiSraUlIb2gN+5C/te3EkUQ0ZOlbqxsb+lk2BSI/FJC5mPoqLgOA9JiiY3I7CQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@authorizerdev/authorizer-js": "^3.3.0-rc.4",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
 	"author": "Lakhan Samani",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@authorizerdev/authorizer-react": "2.2.0-rc.4",
+		"@authorizerdev/authorizer-react": "2.2.0-rc.5",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-is": "^18.3.1",


### PR DESCRIPTION
## Summary
- Bumps `@authorizerdev/authorizer-react` to 2.2.0-rc.5, which includes the fix for the misleading "Back" button on the post-signup MFA-setup screen (authorizer-react#71) — it previously routed users into a signup form pre-filled with the email they'd just used, guaranteeing a duplicate-email error on resubmit. "Skip for now" remains the correct escape hatch.

## Test plan
- [x] `npm run build` (web/app) — clean