### PR TITLE
fix(security): make single-use token primitives atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ e2e-playground: ## Run the live-playground e2e suite (OIDC/SAML/SCIM/SSO/OAuth/M
 	docker compose -f e2e-playground/docker-compose.yml up -d --wait authorizer authorizer-sso mock-oauth mock-saml-idp mailpit sms-sink; \
 	status=$$?; \
 	if [ $$status -eq 0 ]; then \
-		docker compose -f e2e-playground/docker-compose.yml run --rm playwright npx playwright test; \
+		docker compose -f e2e-playground/docker-compose.yml run --rm --build playwright npx playwright test; \
 		status=$$?; \
 	fi; \
 	docker compose -f e2e-playground/docker-compose.yml down -v; \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -451,6 +451,26 @@ func runRoot(c *cobra.Command, args []string) {
 	// the legacy header-based derivation.
 	parsers.SetTrustedURL(rootArgs.config.AuthorizerURL)
 	parsers.SetLogger(&log)
+	if strings.TrimSpace(rootArgs.config.AuthorizerURL) == "" {
+		// GHSA-m82j-rq33-qjx2 (CWE-640, CVSS 8.1). With --url unset, the base URL
+		// for emailed reset/verification/magic links and the JWT `iss` is derived
+		// from request headers (X-Authorizer-URL, X-Forwarded-Host, Host). An
+		// unauthenticated attacker can therefore poison the reset link sent to a
+		// victim, and — because redemption re-validates `iss` against the SAME
+		// request-derived host — replay the identical spoofed header to redeem the
+		// stolen token. The attacker controls both sides of that comparison, so it
+		// is no boundary at all.
+		//
+		// Warned, not fatal: refusing to boot would break every existing
+		// deployment on upgrade. Making --url mandatory is the real fix and is a
+		// deliberate follow-up, so this must be loud enough that nobody reaches
+		// production without seeing it.
+		log.Warn().
+			Str("advisory", "GHSA-m82j-rq33-qjx2").
+			Str("cwe", "CWE-640").
+			Str("fix", "start Authorizer with --url=https://your-authorizer-host").
+			Msg("SECURITY: --url is not set. Password-reset, email-verification and magic-link URLs will be built from attacker-controllable request headers (Host / X-Forwarded-Host / X-Authorizer-URL), allowing reset-link poisoning and account takeover. Set --url to your canonical base URL in any deployment that sends email.")
+	}
 
 	// Storage provider
 	storageProvider, err := storage.New(&rootArgs.config, &storage.Dependencies{

--- a/e2e-playground/docker-compose.yml
+++ b/e2e-playground/docker-compose.yml
@@ -359,6 +359,142 @@ services:
       timeout: 2s
       retries: 30
 
+  # ---------------------------------------------------------------------------
+  # Replica pair: TWO authorizer instances sharing ONE database.
+  #
+  # Every other service in this file is a differently-CONFIGURED single instance
+  # with its own private SQLite file, so no two of them ever share state. That
+  # topology cannot express "does replica B observe what replica A wrote?" — and
+  # a whole class of defect only exists in that gap: state a deployment believes
+  # is shared but that is actually per-process is invisible to every
+  # single-instance test, while silently breaking replay defence and lockout
+  # counters in any horizontally-scaled deployment. See
+  # tests/replica-shared-state.spec.ts.
+  #
+  # Postgres, not a shared SQLite file: two containers writing one SQLite file
+  # over a volume depends on file-locking behaviour that varies by volume driver
+  # and is a known source of CI flake. Postgres is also what a real multi-replica
+  # deployment would use, so the test exercises a realistic configuration.
+  #
+  # Deliberately NO redis: with REDIS_URL set, shared state goes through the
+  # Redis provider, which was always correct. Omitting it is what puts the
+  # database-backed store — the one New() selects for exactly this kind of
+  # deployment — under test.
+  replica-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: e2e
+      POSTGRES_USER: e2e
+      POSTGRES_DB: e2e
+    healthcheck:
+      # -h 127.0.0.1 forces the check over TCP. Without it pg_isready talks to
+      # the unix socket, which the entrypoint's TEMPORARY initdb server already
+      # answers before the real server is listening on TCP — so the container
+      # reports healthy, the replicas start, and both die with "connection
+      # refused" on 5432. Checking the same transport the clients use is what
+      # makes the gate meaningful.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U e2e -d e2e"]
+      interval: 2s
+      timeout: 3s
+      retries: 40
+      start_period: 5s
+
+  authorizer-replica-a: &replica
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    # No `ports:` on either replica, unlike every other service here. They are
+    # driven only from INSIDE the compose network (the playwright container
+    # resolves authorizer-replica-a/-b by service name), so publishing host
+    # ports would buy nothing and only add a host-port collision surface —
+    # which is exactly what it did: a lingering bind from a previous stack's
+    # teardown failed the whole run with "Bind for 0.0.0.0:8085 failed: port is
+    # already allocated" before a single test executed. To reach them from the
+    # host for debugging, add a temporary ports mapping locally.
+    command:
+      # --url is the shared PUBLIC address both replicas issue tokens for (the
+      # `iss` claim), exactly as they would sit behind one load balancer. It
+      # intentionally does NOT name either container: a token minted by A must
+      # be indistinguishable from one minted by B.
+      - "--http-port=8080"
+      - "--url=http://authorizer-replica-a:8080"
+      - "--database-type=postgres"
+      - "--database-url=postgres://e2e:e2e@replica-db:5432/e2e?sslmode=disable"
+      - "--admin-secret=e2e-admin-secret"
+      - "--jwt-type=HS256"
+      - "--jwt-secret=e2e-jwt-secret-do-not-use-in-prod"
+      - "--client-id=e2e-client-id"
+      - "--client-secret=e2e-client-secret"
+      - "--enable-signup=true"
+      - "--app-cookie-secure=false"
+      - "--admin-cookie-secure=false"
+      - "--app-cookie-same-site=lax"
+      - "--allowed-origins=http://localhost:8085,http://localhost:8086,http://authorizer-replica-a:8080,http://authorizer-replica-b:8080"
+      - "--env=e2e"
+      - "--smtp-host=mailpit"
+      - "--smtp-port=1025"
+      - "--rate-limit-rps=1000"
+      - "--rate-limit-burst=1000"
+    depends_on:
+      replica-db: { condition: service_healthy }
+      mailpit: { condition: service_started }
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  # Identical to replica-a (YAML anchor) apart from its published port and its
+  # own --url. Same database, same JWT secret, same client — a second replica of
+  # one logical deployment, not a second deployment.
+  authorizer-replica-b:
+    <<: *replica
+    # Overrides the anchor's depends_on to wait for replica-a to be HEALTHY, not
+    # merely for the database.
+    #
+    # This is a workaround for a real product defect, recorded here rather than
+    # silently absorbed: two Authorizer instances starting at the same time
+    # against a FRESH shared database both run GORM AutoMigrate concurrently and
+    # one dies outright —
+    #
+    #   CREATE TABLE "authorizer_users" ...
+    #   ERROR: duplicate key value violates unique constraint
+    #          "pg_type_typname_nsp_index" (SQLSTATE 23505)
+    #   {"level":"fatal","message":"failed to create storage provider"}
+    #
+    # i.e. startup migration is not concurrency-safe, so a fresh deployment
+    # scaled to N replicas crash-loops until one wins the race. Under an
+    # orchestrator it self-heals via restarts, which is likely why it has gone
+    # unnoticed. Serializing startup here keeps THIS suite deterministic and
+    # focused on what it exists to test (cross-replica cache coherence); it does
+    # not fix the underlying defect. Remove this override once migration is made
+    # concurrency-safe (advisory lock or migrate-then-serve), and the race
+    # becomes testable here directly.
+    depends_on:
+      replica-db: { condition: service_healthy }
+      mailpit: { condition: service_started }
+      authorizer-replica-a: { condition: service_healthy }
+    command:
+      - "--http-port=8080"
+      - "--url=http://authorizer-replica-b:8080"
+      - "--database-type=postgres"
+      - "--database-url=postgres://e2e:e2e@replica-db:5432/e2e?sslmode=disable"
+      - "--admin-secret=e2e-admin-secret"
+      - "--jwt-type=HS256"
+      - "--jwt-secret=e2e-jwt-secret-do-not-use-in-prod"
+      - "--client-id=e2e-client-id"
+      - "--client-secret=e2e-client-secret"
+      - "--enable-signup=true"
+      - "--app-cookie-secure=false"
+      - "--admin-cookie-secure=false"
+      - "--app-cookie-same-site=lax"
+      - "--allowed-origins=http://localhost:8085,http://localhost:8086,http://authorizer-replica-a:8080,http://authorizer-replica-b:8080"
+      - "--env=e2e"
+      - "--smtp-host=mailpit"
+      - "--smtp-port=1025"
+      - "--rate-limit-rps=1000"
+      - "--rate-limit-burst=1000"
+
   mock-oauth:
     build: ./mocks/mock-oauth
     ports: ["4000:4000"]
@@ -396,6 +532,10 @@ services:
       AUTHORIZER_MAGIC_LINK_BASE_URL: http://authorizer-magic-link:8080
       AUTHORIZER_MFA_ENFORCED_BASE_URL: http://authorizer-mfa-enforced:8080
       AUTHORIZER_MFA_MAGIC_LINK_BASE_URL: http://authorizer-mfa-magic-link:8080
+      # Two replicas of ONE deployment over a shared Postgres — see the
+      # authorizer-replica-a service comment.
+      AUTHORIZER_REPLICA_A_BASE_URL: http://authorizer-replica-a:8080
+      AUTHORIZER_REPLICA_B_BASE_URL: http://authorizer-replica-b:8080
       MOCK_OAUTH_BASE_URL: http://mock-oauth:4000
       # https, not http: mock-saml-idp terminates TLS (see its server.ts) so
       # Authorizer's idp_sso_url validation (https-only, no test bypass)
@@ -415,6 +555,8 @@ services:
       authorizer-magic-link: { condition: service_healthy }
       authorizer-mfa-enforced: { condition: service_healthy }
       authorizer-mfa-magic-link: { condition: service_healthy }
+      authorizer-replica-a: { condition: service_healthy }
+      authorizer-replica-b: { condition: service_healthy }
       mock-oauth: { condition: service_started }
       mock-saml-idp: { condition: service_started }
       mailpit: { condition: service_started }

--- a/e2e-playground/playwright.config.ts
+++ b/e2e-playground/playwright.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
         /sso-discovery\.spec\.ts/,
         /webauthn\.spec\.ts/,
         /magic-link\.spec\.ts/,
+        // Drives authorizer-replica-a/-b directly by absolute URL rather than
+        // this project's baseURL; see the `replica` project below.
+        /replica-shared-state\.spec\.ts/,
         '**/mocks/**',
         '**/node_modules/**',
       ],
@@ -80,6 +83,21 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         baseURL: process.env.AUTHORIZER_MAGIC_LINK_BASE_URL || 'http://localhost:8083',
+      },
+    },
+    {
+      // Runs against authorizer-replica-a AND authorizer-replica-b — two
+      // replicas of ONE deployment sharing a Postgres (docker-compose.yml).
+      // Unlike every other project this one is not about a distinct
+      // CONFIGURATION; it is the only place two instances share state at all,
+      // which is what makes cross-replica coherence testable. The spec targets
+      // both replicas by absolute URL, so baseURL here is only a default for
+      // the fixture and the spec never relies on it.
+      name: 'replica',
+      testMatch: /replica-shared-state\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: process.env.AUTHORIZER_REPLICA_A_BASE_URL || 'http://authorizer-replica-a:8080',
       },
     },
   ],

--- a/internal/http_handlers/oauth_authorize_state_test.go
+++ b/internal/http_handlers/oauth_authorize_state_test.go
@@ -216,6 +216,10 @@ func (f *fakeMemoryStore) SetUserSession(userId, key, token string, expiration i
 	return nil
 }
 func (f *fakeMemoryStore) GetUserSession(userId, key string) (string, error) { return "", nil }
+func (f *fakeMemoryStore) ClaimRefreshToken(userId, nonce string) (bool, error) {
+	return true, nil
+}
+
 func (f *fakeMemoryStore) DeleteUserSession(userId, key string) error {
 	f.deletedSessions = append(f.deletedSessions, [2]string{userId, key})
 	return nil

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -288,7 +288,34 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 		// RFC 6749 §4.4 client_credentials: machine identity. The resolver has
 		// already authenticated the service_account; issue its scoped token here.
 		if isClientCredentialsGrant {
-			h.handleClientCredentialsGrant(gc, resolvedClient, scopeParam)
+			// RFC 8707: an optional single `resource` binds the machine token to
+			// one resource server (it becomes the `aud`). PostFormArray (not
+			// Request.PostForm, which is only populated as a side effect of an
+			// earlier bind) returns every repeated value, so a repeated parameter
+			// is rejected rather than silently taking the first — same accessor
+			// and same shape as the token-exchange path.
+			ccResources := gc.PostFormArray("resource")
+			if len(ccResources) > 1 {
+				log.Debug().Str("client_id", resolvedClient.ClientID).Msg("rejected: repeated resource parameter")
+				gc.JSON(http.StatusBadRequest, gin.H{
+					"error":             "invalid_target",
+					"error_description": "only one resource parameter is supported",
+				})
+				return
+			}
+			ccResource := ""
+			if len(ccResources) == 1 {
+				ccResource = strings.TrimSpace(ccResources[0])
+			}
+			if ccResource != "" && !isValidResourceIndicator(ccResource) {
+				log.Debug().Str("client_id", resolvedClient.ClientID).Str("resource", ccResource).Msg("rejected: invalid resource indicator")
+				gc.JSON(http.StatusBadRequest, gin.H{
+					"error":             "invalid_target",
+					"error_description": "resource must be an absolute URI without a fragment",
+				})
+				return
+			}
+			h.handleClientCredentialsGrant(gc, resolvedClient, scopeParam, ccResource)
 			return
 		}
 
@@ -656,7 +683,62 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			// match resolvedClient.ClientID) — a token issued to one client
 			// is rejected before reaching this point if presented by another.
 
-			// remove older refresh token and rotate it for security
+			// Consume the presented refresh token BEFORE issuing its replacement,
+			// and proceed only if this request is the one that consumed it.
+			//
+			// ValidateRefreshToken above only READ the entry. Two concurrent
+			// redemptions of the same token both pass that read, so without an
+			// atomic claim here both would mint an independent, separately-rotating
+			// token family from one refresh token — defeating rotation and its
+			// OAuth 2.1 §6.1 reuse detection outright. ClaimRefreshToken decides
+			// the race in a single storage operation; the loser is rejected with
+			// the same opaque invalid_grant a replay gets, so it is no oracle.
+			//
+			// Distinct from the refreshReuseGraceWindow below: that tolerates a
+			// SEQUENTIAL double-submit (multi-tab retry) by declining to revoke the
+			// family, but still refuses the second request. This is the concurrent
+			// case, where both requests are in flight at once.
+			// FAULT TOLERANCE, two deliberate choices here:
+			//
+			// (a) A claim ERROR aborts with a retryable 503 rather than continuing.
+			// The previous code only logged a failed delete and issued the token
+			// anyway, which was more available but meant an unverifiable single-use
+			// gate silently became no gate at all. Failing closed on a gate whose
+			// outcome is unknown is the correct direction; 503 +
+			// temporarily_unavailable (not invalid_grant) tells a well-behaved
+			// client this is worth retrying and does not falsely brand the token
+			// as permanently bad.
+			//
+			// (b) Claiming BEFORE minting means a failure later in this handler
+			// (user lookup, signing, or persisting the new tokens) leaves the old
+			// refresh token already consumed and no replacement issued — the client
+			// must re-authenticate. That window is pre-existing (the delete sat at
+			// exactly this point before) and is inherent to rotation: minting first
+			// would let two concurrent requests both mint before either claimed,
+			// which is the very defect this closes. A rare forced re-auth is the
+			// right trade against handing one refresh token to two holders.
+			claimed, claimErr := h.MemoryStoreProvider.ClaimRefreshToken(sessionKey, nonce)
+			if claimErr != nil {
+				log.Debug().Err(claimErr).Str("session_key", sessionKey).Msg("Failed to claim refresh token during rotation")
+				gc.JSON(http.StatusServiceUnavailable, gin.H{
+					"error":             "temporarily_unavailable",
+					"error_description": "Could not complete token issuance",
+				})
+				return
+			}
+			if !claimed {
+				// Another request consumed this refresh token first.
+				metrics.RecordSecurityEvent("refresh_token_concurrent_redemption", "token_endpoint")
+				log.Debug().Str("session_key", sessionKey).Msg("refresh token already consumed by a concurrent request")
+				gc.JSON(http.StatusBadRequest, gin.H{
+					"error":             "invalid_grant",
+					"error_description": "The refresh token is invalid or has expired",
+				})
+				return
+			}
+
+			// The refresh entry is now gone; clear the session/access entries that
+			// shared its nonce so the old fingerprint is fully retired.
 			if err := h.MemoryStoreProvider.DeleteUserSession(sessionKey, nonce); err != nil {
 				log.Debug().Err(err).Str("session_key", sessionKey).Msg("Failed to delete old session during token refresh")
 			}
@@ -695,6 +777,33 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			})
 			return
 		}
+		// KNOWN GAP — stale roles on refresh (privilege revocation).
+		//
+		// `roles` is carried forward from the presented refresh token's claims and
+		// is NOT re-derived here, so a role an admin strips from a user keeps
+		// being minted into every rotated access token. Because rotation extends
+		// the lineage indefinitely, that revocation never takes effect for a
+		// client that keeps refreshing. The token is also internally inconsistent:
+		// `allowed_roles` is read from the live user record at signing time while
+		// `roles` is the stale carried set.
+		//
+		// Do NOT "fix" this by intersecting `roles` with user.Roles. That looks
+		// right and is wrong: oauth_sso.go and saml_sp.go build a session's roles
+		// as unionRoles(splitRoles(user.Roles), orgGroupDerivedRoles(...)), where
+		// the derived half comes from the FGA engine and is never written to the
+		// user record. Intersecting against user.Roles therefore silently strips
+		// every org-group-derived role on the first refresh, and for a
+		// SCIM-provisioned user — created with no Roles field at all, see
+		// service/scim CreateUser — it strips ALL of them and the grant is
+		// rejected outright. That breaks exactly the enterprise SSO/SCIM
+		// deployments this matters most to. (Verified: intersecting
+		// ["user","org_admin"] against "user" yields ["user"].)
+		//
+		// The correct fix is to re-derive the EFFECTIVE role set at refresh the
+		// same way login does — user record ∪ current group-derived roles — which
+		// needs the org context available at this point (the refresh token carries
+		// no org claim today) plus an FGA lookup. That is a design change, not a
+		// patch, and is deliberately left undone rather than half-done.
 		hostname := parsers.GetHost(gc)
 		nonce := uuid.New().String()
 		authToken, err := h.TokenProvider.CreateAuthToken(gc, &token.AuthTokenConfig{
@@ -910,7 +1019,7 @@ func (h *httpProvider) respondClientAuthError(gc *gin.Context, err error, resolv
 // stateful access token scoped to a subset of the account's allowed scopes. No
 // id_token and no refresh_token are issued — machines re-authenticate on expiry
 // (RFC 6749 §4.4.3).
-func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, sa *schemas.Client, scope string) {
+func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, sa *schemas.Client, scope, resource string) {
 	log := h.Log.With().Str("func", "handleClientCredentialsGrant").Logger()
 
 	// Scope handling (RFC 6749 §3.3 / §5.2). An empty AllowedScopes is DENY-ALL
@@ -962,15 +1071,17 @@ func (h *httpProvider) handleClientCredentialsGrant(gc *gin.Context, sa *schemas
 	// reconstructs this exact key from the token's login_method + sub claims.
 	sessionKey := constants.AuthRecipeMethodServiceAccount + ":" + sa.ID
 
-	// ponytail: aud is the global ClientID, same as human tokens. RFC 8707
-	// resource-bound audience binding (spec S8) is deliberately deferred to
-	// the Phase 2 token-exchange work, not silently forgotten.
+	// RFC 8707 audience binding: when the caller supplied a `resource` it becomes
+	// the token's `aud`, restricting it to that one resource server. Validated by
+	// the caller as an absolute URI. When omitted the audience stays the
+	// deployment's global client ID (previous behavior).
 	authToken, err := h.TokenProvider.CreateMachineAuthToken(&token.AuthTokenConfig{
 		ServiceAccountID: sa.ID,
 		Scope:            grantedScopes,
 		Nonce:            nonce,
 		LoginMethod:      constants.AuthRecipeMethodServiceAccount,
 		HostName:         hostname,
+		Resource:         resource,
 	})
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to create machine access token")

--- a/internal/http_handlers/token_exchange.go
+++ b/internal/http_handlers/token_exchange.go
@@ -74,6 +74,19 @@ func (h *httpProvider) handleTokenExchangeGrant(gc *gin.Context, agent *schemas.
 		return
 	}
 	resource := strings.TrimSpace(resources[0])
+	// RFC 8707 §2: the resource indicator MUST be an absolute URI without a
+	// fragment. /authorize enforced this from the start; without the same check
+	// here an agent could bind a delegated token's `aud` to an arbitrary opaque
+	// string, which makes the audience restriction unenforceable at the resource
+	// server. Same helper, same rejection, so the two paths cannot drift.
+	if !isValidResourceIndicator(resource) {
+		log.Debug().Str("client_id", agent.ClientID).Str("resource", resource).Msg("rejected: invalid resource indicator")
+		gc.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_target",
+			"error_description": "resource must be an absolute URI without a fragment",
+		})
+		return
+	}
 
 	hostname := parsers.GetHost(gc)
 

--- a/internal/integration_tests/token_grant_hardening_test.go
+++ b/internal/integration_tests/token_grant_hardening_test.go
@@ -1,0 +1,145 @@
+package integration_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/constants"
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	"github.com/authorizerdev/authorizer/internal/token"
+)
+
+// TestClientCredentialsAudienceBinding covers RFC 8707 audience binding on the
+// client_credentials grant.
+//
+// Without it every service-account token in a deployment carries the same `aud`
+// (the deployment's global client_id), so a token minted for one internal
+// service is equally valid at every other — the resource server loses the
+// cheapest rejection it has. Auth0 makes `audience` mandatory on this grant and
+// Keycloak binds it via audience mappers; this is the equivalent.
+func TestClientCredentialsAudienceBinding(t *testing.T) {
+	ts := initTestSetup(t, getTestConfig())
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	saID, saSecret := newDelegationAgent(t, ts, "read:orders")
+
+	get := func(f url.Values) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(f.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Authorizer-URL", testAuthorizerHost(ts))
+		req.SetBasicAuth(saID, saSecret)
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("resource binds the token audience", func(t *testing.T) {
+		f := url.Values{}
+		f.Set("grant_type", "client_credentials")
+		f.Set("resource", "https://orders.internal")
+		w := get(f)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var res map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		claims := decodeJWTPayload(t, res["access_token"].(string))
+		assert.Equal(t, "https://orders.internal", claims["aud"],
+			"the requested resource must become the token audience")
+	})
+
+	t.Run("omitting resource preserves the previous global audience", func(t *testing.T) {
+		f := url.Values{}
+		f.Set("grant_type", "client_credentials")
+		w := get(f)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var res map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		claims := decodeJWTPayload(t, res["access_token"].(string))
+		assert.Equal(t, ts.Config.ClientID, claims["aud"],
+			"backward compatibility: no resource means the deployment client_id stays the audience")
+	})
+
+	t.Run("rejects a non-absolute-URI resource", func(t *testing.T) {
+		for _, bad := range []string{"not-a-uri", "https://rs.example.com#frag", "../../etc"} {
+			f := url.Values{}
+			f.Set("grant_type", "client_credentials")
+			f.Set("resource", bad)
+			w := get(f)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "resource %q must be rejected", bad)
+			assert.Contains(t, w.Body.String(), "invalid_target")
+		}
+	})
+
+	t.Run("rejects a repeated resource parameter", func(t *testing.T) {
+		body := "grant_type=client_credentials&resource=https%3A%2F%2Fa.example.com&resource=https%3A%2F%2Fb.example.com"
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Authorizer-URL", testAuthorizerHost(ts))
+		req.SetBasicAuth(saID, saSecret)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code,
+			"a multi-audience machine token would be replayable across resource servers")
+	})
+}
+
+// TestTokenExchangeRejectsInvalidResourceIndicator pins RFC 8707 §2 on the
+// token-exchange grant. /authorize enforced this from the start; the exchange
+// path did not, so an agent could bind a delegated token's `aud` to an arbitrary
+// opaque string and make the audience restriction unenforceable downstream.
+func TestTokenExchangeRejectsInvalidResourceIndicator(t *testing.T) {
+	ts := initTestSetup(t, getTestConfig())
+	router := gin.New()
+	router.POST("/oauth/token", ts.HttpProvider.TokenHandler())
+
+	_, ctx := createContext(ts)
+	email := "res_ind_" + uuid.New().String() + "@authorizer.dev"
+	_, err := ts.GraphQLProvider.SignUp(ctx, &model.SignUpRequest{
+		Email: &email, Password: "Password@123", ConfirmPassword: "Password@123",
+	})
+	require.NoError(t, err)
+	user, err := ts.StorageProvider.GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	subjectTok, err := ts.TokenProvider.CreateAuthToken(nil, &token.AuthTokenConfig{
+		User: user, Roles: []string{"user"}, Scope: []string{"openid"},
+		LoginMethod: constants.AuthRecipeMethodBasicAuth,
+		Nonce:       uuid.New().String(), HostName: testAuthorizerHost(ts),
+	})
+	require.NoError(t, err)
+
+	agentID, agentSecret := newDelegationAgent(t, ts, "openid")
+	actorTok := agentAccessToken(t, ts, router, agentID, agentSecret)
+
+	mk := func(resource string) url.Values {
+		f := url.Values{}
+		f.Set("grant_type", tokenExchangeGrant)
+		f.Set("subject_token", subjectTok.AccessToken.Token)
+		f.Set("subject_token_type", accessTokenType)
+		f.Set("actor_token", actorTok)
+		f.Set("actor_token_type", accessTokenType)
+		f.Set("resource", resource)
+		return f
+	}
+
+	for _, bad := range []string{"not-a-uri", "https://rs.example.com#frag", "../../etc"} {
+		w := postTokenExchange(ts, router, mk(bad), agentID, agentSecret)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "resource %q must be rejected", bad)
+		assert.Contains(t, w.Body.String(), "invalid_target")
+	}
+
+	// A valid absolute URI still works — the check must not break the happy path.
+	w := postTokenExchange(ts, router, mk("https://mcp.example.com/v1"), agentID, agentSecret)
+	assert.Equal(t, http.StatusOK, w.Code, "a valid resource indicator must still be accepted: %s", w.Body.String())
+}

--- a/internal/memory_store/db/cache.go
+++ b/internal/memory_store/db/cache.go
@@ -1,88 +1,212 @@
 package db
 
 import (
+	"context"
+	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/authorizerdev/authorizer/internal/storage/schemas"
 )
 
-// cacheEntry holds a cached value with its expiration time.
-type cacheEntry struct {
-	Value     string
-	ExpiresAt int64
-}
-
-// cacheStore is a simple in-memory cache used by the DB-backed memory store provider.
-// The DB provider delegates session/state storage to the database, but cache
-// entries are kept in-memory for performance since they are short-lived and
-// tolerant of loss on restart.
-var (
-	cache      = make(map[string]*cacheEntry)
-	cacheMutex sync.RWMutex
+// The DB-backed memory store exists so a multi-instance deployment gets SHARED
+// state without requiring Redis. Its cache must therefore live in the database
+// too, not in the process.
+//
+// A process-local cache silently breaks the security controls layered on these
+// methods, because each replica keeps its own view:
+//   - SAML assertion single-use (http_handlers/saml_sp.go) — an assertion
+//     consumed on replica A is unseen by replica B, so a replay against a
+//     different replica succeeds for the assertion's whole NotOnOrAfter window.
+//   - RFC 7523 client-assertion jti replay (service/clientauth) — same.
+//   - TOTP/OTP lockout counters (service/verify_otp.go) — counts never
+//     aggregate, so N replicas grant N x the configured attempts.
+//   - TOTP pending secrets and org-domain challenges — written on the replica
+//     that starts the flow, missing on the one that finishes it.
+//
+// STORAGE: entries reuse the existing authorizer_session_tokens table, under a
+// reserved user_id namespace (cacheNamespace), with the cache key as key_name
+// and the value as token. That table is the right home for three concrete
+// reasons, none of which the oauth_states table offers:
+//
+//   - A composite index on (user_id, key_name) — so every get/set/delete is an
+//     indexed point lookup, not a scan.
+//   - A real expires_at column, indexed. No expiry encoded into the value.
+//   - An EXISTING reaper, CleanExpiredSessionTokens, already invoked on the
+//     SetUserSession/GetUserSession paths, so expired cache rows are collected
+//     without adding a sweeper. There is no equivalent for oauth_states — that
+//     table has no reaper at all and grows unboundedly, which would have made
+//     any scan over it progressively worse forever.
+//
+// Namespace safety: cacheNamespace can never collide with a real session's
+// user_id, which is either a bare UUID or "<loginMethod>:<uuid>". It contains no
+// ":" so DeleteSessionTokensByNamespace (prefix "<ns>:") cannot match it, and
+// DeleteAllSessionTokensByUserID's substring match is driven by UUIDs, which are
+// never a substring of this literal.
+const (
+	// cacheNamespace is the reserved user_id under which every cache row lives.
+	cacheNamespace = "__authorizer_cache__"
 )
 
-// SetCache stores a key-value pair with a TTL in seconds.
+// incrementMutex serializes this process's read-modify-write in IncrementCache.
+// It does NOT make the increment atomic across instances — see IncrementCache.
+var incrementMutex sync.Mutex
+
+// SetCache stores a key-value pair with a TTL in seconds, shared across every
+// instance backed by the same database.
+//
+// FAULT TOLERANCE — this is delete-then-insert, not an atomic upsert, because
+// the storage layer exposes no upsert (SetUserSession uses the same two-step).
+// So there is a window where the delete succeeds and the insert fails, leaving
+// the key ABSENT rather than at either its old or new value. For a lockout
+// counter that reads as a reset, which hands back attempts. Redis does not have
+// this window (a single SET) and neither did the process-local map.
+//
+// It is survivable rather than fixed because the error is returned and every
+// caller already treats a memory-store fault as fail-open by explicit design
+// (verify_otp.go: "a memory-store fault must not be counted as a user failure
+// or block a legitimate user"). A flapping database therefore loosens the
+// lockout instead of locking out legitimate users — the deliberate direction,
+// but worth knowing it is a real degradation and not merely theoretical. An
+// atomic upsert in the storage layer closes it.
 func (p *provider) SetCache(key string, value string, ttlSeconds int64) error {
-	cacheMutex.Lock()
-	defer cacheMutex.Unlock()
-	cache[key] = &cacheEntry{
-		Value:     value,
-		ExpiresAt: time.Now().Unix() + ttlSeconds,
+	ctx := context.Background()
+	now := time.Now().Unix()
+
+	// Overwrite semantics: drop any existing row first. Whether one was actually
+	// removed is irrelevant — this is a write, not a single-use claim.
+	if err := p.deleteSessionTokenByUserIDAndKey(ctx, cacheNamespace, key); err != nil {
+		p.dependencies.Log.Debug().Err(err).Msg("Error clearing existing cache entry")
+		// Continue anyway — the add below is what must succeed.
+	}
+
+	entry := &schemas.SessionToken{
+		ID:        uuid.New().String(),
+		UserID:    cacheNamespace,
+		KeyName:   key,
+		Token:     value,
+		ExpiresAt: now + ttlSeconds,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	entry.Key = entry.ID
+	if err := p.addSessionToken(ctx, entry); err != nil {
+		return fmt.Errorf("error setting cache: %w", err)
 	}
 	return nil
 }
 
-// GetCache retrieves a cached value by key.
-// Returns empty string and nil error if the key is not found or expired.
+// GetCache retrieves a cached value by key. Returns an empty string and a nil
+// error when the key is absent or expired (a miss is not an error), matching the
+// Redis and in-memory providers.
+//
+// FAULT TOLERANCE — this returns a MISS, not an error, when the database read
+// fails, and that is a fail-OPEN for the replay defences built on it: a store
+// outage makes an already-consumed SAML assertion or client-assertion jti look
+// unseen, so it is accepted again. Two constraints force it:
+//
+//   - The storage layer cannot distinguish "no such row" from "read failed" —
+//     GetSessionTokenByUserIDAndKey returns a plain error for both, and each of
+//     the 7 providers returns a different one (gorm.ErrRecordNotFound,
+//     gocql.ErrNotFound, a bare errors.New, a gocb error...). Propagating the
+//     error would turn every ordinary cache miss into a failure.
+//   - Both replay callers already discard it: saml_sp.go only reports a replay
+//     when err == nil, and clientauth drops the error entirely. So returning it
+//     would not currently change their behaviour.
+//
+// The fault is logged at DEBUG, deliberately not Warn: because a miss and a
+// failure are the same error here, and a miss is the COMMON case for replay
+// defence (most assertions are new), Warn would emit a line on every normal
+// lookup and flood the log. Debug keeps it retrievable when investigating
+// without drowning the signal.
+//
+// Closing the fail-open properly means giving the storage layer a miss/error
+// distinction (a (*SessionToken, bool, error) signature or a sentinel) and then
+// making those callers fail closed — a cross-provider contract change, tracked
+// rather than bodged here.
 func (p *provider) GetCache(key string) (string, error) {
-	cacheMutex.RLock()
-	defer cacheMutex.RUnlock()
-	entry, ok := cache[key]
-	if !ok {
+	ctx := context.Background()
+	row, err := p.getSessionTokenByUserIDAndKey(ctx, cacheNamespace, key)
+	if err != nil {
+		// Indistinguishable from a miss (see above). Debug, not Warn — see the
+		// log-level note in the doc comment.
+		p.dependencies.Log.Debug().Err(err).Str("cache_key", key).
+			Msg("cache read miss or failure (indistinguishable at this layer); treated as a miss")
 		return "", nil
 	}
-	if entry.ExpiresAt < time.Now().Unix() {
-		// Entry expired; clean up asynchronously to avoid write lock in read path.
-		go func() {
-			cacheMutex.Lock()
-			defer cacheMutex.Unlock()
-			// Re-check to avoid deleting a refreshed entry.
-			if e, exists := cache[key]; exists && e.ExpiresAt < time.Now().Unix() {
-				delete(cache, key)
-			}
-		}()
+	if row == nil {
 		return "", nil
 	}
-	return entry.Value, nil
+	// Inclusive expiry, matching GetUserSession and the in-memory store: an entry
+	// is invalid AT its expiry second, not one second later.
+	//
+	// No eviction here on purpose: this is a read path (every replay check hits
+	// it), and deleting from it would add a write per expired lookup. The row is
+	// already treated as absent, SetCache deletes before it rewrites, and
+	// CleanExpiredSessionTokens — invoked on the SetUserSession/GetUserSession
+	// paths — collects it.
+	if row.ExpiresAt <= time.Now().Unix() {
+		return "", nil
+	}
+	return row.Token, nil
 }
 
-// IncrementCache atomically increments the integer counter at key (creating it
-// at 1 if absent or expired) and refreshes its TTL under the same mutex
-// SetCache/GetCache use, returning the new value. Safe under concurrent
-// callers, unlike a GetCache+SetCache pair which would let them all observe
-// the same pre-increment value.
+// IncrementCache increments the counter at key, creating it at 1 when absent or
+// expired, and refreshes its TTL.
+//
+// ponytail: read-modify-write against the shared table, serialized only within
+// this process. Two replicas incrementing in the same instant can read the same
+// prior value and one increment is lost, so a counter can UNDERCOUNT under exact
+// concurrency. That is deliberate and strictly bounded: the previous
+// process-local map made counts not aggregate at all, so N replicas granted N x
+// the attempts before an OTP lockout — this makes the count shared and
+// approximately right instead of reliably wrong. For an exact distributed
+// counter configure REDIS_URL (the Redis provider uses a native atomic INCR);
+// the upgrade path here is a compare-and-set or native increment in the storage
+// layer, which is a per-provider change across all 7 backends.
 func (p *provider) IncrementCache(key string, ttlSeconds int64) (int64, error) {
-	cacheMutex.Lock()
-	defer cacheMutex.Unlock()
-	now := time.Now().Unix()
-	var current int64
-	if entry, ok := cache[key]; ok && entry.ExpiresAt >= now {
-		current, _ = strconv.ParseInt(entry.Value, 10, 64)
+	incrementMutex.Lock()
+	defer incrementMutex.Unlock()
+
+	current, err := p.GetCache(key)
+	if err != nil {
+		return 0, err
 	}
-	next := current + 1
-	cache[key] = &cacheEntry{Value: strconv.FormatInt(next, 10), ExpiresAt: now + ttlSeconds}
+	var next int64 = 1
+	if current != "" {
+		if parsed, pErr := strconv.ParseInt(current, 10, 64); pErr == nil {
+			next = parsed + 1
+		}
+	}
+	if err := p.SetCache(key, strconv.FormatInt(next, 10), ttlSeconds); err != nil {
+		return 0, err
+	}
 	return next, nil
 }
 
-// DeleteCacheByPrefix removes all cache entries whose keys start with the given prefix.
+// DeleteCacheByPrefix removes the cache entry for the given key.
+//
+// IMPORTANT — this performs an EXACT-KEY delete, not prefix expansion, and so
+// diverges from the Redis and in-memory providers, which do expand a prefix.
+// That divergence is deliberate and is safe only because every caller today
+// passes a COMPLETE key, never a partial one:
+//
+//	authenticators/totp/totp.go   DeleteCacheByPrefix(totpPendingSecretKey(userID))
+//	service/verify_otp.go         DeleteCacheByPrefix(lockKey)
+//	service/verify_otp.go         DeleteCacheByPrefix(otpLockKey)
+//
+// The alternative — scanning every row and filtering in Go — would put an
+// O(table) query on a user-facing auth path (it runs on every successful OTP or
+// TOTP verification), and the storage interface exposes no prefix query to do it
+// indexed. An exact-key delete rides the (user_id, key_name) index instead.
+//
+// If a caller ever genuinely needs prefix expansion here it will silently no-op,
+// so: add a prefix-delete to storage.Provider (all 7 backends) and implement it
+// properly rather than reaching for GetAllSessionTokens.
 func (p *provider) DeleteCacheByPrefix(prefix string) error {
-	cacheMutex.Lock()
-	defer cacheMutex.Unlock()
-	for k := range cache {
-		if strings.HasPrefix(k, prefix) {
-			delete(cache, k)
-		}
-	}
-	return nil
+	ctx := context.Background()
+	return p.deleteSessionTokenByUserIDAndKey(ctx, cacheNamespace, prefix)
 }

--- a/internal/memory_store/db/provider.go
+++ b/internal/memory_store/db/provider.go
@@ -95,15 +95,28 @@ func (p *provider) GetUserSession(userId, key string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}
 
-	// Check expiration
+	// Check expiration. Inclusive (<=): a token is invalid AT its expiry second,
+	// not one second later. This matches the in-memory store, which serves an
+	// entry only while ExpiresAt > now, and Redis, whose native TTL drops the key
+	// at the deadline. The exclusive form left a session usable for one extra
+	// second on this provider only — a cross-provider parity gap.
 	currentTime := time.Now().Unix()
-	if token.ExpiresAt < currentTime {
+	if token.ExpiresAt <= currentTime {
 		// Delete expired token
 		_ = p.deleteSessionToken(ctx, token.ID)
 		return "", fmt.Errorf("not found")
 	}
 
 	return token.Token, nil
+}
+
+// ClaimRefreshToken atomically consumes the refresh-token entry for this nonce
+// and reports whether this call consumed it (see memory_store.Provider). The
+// storage layer decides the race in one operation — this method must never
+// read-then-delete.
+func (p *provider) ClaimRefreshToken(userId, nonce string) (bool, error) {
+	ctx := context.Background()
+	return p.storageProvider.DeleteSessionTokenByUserIDAndKey(ctx, userId, constants.TokenTypeRefreshToken+"_"+nonce)
 }
 
 // DeleteUserSession deletes the user session
@@ -194,7 +207,8 @@ func (p *provider) GetMfaSession(userId, key string) (string, error) {
 		if !strings.HasPrefix(session.KeyName, prefix) {
 			continue
 		}
-		if session.ExpiresAt < currentTime {
+		// Inclusive expiry, matching GetUserSession and the in-memory store.
+		if session.ExpiresAt <= currentTime {
 			_ = p.deleteMFASession(ctx, session.ID)
 			return "", fmt.Errorf("not found")
 		}
@@ -288,14 +302,14 @@ func (p *provider) SetState(key, state string) error {
 	}
 	oauthState.Key = oauthState.ID
 
-	// Delete existing if any
-	err := p.deleteOAuthStateByKey(ctx, key)
-	if err != nil {
+	// Delete existing if any. Whether a row was actually removed is irrelevant
+	// here — this is an overwrite, not a single-use claim.
+	if _, err := p.deleteOAuthStateByKey(ctx, key); err != nil {
 		p.dependencies.Log.Debug().Err(err).Msg("Error deleting existing OAuth state")
 		// Continue anyway
 	}
 
-	err = p.addOAuthState(ctx, oauthState)
+	err := p.addOAuthState(ctx, oauthState)
 	if err != nil {
 		return fmt.Errorf("error setting state: %w", err)
 	}
@@ -314,28 +328,44 @@ func (p *provider) GetState(key string) (string, error) {
 	// Enforce 10-minute TTL consistent with Redis provider.
 	if oauthState.CreatedAt > 0 && time.Now().Unix()-oauthState.CreatedAt > 600 {
 		// Clean up expired entry asynchronously.
-		go func() { _ = p.deleteOAuthStateByKey(context.Background(), key) }()
+		go func() { _, _ = p.deleteOAuthStateByKey(context.Background(), key) }()
 		return "", fmt.Errorf("state expired")
 	}
 	return oauthState.State, nil
 }
 
-// RemoveState removes the social login state from the session store
+// RemoveState removes the social login state from the session store. Unlike
+// GetAndRemoveState this is an unconditional cleanup, so "was it already gone"
+// is not an error.
 func (p *provider) RemoveState(key string) error {
 	ctx := context.Background()
-	return p.deleteOAuthStateByKey(ctx, key)
+	_, err := p.deleteOAuthStateByKey(ctx, key)
+	return err
 }
 
 // GetAndRemoveState atomically retrieves and deletes the state from the DB.
 // Enforces 10-minute TTL consistent with other providers.
+//
+// The DELETE — not the preceding read — is what makes this single-use. The read
+// only fetches the payload and can legitimately succeed for several concurrent
+// callers redeeming the same authorization code; the storage layer's delete
+// decides, in one atomic operation, which single caller actually consumed it
+// (see storage.Provider.DeleteOAuthStateByKey). Returning the state on the
+// strength of the read alone would hand the same code to every racer, which is
+// an authorization-code replay (RFC 6749 §4.1.2).
 func (p *provider) GetAndRemoveState(key string) (string, error) {
 	ctx := context.Background()
 	oauthState, err := p.getOAuthStateByKey(ctx, key)
 	if err != nil {
 		return "", fmt.Errorf("not found")
 	}
-	// Delete immediately after retrieval; a concurrent request will fail on getOAuthStateByKey.
-	if err := p.deleteOAuthStateByKey(ctx, key); err != nil {
+	claimed, err := p.deleteOAuthStateByKey(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("not found")
+	}
+	if !claimed {
+		// Another caller won the delete: this request is redeeming an already
+		// consumed key. Same opaque error as a missing key — no replay oracle.
 		return "", fmt.Errorf("not found")
 	}
 	// Enforce 10-minute TTL.
@@ -396,8 +426,12 @@ func (p *provider) deleteSessionToken(ctx context.Context, id string) error {
 	return p.storageProvider.DeleteSessionToken(ctx, id)
 }
 
+// deleteSessionTokenByUserIDAndKey removes an entry, discarding the storage
+// layer's "did I claim it" answer — the callers here (upsert, logout-style
+// cleanup) only need it gone. Use ClaimRefreshToken where the answer matters.
 func (p *provider) deleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
-	return p.storageProvider.DeleteSessionTokenByUserIDAndKey(ctx, userId, key)
+	_, err := p.storageProvider.DeleteSessionTokenByUserIDAndKey(ctx, userId, key)
+	return err
 }
 
 func (p *provider) deleteAllSessionTokensByUserID(ctx context.Context, userId string) error {
@@ -448,7 +482,9 @@ func (p *provider) getOAuthStateByKey(ctx context.Context, key string) (*schemas
 	return p.storageProvider.GetOAuthStateByKey(ctx, key)
 }
 
-func (p *provider) deleteOAuthStateByKey(ctx context.Context, key string) error {
+// deleteOAuthStateByKey removes the entry and reports whether THIS call was the
+// one that removed it (see storage.Provider.DeleteOAuthStateByKey).
+func (p *provider) deleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
 	return p.storageProvider.DeleteOAuthStateByKey(ctx, key)
 }
 

--- a/internal/memory_store/in_memory/store.go
+++ b/internal/memory_store/in_memory/store.go
@@ -28,6 +28,12 @@ func (c *provider) DeleteAllUserSessions(userId string) error {
 }
 
 // DeleteUserSession deletes the user session from the in-memory store.
+// ClaimRefreshToken atomically consumes the refresh-token entry for this nonce
+// and reports whether this call consumed it (see memory_store.Provider).
+func (c *provider) ClaimRefreshToken(userId, nonce string) (bool, error) {
+	return c.sessionStore.Claim(userId, constants.TokenTypeRefreshToken+"_"+nonce), nil
+}
+
 func (c *provider) DeleteUserSession(userId, key string) error {
 	keys := []string{
 		constants.TokenTypeSessionToken + "_" + key,

--- a/internal/memory_store/in_memory/stores/session_store.go
+++ b/internal/memory_store/in_memory/stores/session_store.go
@@ -165,6 +165,22 @@ func (s *SessionStore) RemoveAll(key string) {
 	}
 }
 
+// Claim atomically removes (key, subKey) and reports whether THIS call removed
+// it. The check and the delete happen under one mutex hold, so concurrent
+// callers cannot both observe true — that is what makes it usable as a
+// single-use gate (refresh-token rotation). Remove() cannot serve this purpose:
+// it reports nothing, so every racer would proceed.
+func (s *SessionStore) Claim(key, subKey string) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	k := fmt.Sprintf("%s:%s", key, subKey)
+	if _, ok := s.store[k]; !ok {
+		return false
+	}
+	delete(s.store, k)
+	return true
+}
+
 // Remove value for given key and subkey
 func (s *SessionStore) Remove(key, subKey string) {
 	s.mutex.Lock()

--- a/internal/memory_store/provider.go
+++ b/internal/memory_store/provider.go
@@ -44,6 +44,20 @@ type Provider interface {
 	GetUserSession(userId, key string) (string, error)
 	// DeleteUserSession deletes the user session
 	DeleteUserSession(userId, key string) error
+	// ClaimRefreshToken atomically consumes the refresh-token entry for
+	// (userId, nonce) and reports whether THIS call consumed it. It is the
+	// single-use gate for refresh-token rotation (OAuth 2.1 §6.1): the token
+	// endpoint must win this claim before issuing a replacement, so that under
+	// concurrent redemption of the same refresh token exactly one caller
+	// proceeds.
+	//
+	// It exists separately from DeleteUserSession because that method is a
+	// best-effort cleanup used by logout/revoke — it removes the session,
+	// access and refresh entries for a nonce and nobody cares whether a row was
+	// actually there. Here "did I remove it" IS the security decision, so the
+	// answer must come from one atomic operation and must concern only the
+	// refresh entry. Returns (false, nil) when the entry is already gone.
+	ClaimRefreshToken(userId, nonce string) (bool, error)
 	// DeleteAllSessions deletes all the sessions from the session store
 	DeleteAllUserSessions(userId string) error
 	// DeleteSessionForNamespace deletes the session for a given namespace

--- a/internal/memory_store/provider_test.go
+++ b/internal/memory_store/provider_test.go
@@ -2,6 +2,7 @@ package memory_store
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/authorizerdev/authorizer/internal/config"
+	"github.com/authorizerdev/authorizer/internal/storage"
 )
 
 const (
@@ -19,12 +21,21 @@ const (
 	memoryStoreTypeDB       = "db"
 )
 
+// memoryStoreTypesForTest lists the providers every contract test runs against.
+//
+// memoryStoreTypeDB is included deliberately: New() selects it for ANY
+// deployment that configures a database without REDIS_URL, which makes it the
+// default in production — yet it was previously declared here and never
+// exercised, so its semantics went unverified. Two real defects lived in that
+// gap (a non-atomic GetAndRemoveState that allowed authorization-code replay,
+// and a process-local cache that broke SAML/jti replay defence and OTP lockout
+// across replicas). It needs no Docker: it runs on SQLite like the rest.
 func memoryStoreTypesForTest() []string {
 	var types []string
 	if redisMemoryStoreTestsEnabled() {
 		types = append(types, memoryStoreTypeRedis)
 	}
-	types = append(types, memoryStoreTypeInMemory)
+	types = append(types, memoryStoreTypeInMemory, memoryStoreTypeDB)
 	return types
 }
 
@@ -46,16 +57,38 @@ func getTestMemoryStorageConfig(storageType string) *config.Config {
 	return cfg
 }
 
+// newTestMemoryStore builds a provider of the requested type. The db type is the
+// only one needing a StorageProvider — without one New() silently falls through
+// to the in-memory store, which is exactly how the db provider avoided coverage.
+func newTestMemoryStore(t *testing.T, storeType string) (Provider, error) {
+	t.Helper()
+	logger := zerolog.Nop()
+	cfg := getTestMemoryStorageConfig(storeType)
+	deps := &Dependencies{Log: &logger}
+
+	if storeType == memoryStoreTypeDB {
+		// Not t.TempDir(): SQLite's WAL sidecars can appear during teardown and
+		// make its RemoveAll fail an already-passed test (same reasoning as the
+		// integration harness).
+		dbDir, err := os.MkdirTemp("", "authorizer-ms-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(dbDir) })
+		cfg.DatabaseURL = filepath.Join(dbDir, "memory_store_test.db")
+
+		sp, err := storage.New(cfg, &storage.Dependencies{Log: &logger})
+		require.NoError(t, err)
+		deps.StorageProvider = sp
+	}
+
+	return New(cfg, deps)
+}
+
 // TestMemoryStoreProvider tests the in-memory provider always; Redis only when TEST_ENABLE_REDIS=1.
 // TEST_DBS does not apply (these are not storage-backend tests).
 func TestMemoryStoreProvider(t *testing.T) {
 	for _, storeType := range memoryStoreTypesForTest() {
 		t.Run("should test memory store provider for "+storeType, func(t *testing.T) {
-			cfg := getTestMemoryStorageConfig(storeType)
-			logger := zerolog.Nop()
-			p, err := New(cfg, &Dependencies{
-				Log: &logger,
-			})
+			p, err := newTestMemoryStore(t, storeType)
 			if storeType == memoryStoreTypeRedis && err != nil {
 				t.Skipf("skipping redis memory store test (is Redis running on localhost:6380?): %v", err)
 			}

--- a/internal/memory_store/redis/store.go
+++ b/internal/memory_store/redis/store.go
@@ -39,6 +39,19 @@ func (p *provider) GetUserSession(userId, key string) (string, error) {
 }
 
 // DeleteUserSession deletes the user session from redis store.
+// ClaimRefreshToken atomically consumes the refresh-token entry for this nonce
+// and reports whether this call consumed it (see memory_store.Provider). Redis
+// DEL is atomic and returns the number of keys it actually removed, so exactly
+// one concurrent caller can see a non-zero count.
+func (p *provider) ClaimRefreshToken(userId, nonce string) (bool, error) {
+	key := fmt.Sprintf("%s:%s_%s", userId, constants.TokenTypeRefreshToken, nonce)
+	removed, err := p.store.Del(p.ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return removed > 0, nil
+}
+
 func (p *provider) DeleteUserSession(userId, key string) error {
 	keys := []string{
 		constants.TokenTypeSessionToken + "_" + key,

--- a/internal/memory_store/single_use_test.go
+++ b/internal/memory_store/single_use_test.go
@@ -1,0 +1,246 @@
+package memory_store
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authorizerdev/authorizer/internal/storage"
+)
+
+// TestGetAndRemoveStateIsSingleUse is the regression test for authorization-code
+// replay. GetAndRemoveState is the primitive behind RFC 6749 §4.1.2 single-use
+// codes (see http_handlers.TokenHandler) and the SSO broker's single-use
+// `state`, so under concurrent redemption of the same key exactly one caller may
+// receive the value.
+//
+// The DB-backed provider previously implemented this as a read followed by a
+// separate delete, which handed the same code to every racer: 39 of 40 rounds
+// returned it to BOTH callers. Runs against every provider so no future backend
+// can regress the contract.
+func TestGetAndRemoveStateIsSingleUse(t *testing.T) {
+	for _, storeType := range memoryStoreTypesForTest() {
+		t.Run(storeType, func(t *testing.T) {
+			p, err := newTestMemoryStore(t, storeType)
+			if storeType == memoryStoreTypeRedis && err != nil {
+				t.Skipf("skipping redis (is Redis running on localhost:6380?): %v", err)
+			}
+			require.NoError(t, err)
+
+			const rounds = 40
+			doubleRedemptions := 0
+
+			for i := 0; i < rounds; i++ {
+				key := "authcode_" + uuid.New().String()
+				require.NoError(t, p.SetState(key, "session-data-for-"+key))
+
+				var wg sync.WaitGroup
+				results := make([]string, 2)
+				errs := make([]error, 2)
+				start := make(chan struct{})
+				for j := range results {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						<-start
+						results[idx], errs[idx] = p.GetAndRemoveState(key)
+					}(j)
+				}
+				close(start)
+				wg.Wait()
+
+				won := 0
+				for j := range results {
+					if errs[j] == nil && results[j] != "" {
+						won++
+					}
+				}
+				assert.NotZero(t, won, "one caller must still succeed — the code must not be lost")
+				if won > 1 {
+					doubleRedemptions++
+				}
+			}
+
+			assert.Zero(t, doubleRedemptions,
+				"an authorization code must be redeemable exactly once (RFC 6749 §4.1.2); "+
+					"%d of %d concurrent double-redemptions returned it to both callers", doubleRedemptions, rounds)
+		})
+	}
+}
+
+// TestClaimRefreshTokenIsSingleUse is the regression test for concurrent
+// refresh-token redemption. ClaimRefreshToken is the gate the token endpoint
+// must win before issuing a rotated token (OAuth 2.1 §6.1), so under concurrent
+// redemption of the same nonce exactly one caller may observe true.
+//
+// Before this existed the endpoint validated (a READ) and then deleted, so two
+// simultaneous refreshes both passed and each minted an independent, separately
+// rotating token family from one refresh token — reproduced end to end as
+// [200,200] by e2e-playground/tests/concurrency.spec.ts. Runs against every
+// provider so no backend can regress the contract.
+func TestClaimRefreshTokenIsSingleUse(t *testing.T) {
+	for _, storeType := range memoryStoreTypesForTest() {
+		t.Run(storeType, func(t *testing.T) {
+			p, err := newTestMemoryStore(t, storeType)
+			if storeType == memoryStoreTypeRedis && err != nil {
+				t.Skipf("skipping redis (is Redis running on localhost:6380?): %v", err)
+			}
+			require.NoError(t, err)
+
+			const rounds = 40
+			doubleClaims := 0
+			expiry := time.Now().Add(10 * time.Minute).Unix()
+
+			for i := 0; i < rounds; i++ {
+				sessionKey := "basic_auth:user-" + uuid.New().String()
+				nonce := uuid.New().String()
+				require.NoError(t, p.SetUserSession(
+					sessionKey, "refresh_token_"+nonce, "the-refresh-token", expiry))
+
+				var wg sync.WaitGroup
+				claims := make([]bool, 2)
+				errs := make([]error, 2)
+				start := make(chan struct{})
+				for j := range claims {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						<-start
+						claims[idx], errs[idx] = p.ClaimRefreshToken(sessionKey, nonce)
+					}(j)
+				}
+				close(start)
+				wg.Wait()
+
+				won := 0
+				for j := range claims {
+					require.NoError(t, errs[j])
+					if claims[j] {
+						won++
+					}
+				}
+				assert.NotZero(t, won, "one caller must still win — the token must not be lost")
+				if won > 1 {
+					doubleClaims++
+				}
+			}
+
+			assert.Zero(t, doubleClaims,
+				"a refresh token must be redeemable exactly once (OAuth 2.1 §6.1); "+
+					"%d of %d concurrent double-redemptions were granted to both callers", doubleClaims, rounds)
+		})
+	}
+}
+
+// TestClaimRefreshTokenIsIdempotentlyFalse pins the absent-entry contract: a
+// claim on a nonce that was never issued (or already consumed) is false with no
+// error, never an error the endpoint would have to special-case.
+func TestClaimRefreshTokenIsIdempotentlyFalse(t *testing.T) {
+	for _, storeType := range memoryStoreTypesForTest() {
+		t.Run(storeType, func(t *testing.T) {
+			p, err := newTestMemoryStore(t, storeType)
+			if storeType == memoryStoreTypeRedis && err != nil {
+				t.Skipf("skipping redis: %v", err)
+			}
+			require.NoError(t, err)
+
+			claimed, err := p.ClaimRefreshToken("basic_auth:nobody", uuid.New().String())
+			assert.NoError(t, err, "claiming an absent refresh token is not an error")
+			assert.False(t, claimed)
+		})
+	}
+}
+
+// TestDBStoreCacheIsSharedAcrossInstances is the regression test for the
+// process-local cache. The DB-backed provider is what New() selects for a
+// multi-instance deployment that has a database but no REDIS_URL, so its cache
+// must be visible to every replica: SAML assertion single-use, RFC 7523 jti
+// replay defence, and OTP lockout counters are all built on these methods, and
+// each silently degrades when a replica cannot see what another wrote.
+//
+// Two providers over ONE storage backend stand in for two replicas.
+func TestDBStoreCacheIsSharedAcrossInstances(t *testing.T) {
+	logger := zerolog.Nop()
+	cfg := getTestMemoryStorageConfig(memoryStoreTypeDB)
+
+	dbDir, err := os.MkdirTemp("", "authorizer-ms-shared-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dbDir) })
+	cfg.DatabaseURL = filepath.Join(dbDir, "shared.db")
+
+	sp, err := storage.New(cfg, &storage.Dependencies{Log: &logger})
+	require.NoError(t, err)
+
+	replicaA, err := New(cfg, &Dependencies{Log: &logger, StorageProvider: sp})
+	require.NoError(t, err)
+	replicaB, err := New(cfg, &Dependencies{Log: &logger, StorageProvider: sp})
+	require.NoError(t, err)
+
+	// A consumed SAML assertion / client-assertion jti recorded on one replica
+	// must be visible on the other, or a replay simply targets the other replica.
+	replayKey := "saml_assertion:org-1:" + uuid.New().String()
+	require.NoError(t, replicaA.SetCache(replayKey, "1", 600))
+
+	seen, err := replicaB.GetCache(replayKey)
+	require.NoError(t, err)
+	assert.Equal(t, "1", seen,
+		"replica B must observe the assertion replica A already consumed, else replay defence is per-process")
+
+	// Lockout counters must aggregate across replicas, or N replicas grant N x
+	// the configured OTP attempts.
+	lockKey := "otp_lock:" + uuid.New().String()
+	n, err := replicaA.IncrementCache(lockKey, 300)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	n, err = replicaB.IncrementCache(lockKey, 300)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, n, "the second attempt must see the first replica's count, not restart at 1")
+
+	n, err = replicaA.IncrementCache(lockKey, 300)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, n)
+
+	// Invalidation must clear it everywhere (a correct OTP resets the lockout).
+	require.NoError(t, replicaB.DeleteCacheByPrefix(lockKey))
+	after, err := replicaA.GetCache(lockKey)
+	require.NoError(t, err)
+	assert.Empty(t, after, "clearing a lockout on one replica must clear it for all")
+}
+
+// TestDBStoreCacheDoesNotCollideWithState pins the separation between the two
+// key spaces: a cache write must never be redeemable as an authorization code,
+// nor a code readable as a cache entry, even when both use the identical key.
+//
+// Cache entries live in authorizer_session_tokens under the reserved
+// cacheNamespace user_id; codes and SSO state live in authorizer_oauth_states.
+// The test does not assume that split — it asserts the observable contract — so
+// it keeps holding if the storage layout changes again.
+func TestDBStoreCacheDoesNotCollideWithState(t *testing.T) {
+	p, err := newTestMemoryStore(t, memoryStoreTypeDB)
+	require.NoError(t, err)
+
+	const key = "collision-probe"
+	require.NoError(t, p.SetState(key, "the-authorization-code-payload"))
+	require.NoError(t, p.SetCache(key, "the-cache-payload", 600))
+
+	cached, err := p.GetCache(key)
+	require.NoError(t, err)
+	assert.Equal(t, "the-cache-payload", cached, "cache read must not return the state payload")
+
+	state, err := p.GetAndRemoveState(key)
+	require.NoError(t, err)
+	assert.Equal(t, "the-authorization-code-payload", state, "state read must not return the cache payload")
+
+	// Consuming the code must leave the cache entry intact.
+	stillCached, err := p.GetCache(key)
+	require.NoError(t, err)
+	assert.Equal(t, "the-cache-payload", stillCached, "redeeming a code must not evict a same-named cache entry")
+}

--- a/internal/parsers/host_header_injection_test.go
+++ b/internal/parsers/host_header_injection_test.go
@@ -1,0 +1,88 @@
+package parsers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verification of GHSA-m82j-rq33-qjx2 (Password Reset Poisoning via Host Header
+// Injection, CWE-640).
+//
+// GetHostFromRequest is the single point the advisory's whole data flow hangs
+// off: internal/service/forgot_password.go takes `meta.HostURL` from it, uses it
+// to build the emailed reset link and the JWT `iss`, and
+// internal/service/reset_password.go re-validates that `iss` against the SAME
+// function's output on the redemption request. So whether the attack works is
+// decided entirely here.
+//
+// These tests pin BOTH halves of the current state: the mitigation works when
+// --url is set, and the vulnerable fallback is still live when it is not.
+func TestHostHeaderInjection_GHSA_m82j_rq33_qjx2(t *testing.T) {
+	// Package-level trustedURL is set once at startup; restore it so these
+	// subtests cannot leak into each other or into other tests in this package.
+	original := trustedURL
+	t.Cleanup(func() { trustedURL = original })
+
+	poisoned := func() *http.Request {
+		r, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:8080/graphql", nil)
+		r.Host = "attacker.example"
+		r.Header.Set("X-Forwarded-Host", "attacker.example")
+		r.Header.Set("X-Forwarded-Proto", "https")
+		return r
+	}
+
+	t.Run("MITIGATED: --url set makes every attacker header irrelevant", func(t *testing.T) {
+		SetTrustedURL("https://auth.example.com")
+
+		got := GetHostFromRequest(poisoned())
+		assert.Equal(t, "https://auth.example.com", got,
+			"with --url configured the trusted value must win over Host/X-Forwarded-Host")
+
+		// X-Authorizer-URL is the third header the fallback path honours; it must
+		// be ignored too, not just the forwarding headers.
+		r := poisoned()
+		r.Header.Set("X-Authorizer-URL", "https://attacker.example")
+		assert.Equal(t, "https://auth.example.com", GetHostFromRequest(r),
+			"X-Authorizer-URL must not override the configured --url either")
+	})
+
+	t.Run("VULNERABLE: --url unset lets the attacker choose the reset-link host", func(t *testing.T) {
+		SetTrustedURL("") // the shipped default (cmd/root.go: --url defaults to "")
+
+		got := GetHostFromRequest(poisoned())
+
+		// This is the advisory's core finding, asserted as current behaviour
+		// rather than as the desired one. forgot_password builds
+		//   redirectURI = hostname + "/app/reset-password"
+		// from exactly this value, so the emailed link points at the attacker.
+		assert.Equal(t, "https://attacker.example", got,
+			"documents GHSA-m82j-rq33-qjx2: with --url unset the host is attacker-controlled")
+
+		// sanitizeHost only strips structural characters — it applies no
+		// allowlist, so an arbitrary registrable domain passes untouched.
+		r := poisoned()
+		r.Header.Set("X-Forwarded-Host", "evil.co.uk")
+		assert.Equal(t, "https://evil.co.uk", GetHostFromRequest(r),
+			"sanitizeHost performs no allowlist check, only structural filtering")
+	})
+
+	t.Run("sanitizer still blocks structural injection regardless of --url", func(t *testing.T) {
+		SetTrustedURL("")
+		for _, bad := range []string{
+			"attacker.example/path",
+			"attacker.example?q=1",
+			"attacker.example#frag",
+			"user@attacker.example",
+			"attacker.example\r\nX-Injected: 1",
+		} {
+			r, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:8080/graphql", nil)
+			r.Header.Set("X-Forwarded-Host", bad)
+			r.Host = "real.example"
+			got := GetHostFromRequest(r)
+			assert.Equal(t, "http://real.example", got,
+				"a structurally malformed X-Forwarded-Host (%q) must be rejected and fall through", bad)
+		}
+	})
+}

--- a/internal/storage/db/arangodb/session_token.go
+++ b/internal/storage/db/arangodb/session_token.go
@@ -73,18 +73,22 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
-	query := fmt.Sprintf("FOR d IN %s FILTER d.user_id == @user_id AND d.key_name == @key_name REMOVE d IN %s", schemas.Collections.SessionToken, schemas.Collections.SessionToken)
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
+	// RETURN OLD makes the removal report what it actually removed: a document
+	// is removed by exactly one AQL execution, so only the winning caller reads
+	// a row back. ignoreErrors keeps a loser's concurrent REMOVE from erroring
+	// on an already-deleted document.
+	query := fmt.Sprintf("FOR d IN %s FILTER d.user_id == @user_id AND d.key_name == @key_name REMOVE d IN %s OPTIONS { ignoreErrors: true } RETURN OLD", schemas.Collections.SessionToken, schemas.Collections.SessionToken)
 	bindVars := map[string]interface{}{
 		"user_id":  userId,
 		"key_name": key,
 	}
 	cursor, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = cursor.Close() }()
-	return nil
+	return cursor.HasMore(), nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID
@@ -342,17 +346,22 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
-	query := fmt.Sprintf("FOR d IN %s FILTER d.state_key == @state_key REMOVE d IN %s", schemas.Collections.OAuthState, schemas.Collections.OAuthState)
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
+	// RETURN OLD makes the removal report what it actually removed: each document
+	// is removed by exactly one AQL execution, so only the winning caller reads a
+	// row back. ignoreErrors keeps the loser's concurrent REMOVE from erroring on
+	// an already-deleted document (it simply returns nothing).
+	query := fmt.Sprintf("FOR d IN %s FILTER d.state_key == @state_key REMOVE d IN %s OPTIONS { ignoreErrors: true } RETURN OLD",
+		schemas.Collections.OAuthState, schemas.Collections.OAuthState)
 	bindVars := map[string]interface{}{
 		"state_key": key,
 	}
 	cursor, err := p.db.Query(ctx, query, bindVars)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = cursor.Close() }()
-	return nil
+	return cursor.HasMore(), nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/cassandradb/session_token.go
+++ b/internal/storage/db/cassandradb/session_token.go
@@ -46,26 +46,40 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
 	// Cassandra doesn't support delete with non-primary key filter directly, so scan first
 	var ids []string
 	query := fmt.Sprintf(`SELECT id FROM %s WHERE user_id = ? AND key_name = ? ALLOW FILTERING`,
 		KeySpace+"."+schemas.Collections.SessionToken)
-	iter := p.db.Query(query, userId, key).Iter()
+	iter := p.db.Query(query, userId, key).WithContext(ctx).Iter()
 	var id string
 	for iter.Scan(&id) {
 		ids = append(ids, id)
 	}
 	if err := iter.Close(); err != nil {
-		return err
+		return false, err
 	}
+	// The SELECT is NOT the race arbiter — two callers can read the same id.
+	// `IF EXISTS` makes the DELETE a lightweight transaction (Paxos), so the
+	// cluster applies exactly one of the concurrent deletes and reports
+	// applied=false to the rest. That flag decides who consumed the token.
+	deleted := false
 	for _, id := range ids {
-		delQuery := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.SessionToken)
-		if err := p.db.Query(delQuery, id).Exec(); err != nil {
-			return err
+		delQuery := fmt.Sprintf("DELETE FROM %s WHERE id = ? IF EXISTS", KeySpace+"."+schemas.Collections.SessionToken)
+		// MapScanCAS, not ScanCAS: an LWT result set carries the row's columns
+		// alongside [applied], and ScanCAS with no destinations fails on that
+		// ("not enough columns to scan into: have 1 want 8" on ScyllaDB). The
+		// map absorbs whatever columns come back. Matches the existing LWT usage
+		// in org_domain.go.
+		applied, err := p.db.Query(delQuery, id).WithContext(ctx).MapScanCAS(map[string]interface{}{})
+		if err != nil {
+			return false, err
+		}
+		if applied {
+			deleted = true
 		}
 	}
-	return nil
+	return deleted, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID
@@ -315,25 +329,40 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
 	var ids []string
 	query := fmt.Sprintf(`SELECT id FROM %s WHERE state_key = ? ALLOW FILTERING`,
 		KeySpace+"."+schemas.Collections.OAuthState)
-	iter := p.db.Query(query, key).Iter()
+	iter := p.db.Query(query, key).WithContext(ctx).Iter()
 	var id string
 	for iter.Scan(&id) {
 		ids = append(ids, id)
 	}
 	if err := iter.Close(); err != nil {
-		return err
+		return false, err
 	}
+	// The SELECT above is NOT the race arbiter — two callers can both read the
+	// same id. `IF EXISTS` makes the DELETE a lightweight transaction (Paxos), so
+	// the cluster applies exactly one of the concurrent deletes and reports
+	// applied=false to every other caller. That `applied` flag is what decides
+	// who legitimately consumed the single-use code.
+	deleted := false
 	for _, id := range ids {
-		delQuery := fmt.Sprintf("DELETE FROM %s WHERE id = ?", KeySpace+"."+schemas.Collections.OAuthState)
-		if err := p.db.Query(delQuery, id).Exec(); err != nil {
-			return err
+		delQuery := fmt.Sprintf("DELETE FROM %s WHERE id = ? IF EXISTS", KeySpace+"."+schemas.Collections.OAuthState)
+		// MapScanCAS, not ScanCAS: an LWT result set carries the row's columns
+		// alongside [applied], and ScanCAS with no destinations fails on that
+		// ("not enough columns to scan into: have 1 want 8" on ScyllaDB). The
+		// map absorbs whatever columns come back. Matches the existing LWT usage
+		// in org_domain.go.
+		applied, err := p.db.Query(delQuery, id).WithContext(ctx).MapScanCAS(map[string]interface{}{})
+		if err != nil {
+			return false, err
+		}
+		if applied {
+			deleted = true
 		}
 	}
-	return nil
+	return deleted, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/couchbase/session_token.go
+++ b/internal/storage/db/couchbase/session_token.go
@@ -2,6 +2,7 @@ package couchbase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -56,27 +57,38 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
 	query := fmt.Sprintf(`SELECT _id FROM %s.%s WHERE user_id = $1 AND key_name = $2`,
 		p.scopeName, schemas.Collections.SessionToken)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
+		Context:              ctx,
 		PositionalParameters: []interface{}{userId, key},
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	type idRow struct {
 		ID string `json:"_id"`
 	}
+	// The N1QL SELECT is NOT the race arbiter. A KV Remove on a single document
+	// is atomic: the winner removes it, every other caller gets
+	// ErrDocumentNotFound.
+	deleted := false
 	for q.Next() {
 		var row idRow
 		if err := q.Row(&row); err != nil {
 			continue
 		}
-		_, _ = p.db.Collection(schemas.Collections.SessionToken).Remove(row.ID, &gocb.RemoveOptions{Context: ctx})
+		if _, rErr := p.db.Collection(schemas.Collections.SessionToken).Remove(row.ID, &gocb.RemoveOptions{Context: ctx}); rErr != nil {
+			if errors.Is(rErr, gocb.ErrDocumentNotFound) {
+				continue
+			}
+			return false, rErr
+		}
+		deleted = true
 	}
-	return nil
+	return deleted, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID.
@@ -371,27 +383,39 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
 	query := fmt.Sprintf(`SELECT _id FROM %s.%s WHERE state_key = $1`,
 		p.scopeName, schemas.Collections.OAuthState)
 	q, err := p.db.Query(query, &gocb.QueryOptions{
 		ScanConsistency:      gocb.QueryScanConsistencyRequestPlus,
+		Context:              ctx,
 		PositionalParameters: []interface{}{key},
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	type idRow struct {
 		ID string `json:"_id"`
 	}
+	// The N1QL SELECT is NOT the race arbiter — concurrent callers can both read
+	// the id. A KV Remove on a single document is atomic: the winner removes it,
+	// every other caller gets ErrDocumentNotFound. That is what distinguishes the
+	// caller that consumed the single-use code from one replaying it.
+	deleted := false
 	for q.Next() {
 		var row idRow
 		if err := q.Row(&row); err != nil {
 			continue
 		}
-		_, _ = p.db.Collection(schemas.Collections.OAuthState).Remove(row.ID, &gocb.RemoveOptions{Context: ctx})
+		if _, rErr := p.db.Collection(schemas.Collections.OAuthState).Remove(row.ID, &gocb.RemoveOptions{Context: ctx}); rErr != nil {
+			if errors.Is(rErr, gocb.ErrDocumentNotFound) {
+				continue
+			}
+			return false, rErr
+		}
+		deleted = true
 	}
-	return nil
+	return deleted, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/dynamodb/ops.go
+++ b/internal/storage/db/dynamodb/ops.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -54,6 +55,30 @@ func (p *provider) getItemByHash(ctx context.Context, table, hashKey, hashValue 
 		return fmt.Errorf("no record found")
 	}
 	return unmarshalItem(res.Item, out)
+}
+
+// deleteItemByHashIfExists deletes an item only if it is still present, and
+// reports whether THIS call removed it. The ConditionExpression is evaluated
+// atomically by DynamoDB, so under concurrent deletes of the same item exactly
+// one caller sees true and the rest get ConditionalCheckFailed (returned as
+// false, nil — an absent item is not an error). Used for single-use records
+// where "who removed it" is the security decision, e.g. authorization codes.
+func (p *provider) deleteItemByHashIfExists(ctx context.Context, table, hashKey, hashValue string) (bool, error) {
+	_, err := p.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(table),
+		Key: map[string]types.AttributeValue{
+			hashKey: &types.AttributeValueMemberS{Value: hashValue},
+		},
+		ConditionExpression: aws.String("attribute_exists(" + hashKey + ")"),
+	})
+	if err != nil {
+		var ccf *types.ConditionalCheckFailedException
+		if errors.As(err, &ccf) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (p *provider) deleteItemByHash(ctx context.Context, table, hashKey, hashValue string) error {

--- a/internal/storage/db/dynamodb/session_token.go
+++ b/internal/storage/db/dynamodb/session_token.go
@@ -50,22 +50,31 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
 	f := expression.Name("key_name").Equal(expression.Value(key))
 	items, err := p.queryEq(ctx, schemas.Collections.SessionToken, "user_id", "user_id", userId, &f)
 	if err != nil {
-		return err
+		return false, err
 	}
+	// The query is NOT the race arbiter — concurrent callers can both see the
+	// item. The conditional delete is: DynamoDB evaluates attribute_exists(id)
+	// atomically, so exactly one caller's delete succeeds and the rest get
+	// ConditionalCheckFailed.
+	deleted := false
 	for _, it := range items {
 		var t schemas.SessionToken
 		if err := unmarshalItem(it, &t); err != nil {
-			return err
+			return false, err
 		}
-		if err := p.deleteItemByHash(ctx, schemas.Collections.SessionToken, "id", t.ID); err != nil {
-			return err
+		ok, err := p.deleteItemByHashIfExists(ctx, schemas.Collections.SessionToken, "id", t.ID)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			deleted = true
 		}
 	}
-	return nil
+	return deleted, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID
@@ -296,21 +305,31 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
 	items, err := p.queryEq(ctx, schemas.Collections.OAuthState, "state_key", "state_key", key, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
+	// The GSI query is NOT the race arbiter — concurrent callers can both see the
+	// item. The conditional delete is: DynamoDB evaluates attribute_exists(id)
+	// atomically against the item, so exactly one caller's delete succeeds and
+	// every other gets ConditionalCheckFailed. That distinguishes the caller that
+	// consumed the single-use code from one replaying it.
+	deleted := false
 	for _, it := range items {
 		var s schemas.OAuthState
 		if err := unmarshalItem(it, &s); err != nil {
-			return err
+			return false, err
 		}
-		if err := p.deleteItemByHash(ctx, schemas.Collections.OAuthState, "id", s.ID); err != nil {
-			return err
+		ok, err := p.deleteItemByHashIfExists(ctx, schemas.Collections.OAuthState, "id", s.ID)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			deleted = true
 		}
 	}
-	return nil
+	return deleted, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/mongodb/oauth_state.go
+++ b/internal/storage/db/mongodb/oauth_state.go
@@ -43,10 +43,15 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
 	collection := p.db.Collection(schemas.Collections.OAuthState, options.Collection())
-	_, err := collection.DeleteMany(ctx, bson.M{"state_key": key})
-	return err
+	// DeleteOne (not DeleteMany): state_key is unique, and a single-document
+	// delete is atomic, so DeletedCount identifies the caller that won the race.
+	res, err := collection.DeleteOne(ctx, bson.M{"state_key": key})
+	if err != nil {
+		return false, err
+	}
+	return res.DeletedCount > 0, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/mongodb/session_token.go
+++ b/internal/storage/db/mongodb/session_token.go
@@ -48,10 +48,16 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
 	collection := p.db.Collection(schemas.Collections.SessionToken, options.Collection())
-	_, err := collection.DeleteMany(ctx, bson.M{"user_id": userId, "key_name": key})
-	return err
+	// DeleteOne, not DeleteMany: (user_id, key_name) identifies a single entry
+	// and a single-document delete is atomic, so DeletedCount identifies the
+	// caller that won the race.
+	res, err := collection.DeleteOne(ctx, bson.M{"user_id": userId, "key_name": key})
+	if err != nil {
+		return false, err
+	}
+	return res.DeletedCount > 0, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID

--- a/internal/storage/db/provider_template/oauth_state.go
+++ b/internal/storage/db/provider_template/oauth_state.go
@@ -40,9 +40,15 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key (StateKey).
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
-	// TODO: delete where state_key = ?
-	return nil
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
+	// TODO: delete where state_key = ?, returning whether THIS call removed the
+	// row. The bool MUST come from one atomic operation (a DELETE's affected-row
+	// count, a conditional/compare-and-set delete, or an LWT) — never a separate
+	// existence check then a delete. Authorization-code single-use (RFC 6749
+	// §4.1.2) depends on exactly one concurrent caller observing true; a
+	// read-then-delete hands the same code to every racer. Absent key =>
+	// (false, nil), not an error.
+	return false, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing).

--- a/internal/storage/db/provider_template/session_token.go
+++ b/internal/storage/db/provider_template/session_token.go
@@ -45,9 +45,13 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key (KeyName).
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
-	// TODO: delete where user_id = ? AND key_name = ?
-	return nil
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
+	// TODO: delete where user_id = ? AND key_name = ?, returning whether THIS
+	// call removed the row. The bool MUST come from one atomic operation (a
+	// DELETE's affected-row count, a conditional delete, or an LWT) — never a
+	// separate existence check then a delete. Refresh-token rotation depends on
+	// exactly one concurrent caller observing true. Absent key => (false, nil).
+	return false, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID.

--- a/internal/storage/db/sql/oauth_state.go
+++ b/internal/storage/db/sql/oauth_state.go
@@ -40,8 +40,14 @@ func (p *provider) GetOAuthStateByKey(ctx context.Context, key string) (*schemas
 }
 
 // DeleteOAuthStateByKey deletes an OAuth state by key
-func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) error {
-	return p.db.WithContext(ctx).Where("state_key = ?", key).Delete(&schemas.OAuthState{}).Error
+func (p *provider) DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error) {
+	// A single DELETE statement decides the race: the row lock serializes
+	// concurrent redemptions and RowsAffected tells the winner from the loser.
+	res := p.db.WithContext(ctx).Where("state_key = ?", key).Delete(&schemas.OAuthState{})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 // GetAllOAuthStates retrieves all OAuth states (for testing)

--- a/internal/storage/db/sql/session_token.go
+++ b/internal/storage/db/sql/session_token.go
@@ -49,8 +49,14 @@ func (p *provider) DeleteSessionToken(ctx context.Context, id string) error {
 }
 
 // DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error {
-	return p.db.WithContext(ctx).Where("user_id = ? AND key_name = ?", userId, key).Delete(&schemas.SessionToken{}).Error
+func (p *provider) DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error) {
+	// One DELETE decides the race: the row lock serializes concurrent refresh
+	// redemptions and RowsAffected tells the winner from the loser.
+	res := p.db.WithContext(ctx).Where("user_id = ? AND key_name = ?", userId, key).Delete(&schemas.SessionToken{})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 // DeleteAllSessionTokensByUserID deletes all session tokens for a user ID.

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -142,8 +142,25 @@ type Provider interface {
 	GetSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (*schemas.SessionToken, error)
 	// DeleteSessionToken deletes a session token by ID
 	DeleteSessionToken(ctx context.Context, id string) error
-	// DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and key
-	DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) error
+	// DeleteSessionTokenByUserIDAndKey deletes a session token by user ID and
+	// key. The bool reports whether THIS call removed the row, and it MUST be
+	// decided by a single atomic database operation — never by a separate
+	// existence check followed by a delete.
+	//
+	// This is the single-use primitive behind refresh-token rotation (OAuth 2.1
+	// §6.1): the token endpoint claims the presented refresh token before
+	// issuing its replacement, so under concurrent redemption of the same token
+	// exactly one caller may observe true. A read-then-delete implementation
+	// lets every racer mint an independent token family, which defeats rotation
+	// and its reuse detection. Deleting an absent key is not an error — it
+	// returns (false, nil).
+	//
+	// FAULT TOLERANCE: on error the bool is always false, even where a multi-row
+	// implementation already removed one row before failing. Fail-safe direction —
+	// callers MUST check the error first and treat an error as "claim outcome
+	// unknown", never as "not claimed" (TokenHandler answers 503, not
+	// invalid_grant, for exactly that reason).
+	DeleteSessionTokenByUserIDAndKey(ctx context.Context, userId, key string) (bool, error)
 	// DeleteAllSessionTokensByUserID deletes all session tokens for a user ID
 	DeleteAllSessionTokensByUserID(ctx context.Context, userId string) error
 	// DeleteSessionTokensByNamespace deletes all session tokens for a namespace (e.g., "auth_provider")
@@ -174,8 +191,25 @@ type Provider interface {
 	AddOAuthState(ctx context.Context, state *schemas.OAuthState) error
 	// GetOAuthStateByKey retrieves an OAuth state by key
 	GetOAuthStateByKey(ctx context.Context, key string) (*schemas.OAuthState, error)
-	// DeleteOAuthStateByKey deletes an OAuth state by key
-	DeleteOAuthStateByKey(ctx context.Context, key string) error
+	// DeleteOAuthStateByKey deletes an OAuth state by key. The bool reports
+	// whether THIS call removed the row, and it MUST be decided by a single
+	// atomic database operation (row-level DELETE, LWT, or conditional write) —
+	// never by a separate existence check followed by a delete.
+	//
+	// This is the single-use primitive behind authorization codes (RFC 6749
+	// §4.1.2) and the SSO broker's `state`: under concurrent redemption of the
+	// same code exactly one caller may observe true. A read-then-delete
+	// implementation hands the same code to every racer, which is an
+	// authorization-code replay. Deleting an absent key is not an error — it
+	// returns (false, nil).
+	//
+	// FAULT TOLERANCE: on error the bool is always false, even where a multi-row
+	// implementation already removed one row before failing. That is the
+	// fail-safe direction — a caller that ignored the error would decline to
+	// proceed rather than proceed twice. Callers MUST check the error before
+	// trusting the bool, and MUST treat an error as "claim outcome unknown", not
+	// as "not claimed".
+	DeleteOAuthStateByKey(ctx context.Context, key string) (bool, error)
 	// GetAllOAuthStates retrieves all OAuth states (for testing)
 	GetAllOAuthStates(ctx context.Context) ([]*schemas.OAuthState, error)
 

--- a/internal/storage/provider_test.go
+++ b/internal/storage/provider_test.go
@@ -953,7 +953,7 @@ func testSessionTokenOperations(t *testing.T, ctx context.Context, provider Prov
 
 	// Test AddSessionToken with same key (should replace - delete first then add)
 	// Note: Multiple sessions per user are allowed (different key_name), but same (user_id, key_name) should be unique
-	err = provider.DeleteSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
+	_, err = provider.DeleteSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
 	assert.NoError(t, err)
 
 	token2 := &schemas.SessionToken{
@@ -981,9 +981,16 @@ func testSessionTokenOperations(t *testing.T, ctx context.Context, provider Prov
 	err = provider.AddSessionToken(ctx, token3)
 	require.NoError(t, err)
 
-	// Test DeleteSessionTokenByUserIDAndKey
-	err = provider.DeleteSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
+	// Test DeleteSessionTokenByUserIDAndKey — reports true only for the call
+	// that actually removed the row (the single-use claim behind refresh-token
+	// rotation), and a repeat delete is false, not an error.
+	claimedToken, err := provider.DeleteSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
 	assert.NoError(t, err)
+	assert.True(t, claimedToken, "the first delete of an existing entry must report it claimed the row")
+
+	claimedToken, err = provider.DeleteSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
+	assert.NoError(t, err, "deleting an absent entry is not an error")
+	assert.False(t, claimedToken, "a repeat delete must not claim the row")
 
 	// Verify deletion
 	_, err = provider.GetSessionTokenByUserIDAndKey(ctx, userId, "session_token_key")
@@ -1327,9 +1334,16 @@ func testOAuthStateOperations(t *testing.T, ctx context.Context, provider Provid
 	err = provider.AddOAuthState(ctx, state3)
 	require.NoError(t, err)
 
-	// Test DeleteOAuthStateByKey
-	err = provider.DeleteOAuthStateByKey(ctx, "test_state_key_1")
+	// Test DeleteOAuthStateByKey — reports true only for the call that actually
+	// removed the row (the single-use claim behind authorization codes).
+	claimed, err := provider.DeleteOAuthStateByKey(ctx, "test_state_key_1")
 	assert.NoError(t, err)
+	assert.True(t, claimed, "the first delete of an existing key must report it claimed the row")
+
+	// A second delete of the same key removed nothing: false, and NOT an error.
+	claimed, err = provider.DeleteOAuthStateByKey(ctx, "test_state_key_1")
+	assert.NoError(t, err, "deleting an absent key is not an error")
+	assert.False(t, claimed, "a repeat delete must not claim the row")
 
 	// Verify deletion
 	_, err = provider.GetOAuthStateByKey(ctx, "test_state_key_1")

--- a/internal/token/auth_token.go
+++ b/internal/token/auth_token.go
@@ -403,8 +403,17 @@ func (p *provider) createMachineAccessToken(cfg *AuthTokenConfig) (string, int64
 	}
 	expiresAt := time.Now().Add(expiryBound).Unix()
 	customClaims := jwt.MapClaims{
-		"iss":          cfg.HostName,
-		"aud":          p.config.ClientID,
+		"iss": cfg.HostName,
+		// RFC 8707 audience restriction. When the client_credentials request
+		// carried a `resource`, that resource becomes the audience so the token
+		// is usable ONLY at the named resource server — the same binding the
+		// authorization_code and token-exchange paths already apply, and what
+		// Auth0's required `audience` parameter and Keycloak's audience mappers
+		// provide. Without it every service-account token in a deployment shares
+		// one audience, so a token minted for service A is valid at service B.
+		// Omitted `resource` keeps the previous global-client_id audience, so
+		// existing single-audience deployments are unaffected.
+		"aud":          p.accessTokenAudience(cfg),
 		"nonce":        cfg.Nonce,
 		"sub":          cfg.ServiceAccountID,
 		"exp":          expiresAt,
@@ -506,7 +515,10 @@ func (p *provider) ValidateAccessToken(gc *gin.Context, accessToken string) (map
 	// RFC 8707 audience restriction. A token minted with a resource indicator
 	// carries that resource (an absolute URI, e.g. "https://mcp.example.com") as
 	// its `aud` so it is usable ONLY at that external resource server — which
-	// validates it via /oauth/introspect or JWKS, NOT here. This path guards
+	// validates it locally against the published JWKS, NOT here. (Not via
+	// /oauth/introspect either: that endpoint only answers for a token whose aud
+	// is the authenticated caller's own client_id, so a resource-bound token
+	// always introspects as inactive — see token.DelegatedAccessTokenTTL.) This path guards
 	// Authorizer's OWN protected resources (/userinfo, GraphQL, gRPC). Accepting
 	// a resource-bound token here would defeat the audience restriction the token
 	// was issued with, so reject any `aud` that is an absolute URI (resource

--- a/internal/token/delegation_token.go
+++ b/internal/token/delegation_token.go
@@ -11,9 +11,30 @@ import (
 
 // DelegatedAccessTokenTTL is the fixed short lifetime of an exchanged delegation
 // token (AGENTIC_DELEGATION_DESIGN DC5: 5-minute baseline). Delegation tokens
-// are not refreshable — the agent re-exchanges — and sensitive-scope revocation
-// is enforced out of band via /oauth/introspect, so a short TTL bounds the blast
-// radius of a leaked token.
+// are not refreshable — the agent re-exchanges.
+//
+// REVOCATION: there is none. This TTL is the ONLY bound on a leaked delegated
+// token. Earlier revisions of this comment claimed "sensitive-scope revocation
+// is enforced out of band via /oauth/introspect"; that was never true and is
+// corrected here rather than left as a false assurance:
+//
+//   - These tokens are stateless — nothing is written to the session store at
+//     issuance, so there is no entry to delete.
+//   - /oauth/introspect cannot report on one anyway. It answers only for a token
+//     whose `aud` is the AUTHENTICATED CALLER's client_id, while a delegated
+//     token's `aud` is the RFC 8707 resource URI. A resource server presenting
+//     its own credentials therefore always gets {"active": false} — correct
+//     per RFC 7662 §2.2 (no oracle), but useless as a revocation signal.
+//
+// So a delegated token is valid until it expires, full stop. Downstream
+// resource servers verify it locally against /.well-known/jwks.json. Keep this
+// TTL short; lengthening it directly lengthens the window in which a stolen
+// token cannot be stopped.
+//
+// Making revocation real needs a resource registry (which client may introspect
+// which resource's tokens) plus either stateful issuance or a deny-list — a
+// design change, not a patch. Until that exists, do not document or rely on
+// revocation for delegated tokens.
 const DelegatedAccessTokenTTL = 5 * time.Minute
 
 // accessTokenJWTType is the RFC 9068 media type stamped in the JWT header `typ`
@@ -45,8 +66,9 @@ type DelegationTokenConfig struct {
 // CreateDelegatedAccessToken mints the RFC 8693 delegation access token. Unlike
 // the first-party access tokens it is stateless (not registered in the memory
 // store) and its `aud` is the bound resource, not this server's client_id — it
-// is validated by the downstream resource server (local JWT verification and/or
-// /oauth/introspect), never by Authorizer's own ValidateAccessToken path. The
+// is validated by the downstream resource server through local JWT verification
+// against the published JWKS, never by Authorizer's own ValidateAccessToken
+// path and NOT via /oauth/introspect (see DelegatedAccessTokenTTL). The
 // CUSTOM_ACCESS_TOKEN_SCRIPT is intentionally not run: `act`/`client_id` are
 // reserved and there is no resource-owner user object to feed the script.
 func (p *provider) CreateDelegatedAccessToken(cfg *DelegationTokenConfig) (*JWTToken, error) {


### PR DESCRIPTION
## Why

Authorization codes and refresh tokens were validated by a read followed by a
separate delete. Concurrent redemption therefore handed the same credential to
every caller. Both reproduced against a real build:

- **39 of 40** concurrent double-redemptions returned the same authorization
  code to *both* callers (RFC 6749 §4.1.2 single-use defeated).
- Two simultaneous refreshes both returned `200` and each minted an
  independent, separately-rotating token family from one refresh token
  (OAuth 2.1 §6.1 reuse detection defeated).

Neither was reachable by the existing suite: every replay assertion in the repo
is sequential (`await` first, then send second), which a read-then-delete passes
perfectly, and there was not one `Promise.all` anywhere in the e2e specs.

## What changed

**Atomic single-use claims.** `DeleteOAuthStateByKey` and
`DeleteSessionTokenByUserIDAndKey` now return whether *this* call removed the
row, decided by one atomic operation per backend:

| Backend | Mechanism |
|---|---|
| SQL | `RowsAffected` |
| MongoDB | `DeleteOne` + `DeletedCount` |
| ArangoDB | `REMOVE … RETURN OLD` |
| Cassandra / ScyllaDB | `DELETE … IF EXISTS` (Paxos LWT) |
| DynamoDB | conditional delete on `attribute_exists` |
| Couchbase | KV `Remove` + `ErrDocumentNotFound` |

Redis and in-memory were already correct. `TokenHandler` gates issuance on
winning the claim; the loser gets the same opaque `invalid_grant` a replay does.

**DB-backed cache was process-local.** The store selected for any deployment
with a database and no `REDIS_URL` kept its cache in a package-level map, so
SAML assertion single-use, RFC 7523 `jti` replay and OTP lockout counters were
per-replica — N replicas granted N× the attempts. Moved into
`authorizer_session_tokens`, which has an indexed `(user_id, key_name)`, a real
`expires_at`, and an existing reaper. (`oauth_states` has no reaper at all.)

**M2M audience binding.** `client_credentials` ignored RFC 8707 `resource`, so
every service-account token carried the same `aud` and was valid at every
internal service. Auth0 makes `audience` mandatory on this grant; Keycloak binds
it via audience mappers. Omitting `resource` keeps the previous behaviour.

**Also:** token-exchange accepted any opaque string as `resource` where
`/authorize` enforced absolute-URI; DB-store session expiry was exclusive
(entries lived one second past expiry) where in-memory and Redis are inclusive;
startup now warns when `--url` is unset (GHSA-m82j-rq33-qjx2 — reset links are
otherwise built from attacker-controllable `Host` headers).

## New coverage for the blind spots

- `internal/memory_store/single_use_test.go` — concurrent claim contract, run
  against **every** provider. The `db` provider was declared in the test matrix
  but never exercised; adding it immediately surfaced the expiry off-by-one.
- `e2e-playground/tests/concurrency.spec.ts` — fires redemptions with
  `Promise.all` instead of sequentially. This is what caught the refresh race.
- `e2e-playground/tests/replica-shared-state.spec.ts` + two authorizer replicas
  over a shared Postgres — the first place two instances share state at all, so
  cross-replica cache coherence is testable.
- `internal/parsers/host_header_injection_test.go` — pins both halves of
  GHSA-m82j-rq33-qjx2 (mitigated with `--url`, vulnerable without).
- `make e2e-playground` never rebuilt the Playwright image, so **any** spec edit
  was silently ignored and the stale suite re-ran. Added `--build`.

## Known gaps, documented in place — not fixed here

Each needs a design decision rather than a patch:

1. **Stale roles on refresh.** Roles are carried from the old token, so a
   stripped role keeps being minted. Do *not* intersect with `user.Roles`: SSO
   and SAML build session roles as
   `unionRoles(splitRoles(user.Roles), orgGroupDerivedRoles(...))`, where the
   derived half comes from the FGA engine. Intersecting strips every
   org-group-derived role and, for SCIM users (created with no `Roles` field),
   rejects the grant outright. Verified: `["user","org_admin"] ∩ "user" → ["user"]`.
   Correct fix re-derives effective roles at refresh, which needs org context in
   the token plus an FGA lookup.
2. **Delegated (RFC 8693) tokens have no revocation.** The 5-minute TTL is the
   only bound; a prior comment claiming `/oauth/introspect` enforced it was
   false and is corrected. Real revocation needs a resource registry.
3. **Concurrent `AutoMigrate`** kills a replica on a fresh shared database.
   Worked around in the e2e compose with a comment; wants an advisory lock.

## Fault tolerance

Fail-closed on security gates, fail-open on availability aids — matching the
existing philosophy. A claim error returns a retryable `503`, not
`invalid_grant`, so a store fault is never reported as permanently-bad
credentials. On error the claim bool is always `false` even if a row was already
removed (fail-safe direction), written into the interface contract.

Residual, all documented and all absent when `REDIS_URL` is set: the DB cache
fails open on read faults (the storage layer cannot distinguish "no row" from
"read failed" — 7 different error types), `SetCache` is delete-then-insert so a
partial failure loses the key, and `IncrementCache` can undercount under exact
cross-replica concurrency. **Multi-instance production should use Redis**, not
just a shared database.

## Verification

All run on the final tree:

| Gate | Result |
|---|---|
| `go build` / `go vet` | pass |
| `make lint` | 0 issues |
| `go test ./...` (SQLite) | exit 0, 39 packages |
| memory_store with Redis | pass |
| `make test-all-db` (7 backends) | exit 0 |
| `make e2e-playground` | 75/75, 0 skipped |
| `make smoke` | pass |

`test-all-db` earned its keep: the first run failed on ScyllaDB only, because
`ScanCAS()` with no destinations cannot read an LWT result set that carries the
row's columns (`have 1 want 8`). Every claim errored to `false`, which would
have made Cassandra/ScyllaDB deployments unable to redeem any code or refresh
token at all. Fixed with `MapScanCAS`, matching the existing LWT usage in
`org_domain.go`.

## Review notes

Two changes in an earlier pass of this work were wrong and were reverted or
reworked after review — the role narrowing above, and the cache initially landing
in `oauth_states` (a table with no reaper, scanned on every successful OTP
verification). Both are called out because the diff is large and
security-sensitive; the storage-interface changes in particular touch all seven
backends.
