### PR TITLE
docs: neutralise vendor comparisons in comments

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -510,7 +510,9 @@ The v2 repo ships with a `Makefile` that wraps the most common development and b
 
 ### Model
 
-v2 ships a Keycloak-inspired four-pillar authorization engine:
+v2 ships a four-pillar authorization engine, following the role/group/permission
+model conventional in enterprise IAM (Keycloak and similar servers organise
+authorization along the same lines):
 
 | Concept    | Purpose                                                                 |
 | ---------- | ----------------------------------------------------------------------- |

--- a/internal/http_handlers/authorize.go
+++ b/internal/http_handlers/authorize.go
@@ -382,7 +382,8 @@ func (h *httpProvider) AuthorizeHandler() gin.HandlerFunc {
 		// Forward all RP-provided OIDC parameters through the login UI so
 		// the React app can send them back on the second /authorize
 		// round-trip. Without this, the code flow loses the RP-provided
-		// values and Auth0/Okta/Keycloak reject the resulting tokens.
+		// values and strict downstream RPs (e.g. Auth0, Okta, Keycloak) reject the
+		// resulting tokens.
 		authState += "&nonce=" + url.QueryEscape(nonce)
 		if codeChallenge != "" {
 			authState += "&code_challenge=" + url.QueryEscape(codeChallenge)

--- a/internal/http_handlers/oauth_sso.go
+++ b/internal/http_handlers/oauth_sso.go
@@ -1,7 +1,7 @@
 package http_handlers
 
 // Per-organization enterprise OIDC SSO — Authorizer acting as the Relying Party
-// (broker). An org configures its upstream OIDC IdP (Okta/Entra/Google) as a
+// (broker). An org configures its upstream OIDC IdP (e.g. Okta, Entra, Google) as a
 // sso_oidc TrustedIssuer row; its users log in through that IdP and Authorizer
 // JIT-provisions them and issues a normal Authorizer session.
 //

--- a/internal/http_handlers/saml_sp.go
+++ b/internal/http_handlers/saml_sp.go
@@ -1,7 +1,7 @@
 package http_handlers
 
 // Per-organization enterprise SAML 2.0 SSO — Authorizer acting as the Service
-// Provider (SP). An org configures its upstream corporate IdP (Okta/Entra/ADFS)
+// Provider (SP). An org configures its upstream corporate IdP (e.g. Okta, Entra, ADFS)
 // as an sso_saml TrustedIssuer row; its users log in through that IdP, Authorizer
 // validates the signed assertion, JIT-provisions the user (namespaced by
 // (org_id, IdP-entity-id, NameID)) and issues a normal Authorizer session.

--- a/internal/http_handlers/token.go
+++ b/internal/http_handlers/token.go
@@ -543,7 +543,7 @@ func (h *httpProvider) TokenHandler() gin.HandlerFunc {
 			// NOTE: Do NOT delete the user's browser session here. The
 			// /authorize endpoint already performed session rollover when it
 			// created the authorization code. The /oauth/token endpoint is
-			// called server-to-server by the RP (Auth0/Okta/Keycloak), not
+			// called server-to-server by the RP (e.g. Auth0, Okta, Keycloak), not
 			// by the user's browser. Deleting the session here would
 			// invalidate the cookie the user's browser holds, breaking
 			// subsequent session lookups (e.g., GraphQL session query).

--- a/internal/integration_tests/token_grant_hardening_test.go
+++ b/internal/integration_tests/token_grant_hardening_test.go
@@ -24,8 +24,10 @@ import (
 // Without it every service-account token in a deployment carries the same `aud`
 // (the deployment's global client_id), so a token minted for one internal
 // service is equally valid at every other — the resource server loses the
-// cheapest rejection it has. Auth0 makes `audience` mandatory on this grant and
-// Keycloak binds it via audience mappers; this is the equivalent.
+// cheapest rejection it has. Binding a machine token to the API it is meant for
+// is the established shape for this grant; `resource` (RFC 8707) is the
+// standards-track spelling of it, and some providers expose the same idea as an
+// `audience` request parameter or an audience claim mapper.
 func TestClientCredentialsAudienceBinding(t *testing.T) {
 	ts := initTestSetup(t, getTestConfig())
 	router := gin.New()

--- a/internal/storage/schemas/scim_endpoint.go
+++ b/internal/storage/schemas/scim_endpoint.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ScimEndpoint is the per-organization inbound SCIM 2.0 connection credential.
-// A customer's IdP (Okta, Entra, …) authenticates to /scim/v2/ with a bearer
+// A customer's IdP (e.g. Okta, Entra) authenticates to /scim/v2/ with a bearer
 // token; the org it may provision is derived ONLY from the matched endpoint
 // (design §4.4 H6 — never from the URL or payload).
 //

--- a/internal/storage/schemas/trusted_issuer.go
+++ b/internal/storage/schemas/trusted_issuer.go
@@ -118,7 +118,9 @@ type TrustedIssuer struct {
 	// EnableTokenReview activates online K8s TokenReview validation (kubernetes_sa only).
 	// When true, Authorizer calls the K8s API server after offline JWT verification to
 	// confirm the bound Pod/ServiceAccount still exists.
-	// Default false — offline JWKS validation only (same as Keycloak default).
+	// Default false — offline JWKS validation only, which is the usual default
+	// for JWT-bearer trust across OIDC providers (an online revocation check
+	// costs an API round-trip on every authentication).
 	// SECURITY NOTE (S7): offline-only validation accepts tokens for deleted objects
 	// until exp. Enable this flag for high-security workloads.
 	EnableTokenReview bool `json:"enable_token_review" bson:"enable_token_review" cql:"enable_token_review" dynamo:"enable_token_review"`

--- a/internal/token/auth_token.go
+++ b/internal/token/auth_token.go
@@ -407,12 +407,12 @@ func (p *provider) createMachineAccessToken(cfg *AuthTokenConfig) (string, int64
 		// RFC 8707 audience restriction. When the client_credentials request
 		// carried a `resource`, that resource becomes the audience so the token
 		// is usable ONLY at the named resource server — the same binding the
-		// authorization_code and token-exchange paths already apply, and what
-		// Auth0's required `audience` parameter and Keycloak's audience mappers
-		// provide. Without it every service-account token in a deployment shares
-		// one audience, so a token minted for service A is valid at service B.
-		// Omitted `resource` keeps the previous global-client_id audience, so
-		// existing single-audience deployments are unaffected.
+		// authorization_code and token-exchange paths already apply. Without it
+		// every service-account token in a deployment shares one audience, so a
+		// token minted for service A is valid at service B and the resource
+		// server loses its cheapest rejection. Omitted `resource` keeps the
+		// previous global-client_id audience, so existing single-audience
+		// deployments are unaffected.
 		"aud":          p.accessTokenAudience(cfg),
 		"nonce":        cfg.Nonce,
 		"sub":          cfg.ServiceAccountID,

--- a/perf/README.md
+++ b/perf/README.md
@@ -271,8 +271,9 @@ contention, not the server's ceiling.
 ## Publishing numbers worldwide — checklist
 
 Any number that leaves this repo needs its methodology attached, or it's not
-defensible against scrutiny (this is a self-hosted auth server competing on
-"lighter than Keycloak" — the number needs to survive a skeptical read):
+defensible against scrutiny. Resource-footprint claims about a self-hosted auth
+server get read skeptically and get benchmarked back at you, so publish nothing
+that can't survive someone reproducing it:
 
 - [ ] Hardware: exact chip, core count, RAM, arch (x86_64 vs arm64)
 - [ ] Native vs Docker/VM (Docker Desktop on macOS adds virtualization overhead — disclose it)


### PR DESCRIPTION
## Why

Several comments named other IdP vendors as a benchmark rather than as an
illustration — "what Auth0's required `audience` parameter and Keycloak's
audience mappers provide", "same as Keycloak default", "competing on lighter
than Keycloak". That framing dates badly (it is wrong the moment another vendor
changes behaviour), and it puts positioning language into source comments where
an engineer wants the reason, not the scoreboard.

Named products are kept — they are genuinely useful for orientation — but only
in example form.

## Changes

| File | Before | After |
|---|---|---|
| `internal/token/auth_token.go` | "…and what Auth0's required `audience` parameter and Keycloak's audience mappers provide" | explains the consequence directly: one shared audience means a token minted for service A is valid at service B |
| `token_grant_hardening_test.go` | "Auth0 makes `audience` mandatory…; this is the equivalent" | describes the established shape for the grant, with `resource` as the standards-track spelling |
| `internal/storage/schemas/trusted_issuer.go` | "same as Keycloak default" | justified by its actual cost — an API round-trip per authentication |
| `MIGRATION.md` | "Keycloak-inspired four-pillar authorization engine" | described by its own role/group/permission shape, noting the model is conventional in enterprise IAM |
| `perf/README.md` | "competing on 'lighter than Keycloak'" | argues from reproducibility: published numbers get benchmarked back at you |

Also normalised bare slash-lists to explicit example form so they cannot be read
as claims — `(Okta/Entra/ADFS)` becomes `(e.g. Okta, Entra, ADFS)` in
`saml_sp.go`, `oauth_sso.go`, `scim_endpoint.go`, `authorize.go` and `token.go`.

## Left alone deliberately

- **Interop facts**, where the vendor name *is* the information: the Okta and
  Auth0 doc links in `authorize.go`, and the CHANGELOG's "(Auth0 compatibility)"
  note on base64url padding tolerance — that is literally why the code exists.
- **CHANGELOG history** — a record of what shipped, not something to rewrite.
- **Test fixtures** using Okta/Entra as sample IdP names.
- `.claude/research/machine-client-authz-landscape.md` — an explicitly headed
  competitive-landscape brief, doing exactly its job.

## Verification

Comment- and docs-only. Mechanically confirmed that every changed Go line is a
comment:

```
git diff -U0 -- '*.go' | grep '^[+-]' | grep -v '^[+-]\s*//'
→ (empty)
```

`go build`, `make lint-go` (0 issues), and the touched packages
(`internal/token`, `internal/storage/schemas`, `internal/http_handlers`) all pass.
