### PR TITLE
fix(e2e): rebuild images so the suite tests current source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,8 +313,11 @@ e2e-playground: ## Run the live-playground e2e suite (OIDC/SAML/SCIM/SSO/OAuth/M
 # makes this close to free when nothing changed.
 	export DOCKER_DEFAULT_PLATFORM=linux/$$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); \
 	docker compose -f e2e-playground/docker-compose.yml build; \
-	docker compose -f e2e-playground/docker-compose.yml up -d --wait authorizer authorizer-sso mock-oauth mock-saml-idp mailpit sms-sink; \
 	status=$$?; \
+	if [ $$status -eq 0 ]; then \
+		docker compose -f e2e-playground/docker-compose.yml up -d --wait authorizer authorizer-sso mock-oauth mock-saml-idp mailpit sms-sink; \
+		status=$$?; \
+	fi; \
 	if [ $$status -eq 0 ]; then \
 		docker compose -f e2e-playground/docker-compose.yml run --rm --build playwright npx playwright test; \
 		status=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,18 @@ perf-k6-check:
 
 .PHONY: e2e-playground
 e2e-playground: ## Run the live-playground e2e suite (OIDC/SAML/SCIM/SSO/OAuth/MFA) against an ephemeral docker-compose stack
+# The explicit `build` below is load-bearing: `docker compose up` builds an image
+# only when one does not already exist, so without it a second run silently
+# reuses the image from the FIRST run and the whole suite tests stale server
+# code. `down -v` at the end removes containers and volumes, never images, so a
+# stale image survives indefinitely. Building every service (rather than adding
+# --build to the `up` list) covers the instances started implicitly through the
+# playwright service's depends_on — authorizer-webauthn, -magic-link,
+# -mfa-enforced, -mfa-magic-link, -replica-a/-b, webhook-sink — which are never
+# named in the `up` line and so would otherwise never be rebuilt. Layer caching
+# makes this close to free when nothing changed.
 	export DOCKER_DEFAULT_PLATFORM=linux/$$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); \
+	docker compose -f e2e-playground/docker-compose.yml build; \
 	docker compose -f e2e-playground/docker-compose.yml up -d --wait authorizer authorizer-sso mock-oauth mock-saml-idp mailpit sms-sink; \
 	status=$$?; \
 	if [ $$status -eq 0 ]; then \


### PR DESCRIPTION
## The bug

`docker compose up` builds an image only when one does not already exist, and
`down -v` removes containers and volumes but **never images**. So the first
`make e2e-playground` built the authorizer image, and every run after that
silently reused it — the suite has been exercising stale server code for as long
as the image survived on the machine.

`e2e-playground-sdk` already passed `--build` on its `up`. The main target did not.

## Demonstrated, not inferred

```
# add a startup log line to cmd/root.go, then build + up
docker compose logs authorizer | grep E2E_FRESHNESS_MARKER_ZULU
→ 1 hit                      # build picks up local source

# revert the source completely, then `up` with no build
docker compose logs authorizer | grep E2E_FRESHNESS_MARKER_ZULU
→ 1 hit                      # container still runs code deleted from source
```

The second result is the bug: a container serving a log line that no longer
exists anywhere in the tree.

## Fix

An explicit `docker compose build` before `up`.

Building **every** service rather than adding `--build` to the `up` list is
deliberate: the `up` line names only `authorizer`, `authorizer-sso` and the
mocks. The remaining instances — `authorizer-webauthn`, `-magic-link`,
`-mfa-enforced`, `-mfa-magic-link`, `-replica-a`, `-replica-b`, `webhook-sink` —
are started implicitly through the `playwright` service's `depends_on`, are never
named in `up`, and so would still never be rebuilt. Layer caching makes the extra
build close to free when nothing changed.

## A note on how this was nearly misdiagnosed

The first evidence I looked at was image IDs changing between builds, which is
**not** a reliable staleness signal here. The Dockerfile's final stage copies only
the compiled binary and the built web assets, and the Go build uses `-trimpath`,
so a comment-only source change produces a byte-identical binary and therefore an
identical image ID. Image-ID comparison can only be trusted for changes that
actually alter the binary — hence the startup-marker probe above.

## Verification

`make e2e-playground` on the fixed target: **75 passed, 0 failed, 0 skipped**,
exit 0, images confirmed rebuilt from current source.

One unrelated flake was observed once across these runs —
`tests/social/apple.spec.ts` hit a 15s `waitForURL` navigation timeout during a
run that competed with an image rebuild for CPU. It passed on every other run,
including a clean 75/75 immediately after. Noting it rather than hiding it; if it
recurs, that timeout is the thing to look at.
