### PR TITLE
ci(release): push images to Docker Hub alongside Quay

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ on:
 
 env:
   DOCKER_IMAGE: quay.io/authorizer/authorizer
+  # Quay exposes no lifetime pull counter (only a trailing 92-day window), so
+  # the same image also goes to Docker Hub, which does.
+  DOCKERHUB_IMAGE: docker.io/lakhansamani/authorizer
   BUILDKIT_INLINE_CACHE: 1
 
 jobs:
@@ -68,16 +71,21 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         env:
           SOURCE_URL: https://github.com/${{ github.repository }}
         run: |
           VERSION=$(basename ${GITHUB_REF})
-          TAG_ARGS=(-t "${DOCKER_IMAGE}:${VERSION}")
+          TAG_ARGS=(-t "${DOCKER_IMAGE}:${VERSION}" -t "${DOCKERHUB_IMAGE}:${VERSION}")
           # Only a final release moves :latest. Match strict semver with no
           # pre-release suffix (vX.Y.Z / X.Y.Z) so rc/beta/alpha/pre never win.
           if [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            TAG_ARGS+=(-t "${DOCKER_IMAGE}:latest")
+            TAG_ARGS+=(-t "${DOCKER_IMAGE}:latest" -t "${DOCKERHUB_IMAGE}:latest")
           fi
           docker buildx build \
             --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
## Why

Quay has no lifetime pull counter. It stores daily rows in `RepositoryActionCount` and exposes at most a trailing **92 days** (`MAX_DAYS_IN_3_MONTHS`, `quay/quay`); the namespace listing's `popularity` field is a **7-day** sum (`get_repositories_action_sums`). There is no cumulative column in the schema — nothing to enable, nothing to fix on Quay's side.

Docker Hub does keep a monotonic counter, and `lakhansamani/authorizer` already holds five years of it. It stalled at v2.2.1 (2026-04-14) when releases went Quay-only.

Current state:

| | counter | value |
|---|---|---|
| `quay.io/authorizer/authorizer` | 92-day window | 2,380 |
| | popularity (7d) | 239 |
| `docker.io/lakhansamani/authorizer` | **lifetime** | 39,154 |

## What

- Release workflow tags both registries in the **same** `docker buildx build --push`. Identical digests, no extra build minutes, no second job.
- `:latest` still moves only on strict semver — rc/beta/alpha never win, on either registry.
- Buildcache stays on Quay alone; one cache is enough and it is not user-facing.

One file changed. No new secrets: reuses `DOCKER_USERNAME` / `DOCKER_PASSWORD`, already present from when releases last shipped to Docker Hub.

## Notes

- Those two secrets date to 2021-09-11 and were last exercised around v2.2.1. If `DOCKER_PASSWORD` is an account password rather than an access token and the account has 2FA enabled, `docker login` will fail — worth a dry run via `workflow_dispatch` before tagging a real release.
- `buildcache` pulls from our own CI land in the same repo-level counter, so neither total is purely end-user traffic.
- `DOCKERHUB_IMAGE` points at the personal namespace `lakhansamani/authorizer` to preserve the existing 39k history. Moving to an `authorizer/authorizer` org on Docker Hub is a one-line change but forks the counter — worth deciding now rather than later.
