### PR TITLE
docs: add --encryption-key to server config examples

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -97,7 +97,8 @@ Pass all config as **CLI arguments** when starting the server binary (e.g. the v
   --client-secret=YOUR_CLIENT_SECRET \
   --admin-secret=your-admin-secret \
   --jwt-type=HS256 \
-  --jwt-secret=your-jwt-secret
+  --jwt-secret=your-jwt-secret \
+  --encryption-key=your-encryption-key
 ```
 
 For local development (from repo root):
@@ -106,7 +107,7 @@ For local development (from repo root):
 make dev
 # or
 go run main.go --database-type=sqlite --database-url=test.db \
-  --jwt-type=HS256 --jwt-secret=test --admin-secret=admin \
+  --jwt-type=HS256 --jwt-secret=test --encryption-key=test-encryption-key --admin-secret=admin \
   --client-id=123456 --client-secret=secret
 ```
 
@@ -296,6 +297,7 @@ Use these v2 **CLI flags** instead of v1 env or dashboard config. Flag names use
 | `JWT_SECRET`                        | `--jwt-secret`                          |
 | `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` | `--jwt-private-key`, `--jwt-public-key` |
 | `JWT_ROLE_CLAIM`                    | `--jwt-role-claim`                      |
+| _(new in 2.4.0)_                    | `--encryption-key`                      |
 | `CUSTOM_ACCESS_TOKEN_SCRIPT`        | `--custom-access-token-script`          |
 
 
@@ -370,7 +372,7 @@ These mutations and queries exist for compatibility but **return an error** in v
 | -------------------- | ------------------------------------------------------------------------- | --------- |
 | `_update_env`        | Returns error: *"deprecated. please configure env via cli args"*          | Configure via CLI flags at startup. |
 | `_admin_signup`      | Returns error: *"deprecated. please configure admin secret via cli args"* | Set admin secret with `--admin-secret` at startup. |
-| `_generate_jwt_keys` | Returns error: *"deprecated. please configure jwt keys via cli args"*     | Set JWT with `--jwt-type`, `--jwt-secret`, or `--jwt-private-key` / `--jwt-public-key` at startup. |
+| `_generate_jwt_keys` | Returns error: *"deprecated. please configure jwt keys via cli args"*     | Set JWT with `--jwt-type`, `--jwt-secret`, or `--jwt-private-key` / `--jwt-public-key` at startup. RSA/ECDSA also needs `--encryption-key` (2.4.0+). |
 | `mobile_signup`      | Returns error: *"deprecated, use signup with mobile phone_number"*        | Use the `signup` mutation with `phone_number` instead. |
 | `mobile_login`       | Returns error: *"deprecated, use login with mobile phone_number"*         | Use the `login` mutation with `phone_number` instead. |
 
@@ -384,6 +386,7 @@ These mutations and queries exist for compatibility but **return an error** in v
 
 - **Admin secret:** set with `--admin-secret` at startup.
 - **JWT keys/type:** set with `--jwt-type`, `--jwt-secret`, or `--jwt-private-key` / `--jwt-public-key` at startup.
+- **At-rest encryption key (2.4.0+):** `--encryption-key` protects TOTP secrets and OTP digests. Required with `RS*`/`ES*` — those have no `--jwt-secret` to fall back to, and the server refuses to start without it. HMAC deployments fall back automatically, but a distinct key keeps JWT-secret rotation from locking out enrolled TOTP users.
 - **All other env:** use the corresponding CLI flags when starting the server.
 
 If your app or dashboard calls any of the deprecated mutations or queries above, remove or replace those calls and use the migration guidance in the tables.
@@ -486,7 +489,7 @@ The v2 repo ships with a `Makefile` that wraps the most common development and b
 
 - Copy all env configs from your v1 dashboard (client_id, client_secret, admin_secret, social provider configs, roles, JWT secrets, session/Redis config, email/SMTP config, allowed_origins, custom_access_token_script) and pass them as CLI args.
 - Set `**--client-id**` and `**--client-secret**` (required).
-- Set `**--admin-secret**` and JWT options (`**--jwt-type**` and `**--jwt-secret**` or key pair) at startup.
+- Set `**--admin-secret**` and JWT options (`**--jwt-type**` and `**--jwt-secret**` or key pair) at startup. With a key pair, also set `**--encryption-key**` (2.4.0+).
 - Stop calling `**_update_env**`, `**_admin_signup**`, and `**_generate_jwt_keys**`; remove or replace with startup config.
 - Update Docker/K8s/deployment to pass config as **CLI args** (or via a wrapper that maps env → args).
 - Upgrade **@authorizerdev/authorizer-js** to v3 and **@authorizerdev/authorizer-react** to v2; update type names and Node version as needed.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This guide helps you practice using Authorizer to evaluate it before you use it 
     --database-url=test.db \
     --jwt-type=HS256 \
     --jwt-secret=test \
+    --encryption-key=test-encryption-key \
     --admin-secret=admin \
     --client-id=123456 \
     --client-secret=secret
@@ -168,7 +169,8 @@ The default image runs as **non-root** (UID `65532`). Writable mounts (SQLite un
      --client-secret=secret \
      --admin-secret=admin \
      --jwt-type=HS256 \
-     --jwt-secret=test
+     --jwt-secret=test \
+     --encryption-key=test-encryption-key
    ```
 
 2. **Keep non-root** and make the mount writable by `65532` (good for production-style bind mounts):
@@ -268,6 +270,7 @@ Deploy / Try Authorizer using binaries. With each [Authorizer Release](https://g
     --database-url=test.db \
     --jwt-type=HS256 \
     --jwt-secret=test \
+    --encryption-key=test-encryption-key \
     --admin-secret=admin \
     --client-id=123456 \
     --client-secret=secret

--- a/perf/README.md
+++ b/perf/README.md
@@ -113,13 +113,14 @@ createdb authorizer_perf
   --jwt-type RS256 \
   --jwt-private-key "$(cat perf/dev-jwt-private.pem)" \
   --jwt-public-key "$(cat perf/dev-jwt-public.pem)" \
+  --encryption-key "$(openssl rand -hex 32)" \
   --client-id kbyuFDidLLm280LIwVFiazOqjO3ty8KH \
   --client-secret 60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa \
   --allowed-origins localhost:8080 \
   --http-port 8080
 ```
 
-`--admin-secret`, `--jwt-type`/`--jwt-private-key`/`--jwt-public-key`, and
+`--admin-secret`, `--jwt-type`/`--jwt-private-key`/`--jwt-public-key`, `--encryption-key`, and
 `--client-id`/`--client-secret` are all required — the server exits with
 `client ID missing in rootArgs` (or similar) without them. `--fga-store` can
 be omitted: it auto-reuses `--database-url` when the main DB is SQL-compatible


### PR DESCRIPTION
Documentation follow-up to the at-rest key change in #742. No code.

`perf/README.md` starts the server with `RS256` and no `--encryption-key` — that combination now exits at startup:

```
Error: --encryption-key is required: no encryption key is set and --jwt-secret is
empty (normal for RSA/ECDSA JWT types), so there is nothing to fall back to.
```

Verified against a binary built from this branch: `RS256` without the key exits, `RS256` with it boots, `HS256` without it boots via the `--jwt-secret` fallback.

- `perf/README.md` — adds the flag to the RS256 invocation and to the prose flag list
- `README.md`, `MIGRATION.md` — HMAC examples set a distinct key; rotating `--jwt-secret` otherwise re-keys TOTP secrets and locks out enrolled users
- `MIGRATION.md` — env→flag table gains an `--encryption-key` row marked new in 2.4.0, plus the RS*/ES* requirement in the JWT prose

Docs site counterpart: authorizerdev/docs#81.