### PR TITLE
chore: bump klauspost/compress to v1.18.7 for GO-2026-5841

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=


### PR DESCRIPTION
First, the CI signal: the `govulncheck` failure on `main` was **not** a vulnerability report. That job died in `Set up job` with `Failed to resolve action download info. Error: Service Unavailable` — the ongoing GitHub Actions outage (`Actions: major_outage`, incident opened 15:22 UTC). It never scanned anything.

Ran it locally instead. Two module-level findings, one fixable:

| ID | What | Fixed in | Action |
|---|---|---|---|
| GO-2026-5841 | OOB read in `klauspost/compress/s2` | `v1.18.7` | bumped here |
| GO-2026-5932 | `golang.org/x/crypto/openpgp` unmaintained | **N/A** | nothing to bump |

`klauspost/compress` is indirect, via `prometheus/client_golang` → `zstd`. govulncheck classes it as not called, which is right — the flaw is in `s2` and we use `zstd` — but v1.18.7 is a drop-in.

GO-2026-5932 has no fixed version, so it cannot be resolved by upgrading, and `x/crypto/openpgp` is not in any call path here. It will keep appearing under module results until the advisory or the module changes.

After the bump, verified locally (Actions is still down, so CI cannot run):

- `govulncheck ./...` → 0 called, module findings 2 → **1**
- `go build ./...`, `go vet ./...` → clean
- `make test` → **41 packages ok, 0 failures**
- `make smoke` → PASS (GraphQL + REST + gRPC + MCP)
- `make lint` → **0 issues**, prettier clean

go.mod/go.sum only, no code change.